### PR TITLE
feat(api): add structured error responses with error codes

### DIFF
--- a/api/ERROR_CODES.md
+++ b/api/ERROR_CODES.md
@@ -1,0 +1,105 @@
+# OpenAgents API Error Codes
+
+All API errors follow a consistent schema:
+
+```json
+{
+  "code": "ERROR_CODE",
+  "message": "Human-readable error description",
+  "details": { ... },
+  "request_id": "uuid-for-tracing"
+}
+```
+
+## Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `VALIDATION_ERROR` | 422 | Request validation failed (missing/invalid fields) |
+| `NOT_FOUND` | 404 | Requested resource does not exist |
+| `AUTH_FAILED` | 401 | Authentication failed (invalid/expired token) |
+| `FORBIDDEN` | 403 | Authenticated but not authorized for this action |
+| `RATE_LIMITED` | 429 | Too many requests, retry after the specified time |
+| `BAD_REQUEST` | 400 | Malformed request |
+| `CONFLICT` | 409 | Resource conflict (e.g., duplicate entry) |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |
+
+## Error Details
+
+### VALIDATION_ERROR
+
+Includes field-level validation errors:
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Request validation failed",
+  "details": {
+    "fields": {
+      "email": "Invalid email format",
+      "name": "Field required"
+    }
+  },
+  "request_id": "abc-123"
+}
+```
+
+### NOT_FOUND
+
+Includes the resource type and identifier:
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Agent not found",
+  "details": {
+    "resource": "Agent",
+    "identifier": "123"
+  },
+  "request_id": "abc-123"
+}
+```
+
+### RATE_LIMITED
+
+Includes retry timing:
+
+```json
+{
+  "code": "RATE_LIMITED",
+  "message": "Rate limit exceeded",
+  "details": {
+    "retry_after": 60
+  },
+  "request_id": "abc-123"
+}
+```
+
+Also includes `Retry-After` header.
+
+## Request ID
+
+Every error response includes a `request_id` for tracing:
+
+- Pass `X-Request-ID` header to use your own ID
+- If not provided, a UUID is generated
+- The ID is returned in both the response body and `X-Request-ID` header
+
+## Example Error Handling (Python)
+
+```python
+import requests
+
+response = requests.get("https://api.openagents.dev/agents/999")
+
+if response.status_code != 200:
+    error = response.json()
+    print(f"Error: {error['code']} - {error['message']}")
+    print(f"Request ID: {error['request_id']}")
+
+    if error['code'] == 'NOT_FOUND':
+        print(f"Resource: {error['details']['resource']}")
+    elif error['code'] == 'VALIDATION_ERROR':
+        for field, msg in error['details']['fields'].items():
+            print(f"  {field}: {msg}")
+```

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,246 @@
+"""Structured error handling for the OpenAgents API.
+
+This module provides consistent error responses across all API endpoints.
+All errors follow the schema: {code, message, details, request_id}
+"""
+
+import uuid
+from enum import Enum
+from typing import Any, Dict, Optional
+from fastapi import Request, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import RequestValidationError
+from pydantic import BaseModel
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+class ErrorCode(str, Enum):
+    """Standard error codes for the OpenAgents API."""
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_FOUND = "NOT_FOUND"
+    AUTH_FAILED = "AUTH_FAILED"
+    FORBIDDEN = "FORBIDDEN"
+    RATE_LIMITED = "RATE_LIMITED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    BAD_REQUEST = "BAD_REQUEST"
+    CONFLICT = "CONFLICT"
+
+
+class ErrorResponse(BaseModel):
+    """Structured error response schema."""
+
+    code: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    request_id: str
+
+
+class APIError(Exception):
+    """Base exception for API errors with structured responses."""
+
+    def __init__(
+        self,
+        code: ErrorCode,
+        message: str,
+        details: Optional[Dict[str, Any]] = None,
+        status_code: int = 400,
+    ):
+        self.code = code
+        self.message = message
+        self.details = details or {}
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class NotFoundError(APIError):
+    """Resource not found error."""
+
+    def __init__(self, resource: str, identifier: Any = None):
+        details = {"resource": resource}
+        if identifier is not None:
+            details["identifier"] = str(identifier)
+        super().__init__(
+            code=ErrorCode.NOT_FOUND,
+            message=f"{resource} not found",
+            details=details,
+            status_code=404,
+        )
+
+
+class AuthenticationError(APIError):
+    """Authentication failed error."""
+
+    def __init__(self, message: str = "Authentication failed", details: Dict = None):
+        super().__init__(
+            code=ErrorCode.AUTH_FAILED,
+            message=message,
+            details=details,
+            status_code=401,
+        )
+
+
+class ForbiddenError(APIError):
+    """Access forbidden error."""
+
+    def __init__(self, message: str = "Access forbidden", details: Dict = None):
+        super().__init__(
+            code=ErrorCode.FORBIDDEN,
+            message=message,
+            details=details,
+            status_code=403,
+        )
+
+
+class RateLimitError(APIError):
+    """Rate limit exceeded error."""
+
+    def __init__(self, retry_after: int, message: str = "Rate limit exceeded"):
+        super().__init__(
+            code=ErrorCode.RATE_LIMITED,
+            message=message,
+            details={"retry_after": retry_after},
+            status_code=429,
+        )
+
+
+class ValidationError(APIError):
+    """Request validation error."""
+
+    def __init__(self, message: str, field_errors: Dict[str, str] = None):
+        super().__init__(
+            code=ErrorCode.VALIDATION_ERROR,
+            message=message,
+            details={"fields": field_errors} if field_errors else None,
+            status_code=422,
+        )
+
+
+class ConflictError(APIError):
+    """Resource conflict error."""
+
+    def __init__(self, message: str, details: Dict = None):
+        super().__init__(
+            code=ErrorCode.CONFLICT,
+            message=message,
+            details=details,
+            status_code=409,
+        )
+
+
+def get_request_id(request: Request) -> str:
+    """Get or generate a request ID for tracing."""
+    request_id = request.headers.get("X-Request-ID")
+    if not request_id:
+        request_id = str(uuid.uuid4())
+    return request_id
+
+
+def build_error_response(
+    code: ErrorCode,
+    message: str,
+    request_id: str,
+    details: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a structured error response dictionary."""
+    response = {
+        "code": code.value if isinstance(code, ErrorCode) else code,
+        "message": message,
+        "request_id": request_id,
+    }
+    if details:
+        response["details"] = details
+    return response
+
+
+async def api_error_handler(request: Request, exc: APIError) -> JSONResponse:
+    """Handle APIError exceptions with structured responses."""
+    request_id = get_request_id(request)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=build_error_response(
+            code=exc.code,
+            message=exc.message,
+            request_id=request_id,
+            details=exc.details,
+        ),
+        headers={"X-Request-ID": request_id},
+    )
+
+
+async def validation_error_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Handle Pydantic validation errors with field-level details."""
+    request_id = get_request_id(request)
+
+    field_errors = {}
+    for error in exc.errors():
+        loc = ".".join(str(x) for x in error["loc"] if x != "body")
+        field_errors[loc] = error["msg"]
+
+    return JSONResponse(
+        status_code=422,
+        content=build_error_response(
+            code=ErrorCode.VALIDATION_ERROR,
+            message="Request validation failed",
+            request_id=request_id,
+            details={"fields": field_errors},
+        ),
+        headers={"X-Request-ID": request_id},
+    )
+
+
+async def http_exception_handler(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    """Handle FastAPI HTTPException with structured responses."""
+    request_id = get_request_id(request)
+
+    # Map HTTP status codes to error codes
+    status_to_code = {
+        400: ErrorCode.BAD_REQUEST,
+        401: ErrorCode.AUTH_FAILED,
+        403: ErrorCode.FORBIDDEN,
+        404: ErrorCode.NOT_FOUND,
+        409: ErrorCode.CONFLICT,
+        422: ErrorCode.VALIDATION_ERROR,
+        429: ErrorCode.RATE_LIMITED,
+    }
+
+    code = status_to_code.get(exc.status_code, ErrorCode.INTERNAL_ERROR)
+    message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=build_error_response(
+            code=code,
+            message=message,
+            request_id=request_id,
+        ),
+        headers={"X-Request-ID": request_id},
+    )
+
+
+async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Handle unexpected exceptions with a generic error response."""
+    request_id = get_request_id(request)
+
+    return JSONResponse(
+        status_code=500,
+        content=build_error_response(
+            code=ErrorCode.INTERNAL_ERROR,
+            message="An internal error occurred",
+            request_id=request_id,
+        ),
+        headers={"X-Request-ID": request_id},
+    )
+
+
+def register_error_handlers(app):
+    """Register all error handlers with the FastAPI application."""
+    app.add_exception_handler(APIError, api_error_handler)
+    app.add_exception_handler(RequestValidationError, validation_error_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, generic_exception_handler)

--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,16 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+from .errors import register_error_handlers, NotFoundError
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+# Register structured error handlers
+register_error_handlers(app)
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -2,10 +2,12 @@
 
 import jwt
 import os
-from fastapi import Request, HTTPException, Depends
+from fastapi import Request, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from datetime import datetime, timedelta
 from typing import Optional
+
+from ..errors import AuthenticationError, ForbiddenError
 
 # BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
 # crashing the entire application on startup
@@ -38,9 +40,9 @@ def decode_token(token: str) -> dict:
         payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
         return payload
     except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Token has expired")
+        raise AuthenticationError("Token has expired")
     except jwt.InvalidTokenError:
-        raise HTTPException(status_code=401, detail="Invalid token")
+        raise AuthenticationError("Invalid token")
 
 
 async def get_current_user(
@@ -50,7 +52,7 @@ async def get_current_user(
     payload = decode_token(token)
 
     if payload.get("type") != "access":
-        raise HTTPException(status_code=401, detail="Invalid token type")
+        raise AuthenticationError("Invalid token type")
 
     # BUG: No token revocation check — logged-out or compromised tokens
     # remain valid until they naturally expire
@@ -61,7 +63,7 @@ async def get_current_user(
     }
 
     if not user_data["id"]:
-        raise HTTPException(status_code=401, detail="Invalid token payload")
+        raise AuthenticationError("Invalid token payload")
 
     return user_data
 
@@ -69,7 +71,7 @@ async def get_current_user(
 def require_role(role: str):
     async def role_checker(user: dict = Depends(get_current_user)):
         if role not in user.get("roles", []):
-            raise HTTPException(status_code=403, detail=f"Role '{role}' required")
+            raise ForbiddenError(f"Role '{role}' required")
         return user
     return role_checker
 

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -1,11 +1,14 @@
 """Rate limiting middleware for the OpenAgents API."""
 
 import time
+import uuid
 from collections import defaultdict
-from fastapi import Request, HTTPException
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from typing import Dict, Tuple
+
+from ..errors import ErrorCode, build_error_response
 
 
 class RateLimitConfig:
@@ -65,13 +68,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         is_limited, value = self._is_rate_limited(client_ip)
 
         if is_limited:
+            request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
             return JSONResponse(
                 status_code=429,
-                content={
-                    "error": "Rate limit exceeded",
-                    "retry_after": value,
-                },
-                headers={"Retry-After": str(value)},
+                content=build_error_response(
+                    code=ErrorCode.RATE_LIMITED,
+                    message="Rate limit exceeded",
+                    request_id=request_id,
+                    details={"retry_after": value},
+                ),
+                headers={"Retry-After": str(value), "X-Request-ID": request_id},
             )
 
         response = await call_next(request)

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,12 +1,13 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
+from ..errors import NotFoundError, ForbiddenError
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -58,7 +59,7 @@ async def list_agents(
 async def get_agent(agent_id: int, db=Depends(get_db)):
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        raise NotFoundError("Agent", agent_id)
     return agent
 
 
@@ -68,9 +69,9 @@ async def update_agent(
 ):
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        raise NotFoundError("Agent", agent_id)
     if agent.owner_id != user["id"]:
-        raise HTTPException(status_code=403, detail="Not the owner")
+        raise ForbiddenError("You are not the owner of this agent")
     for field, value in update.dict(exclude_unset=True).items():
         setattr(agent, field, value)
     db.commit()
@@ -82,7 +83,7 @@ async def update_agent(
 async def delete_agent(agent_id: int, db=Depends(get_db)):
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        raise NotFoundError("Agent", agent_id)
     db.delete(agent)
     db.commit()
     return {"deleted": True}

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,12 +1,13 @@
 """Payment and escrow endpoints for bounty payouts."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
 from ..models.database import get_db, Payment, Task
 from ..middleware.auth import get_current_user
+from ..errors import NotFoundError, ForbiddenError, ValidationError
 
 router = APIRouter(prefix="/payments", tags=["payments"])
 
@@ -30,9 +31,9 @@ async def deposit_escrow(
 ):
     task = db.query(Task).filter(Task.id == deposit.task_id).first()
     if not task:
-        raise HTTPException(status_code=404, detail="Task not found")
+        raise NotFoundError("Task", deposit.task_id)
     if task.creator_id != user["id"]:
-        raise HTTPException(status_code=403, detail="Only task creator can fund escrow")
+        raise ForbiddenError("Only task creator can fund escrow")
 
     # BUG: No idempotency key — retried requests create duplicate escrow entries,
     # locking more funds than intended
@@ -65,9 +66,9 @@ async def claim_payment(
 ):
     task = db.query(Task).filter(Task.id == claim.task_id).first()
     if not task:
-        raise HTTPException(status_code=404, detail="Task not found")
+        raise NotFoundError("Task", claim.task_id)
     if task.status != "completed":
-        raise HTTPException(status_code=400, detail="Task not yet completed")
+        raise ValidationError("Task not yet completed", {"status": f"Expected 'completed', got '{task.status}'"})
 
     # BUG: Race condition — two concurrent claims can both read status="escrowed"
     # before either updates it, causing a double-payout
@@ -76,7 +77,7 @@ async def claim_payment(
     ).all()
 
     if not payments:
-        raise HTTPException(status_code=400, detail="No escrowed funds available")
+        raise ValidationError("No escrowed funds available")
 
     total_claimed = 0.0
     for payment in payments:

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,12 +1,13 @@
 """Task management endpoints for bounty assignments."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
 from ..models.database import get_db, Task
 from ..middleware.auth import get_current_user
+from ..errors import NotFoundError, ForbiddenError, ValidationError
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
@@ -65,7 +66,7 @@ async def list_tasks(
 async def get_task(task_id: int, db=Depends(get_db)):
     task = db.query(Task).filter(Task.id == task_id).first()
     if not task:
-        raise HTTPException(status_code=404, detail="Task not found")
+        raise NotFoundError("Task", task_id)
     return task
 
 
@@ -78,12 +79,12 @@ async def update_task_status(
 ):
     task = db.query(Task).filter(Task.id == task_id).first()
     if not task:
-        raise HTTPException(status_code=404, detail="Task not found")
+        raise NotFoundError("Task", task_id)
 
     # BUG: Creator can mark their own task as completed — should require
     # a third party or the assignee to confirm completion
     if task.creator_id != user["id"]:
-        raise HTTPException(status_code=403, detail="Only the creator can update status")
+        raise ForbiddenError("Only the creator can update status")
 
     task.status = update.status
     task.updated_at = datetime.utcnow()
@@ -95,11 +96,11 @@ async def update_task_status(
 async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(get_db)):
     task = db.query(Task).filter(Task.id == task_id).first()
     if not task:
-        raise HTTPException(status_code=404, detail="Task not found")
+        raise NotFoundError("Task", task_id)
     if task.creator_id != user["id"]:
-        raise HTTPException(status_code=403, detail="Only the creator can cancel")
+        raise ForbiddenError("Only the creator can cancel")
     if task.status not in ("open", "assigned"):
-        raise HTTPException(status_code=400, detail="Cannot cancel an active task")
+        raise ValidationError("Cannot cancel an active task", {"status": f"Task status is '{task.status}'"})
     task.status = "cancelled"
     db.commit()
     return {"id": task.id, "status": "cancelled"}

--- a/api/tests/test_errors.py
+++ b/api/tests/test_errors.py
@@ -1,0 +1,236 @@
+"""Tests for structured error handling in the OpenAgents API."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from ..errors import (
+    ErrorCode,
+    APIError,
+    NotFoundError,
+    AuthenticationError,
+    ForbiddenError,
+    RateLimitError,
+    ValidationError,
+    ConflictError,
+    register_error_handlers,
+    build_error_response,
+)
+
+
+# Test app setup
+app = FastAPI()
+register_error_handlers(app)
+
+
+class TestInput(BaseModel):
+    name: str
+    count: int
+
+
+@app.get("/not-found")
+async def trigger_not_found():
+    raise NotFoundError("Agent", 123)
+
+
+@app.get("/auth-failed")
+async def trigger_auth_failed():
+    raise AuthenticationError("Token has expired")
+
+
+@app.get("/forbidden")
+async def trigger_forbidden():
+    raise ForbiddenError("You don't have access")
+
+
+@app.get("/rate-limited")
+async def trigger_rate_limited():
+    raise RateLimitError(retry_after=60)
+
+
+@app.get("/validation-error")
+async def trigger_validation_error():
+    raise ValidationError("Invalid input", {"email": "Invalid email format"})
+
+
+@app.get("/conflict")
+async def trigger_conflict():
+    raise ConflictError("Resource already exists")
+
+
+@app.get("/internal-error")
+async def trigger_internal_error():
+    raise Exception("Something went wrong")
+
+
+@app.post("/pydantic-validation")
+async def trigger_pydantic_validation(data: TestInput):
+    return data
+
+
+client = TestClient(app)
+
+
+class TestErrorCodes:
+    """Test that all error codes are properly defined."""
+
+    def test_error_codes_exist(self):
+        assert ErrorCode.VALIDATION_ERROR == "VALIDATION_ERROR"
+        assert ErrorCode.NOT_FOUND == "NOT_FOUND"
+        assert ErrorCode.AUTH_FAILED == "AUTH_FAILED"
+        assert ErrorCode.FORBIDDEN == "FORBIDDEN"
+        assert ErrorCode.RATE_LIMITED == "RATE_LIMITED"
+        assert ErrorCode.INTERNAL_ERROR == "INTERNAL_ERROR"
+        assert ErrorCode.BAD_REQUEST == "BAD_REQUEST"
+        assert ErrorCode.CONFLICT == "CONFLICT"
+
+
+class TestNotFoundError:
+    """Test NOT_FOUND error responses."""
+
+    def test_not_found_response_structure(self):
+        response = client.get("/not-found")
+        assert response.status_code == 404
+
+        data = response.json()
+        assert data["code"] == "NOT_FOUND"
+        assert data["message"] == "Agent not found"
+        assert "request_id" in data
+        assert data["details"]["resource"] == "Agent"
+        assert data["details"]["identifier"] == "123"
+
+    def test_not_found_has_request_id_header(self):
+        response = client.get("/not-found")
+        assert "X-Request-ID" in response.headers
+
+
+class TestAuthenticationError:
+    """Test AUTH_FAILED error responses."""
+
+    def test_auth_failed_response_structure(self):
+        response = client.get("/auth-failed")
+        assert response.status_code == 401
+
+        data = response.json()
+        assert data["code"] == "AUTH_FAILED"
+        assert data["message"] == "Token has expired"
+        assert "request_id" in data
+
+
+class TestForbiddenError:
+    """Test FORBIDDEN error responses."""
+
+    def test_forbidden_response_structure(self):
+        response = client.get("/forbidden")
+        assert response.status_code == 403
+
+        data = response.json()
+        assert data["code"] == "FORBIDDEN"
+        assert data["message"] == "You don't have access"
+        assert "request_id" in data
+
+
+class TestRateLimitError:
+    """Test RATE_LIMITED error responses."""
+
+    def test_rate_limited_response_structure(self):
+        response = client.get("/rate-limited")
+        assert response.status_code == 429
+
+        data = response.json()
+        assert data["code"] == "RATE_LIMITED"
+        assert data["message"] == "Rate limit exceeded"
+        assert data["details"]["retry_after"] == 60
+        assert "request_id" in data
+
+
+class TestValidationError:
+    """Test VALIDATION_ERROR responses."""
+
+    def test_custom_validation_error(self):
+        response = client.get("/validation-error")
+        assert response.status_code == 422
+
+        data = response.json()
+        assert data["code"] == "VALIDATION_ERROR"
+        assert data["message"] == "Invalid input"
+        assert data["details"]["fields"]["email"] == "Invalid email format"
+
+    def test_pydantic_validation_error(self):
+        response = client.post("/pydantic-validation", json={"name": 123})
+        assert response.status_code == 422
+
+        data = response.json()
+        assert data["code"] == "VALIDATION_ERROR"
+        assert data["message"] == "Request validation failed"
+        assert "fields" in data["details"]
+        assert "request_id" in data
+
+
+class TestConflictError:
+    """Test CONFLICT error responses."""
+
+    def test_conflict_response_structure(self):
+        response = client.get("/conflict")
+        assert response.status_code == 409
+
+        data = response.json()
+        assert data["code"] == "CONFLICT"
+        assert data["message"] == "Resource already exists"
+        assert "request_id" in data
+
+
+class TestInternalError:
+    """Test INTERNAL_ERROR responses."""
+
+    def test_internal_error_response_structure(self):
+        response = client.get("/internal-error")
+        assert response.status_code == 500
+
+        data = response.json()
+        assert data["code"] == "INTERNAL_ERROR"
+        assert data["message"] == "An internal error occurred"
+        assert "request_id" in data
+
+
+class TestRequestIdPropagation:
+    """Test that request IDs are properly propagated."""
+
+    def test_custom_request_id_used(self):
+        custom_id = "test-request-id-12345"
+        response = client.get("/not-found", headers={"X-Request-ID": custom_id})
+
+        data = response.json()
+        assert data["request_id"] == custom_id
+        assert response.headers["X-Request-ID"] == custom_id
+
+    def test_request_id_generated_if_missing(self):
+        response = client.get("/not-found")
+        data = response.json()
+        assert "request_id" in data
+        assert len(data["request_id"]) == 36  # UUID format
+
+
+class TestBuildErrorResponse:
+    """Test the build_error_response helper."""
+
+    def test_builds_complete_response(self):
+        response = build_error_response(
+            code=ErrorCode.NOT_FOUND,
+            message="Resource not found",
+            request_id="abc-123",
+            details={"id": 42},
+        )
+        assert response["code"] == "NOT_FOUND"
+        assert response["message"] == "Resource not found"
+        assert response["request_id"] == "abc-123"
+        assert response["details"]["id"] == 42
+
+    def test_omits_details_when_none(self):
+        response = build_error_response(
+            code=ErrorCode.INTERNAL_ERROR,
+            message="Error",
+            request_id="abc-123",
+        )
+        assert "details" not in response


### PR DESCRIPTION
/claim #202

## Summary

Implements structured error responses across the OpenAgents API with consistent error schema and codes.

### Changes

- **New `api/errors.py`**: Error schema, exception classes, and handlers
- **Error codes**: `VALIDATION_ERROR`, `NOT_FOUND`, `AUTH_FAILED`, `FORBIDDEN`, `RATE_LIMITED`, `INTERNAL_ERROR`, `BAD_REQUEST`, `CONFLICT`
- **Updated routes**: All HTTPException calls replaced with structured error classes
- **Request ID**: Every error includes `request_id` for tracing (via header or auto-generated)
- **Tests**: Comprehensive test suite for each error code
- **Documentation**: `ERROR_CODES.md` with usage examples

### Error Response Schema

```json
{
  "code": "NOT_FOUND",
  "message": "Agent not found",
  "details": {"resource": "Agent", "identifier": "123"},
  "request_id": "abc-123-uuid"
}
```

### Validation Errors Include Field Details

```json
{
  "code": "VALIDATION_ERROR",
  "message": "Request validation failed",
  "details": {"fields": {"email": "Invalid format"}},
  "request_id": "abc-123"
}
```

## Test Results

All acceptance criteria verified:
- [x] All error responses follow schema
- [x] Error codes documented in ERROR_CODES.md
- [x] Validation errors include field-level details
- [x] Request ID present in all errors
- [x] Tests for each error code

## Files Changed

- `api/errors.py` - New error handling module
- `api/main.py` - Register error handlers
- `api/middleware/auth.py` - Use AuthenticationError
- `api/middleware/ratelimit.py` - Use RateLimitError format
- `api/routes/agents.py` - Use NotFoundError, ForbiddenError
- `api/routes/payments.py` - Use structured errors
- `api/routes/tasks.py` - Use structured errors
- `api/tests/test_errors.py` - Comprehensive tests
- `api/ERROR_CODES.md` - Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)