### PR TITLE
Account for CompoundVault strategy losses during compound

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -59,9 +59,11 @@ contract GovernorAlpha is ReentrancyGuard {
         Proposal storage p = proposals[proposalId];
         p.id = proposalId;
         p.proposer = msg.sender;
-        p.targets = targets;
-        p.values = values;
-        p.calldatas = calldatas;
+        for (uint256 i = 0; i < targets.length; i++) {
+            p.targets.push(targets[i]);
+            p.values.push(values[i]);
+            p.calldatas.push(calldatas[i]);
+        }
         p.startBlock = block.number + VOTING_DELAY;
         p.endBlock = block.number + VOTING_DELAY + VOTING_PERIOD;
 

--- a/contracts/mocks/CompoundVaultMocks.sol
+++ b/contracts/mocks/CompoundVaultMocks.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockVaultToken is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function slash(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+}
+
+contract MockCompoundStrategy {
+    MockVaultToken public immutable token;
+    int256 public nextReturn;
+
+    constructor(address token_) {
+        token = MockVaultToken(token_);
+    }
+
+    function setNextReturn(int256 amount) external {
+        nextReturn = amount;
+    }
+
+    function compound() external {
+        int256 amount = nextReturn;
+        nextReturn = 0;
+
+        if (amount > 0) {
+            token.mint(msg.sender, uint256(amount));
+        } else if (amount < 0) {
+            token.slash(msg.sender, uint256(-amount));
+        }
+    }
+}

--- a/contracts/mocks/StakingRewardsMocks.sol
+++ b/contracts/mocks/StakingRewardsMocks.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract StakingToken is ERC20 {
+    constructor() ERC20("Staking Token", "STAKE") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract RewardToken is ERC20 {
+    constructor() ERC20("Reward Token", "RWD") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -72,13 +72,7 @@ contract ChainlinkAdapter {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (, int256 answer,,,) = config.feed.latestRoundData();
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/vault/CompoundVault.sol
+++ b/contracts/vault/CompoundVault.sol
@@ -6,6 +6,10 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+interface ICompoundStrategy {
+    function compound() external;
+}
+
 /// @title CompoundVault
 /// @notice Auto-compounding vault that periodically harvests yield and reinvests.
 /// @dev Deposits into an underlying strategy, harvests rewards, sells for the base
@@ -23,6 +27,7 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     uint256 public performanceFeeBps; // basis points (e.g., 1000 = 10%)
     uint256 public lastHarvestTime;
     uint256 public lastPricePerShare;
+    uint256 public totalLoss;
 
     mapping(address => uint256) public userShares;
 
@@ -30,6 +35,7 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     event Withdrawn(address indexed user, uint256 amount, uint256 shares);
     event Harvested(uint256 profit, uint256 fee, uint256 timestamp);
     event Compounded(uint256 amount, uint256 newPricePerShare);
+    event StrategyLoss(uint256 amount);
 
     constructor(
         address _baseToken,
@@ -112,21 +118,32 @@ contract CompoundVault is Ownable, ReentrancyGuard {
         emit Harvested(profit, fee, block.timestamp);
     }
 
-    /// @notice Compound harvested rewards by converting and re-depositing.
-    /// @dev In production this would swap rewardToken -> baseToken via a DEX.
-    ///      Simplified here to direct deposit of reward token balance.
-    function compound() external onlyOwner {
-        uint256 rewardBalance = rewardToken.balanceOf(address(this));
-        if (rewardBalance == 0) return;
+    /// @notice Compound strategy returns and account for both gains and losses.
+    /// @dev The strategy call may increase or decrease the vault's base token
+    ///      balance. Accounting follows the observed balance delta instead of
+    ///      assuming every strategy result is a positive yield.
+    function compound() external onlyOwner nonReentrant {
+        require(strategy != address(0), "Vault: no strategy");
+        require(strategy.code.length > 0, "Vault: invalid strategy");
 
-        // In a real implementation, this would swap via a DEX router.
-        // For this contract, we assume baseToken == rewardToken or an oracle price.
-        uint256 compoundAmount = (rewardBalance * lastPricePerShare) / 1e18;
+        uint256 balanceBefore = baseToken.balanceOf(address(this));
+        ICompoundStrategy(strategy).compound();
+        uint256 balanceAfter = baseToken.balanceOf(address(this));
 
-        totalDeposited += compoundAmount;
-        lastPricePerShare = totalShares > 0 ? (totalDeposited * 1e18) / totalShares : 1e18;
+        if (balanceAfter >= balanceBefore) {
+            uint256 compoundAmount = balanceAfter - balanceBefore;
+            totalDeposited += compoundAmount;
+            _updatePricePerShare();
 
-        emit Compounded(compoundAmount, lastPricePerShare);
+            emit Compounded(compoundAmount, lastPricePerShare);
+        } else {
+            uint256 loss = balanceBefore - balanceAfter;
+            totalLoss += loss;
+            totalDeposited = loss >= totalDeposited ? 0 : totalDeposited - loss;
+            _updatePricePerShare();
+
+            emit StrategyLoss(loss);
+        }
     }
 
     /// @notice Update the performance fee.
@@ -146,5 +163,9 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     function pricePerShare() external view returns (uint256) {
         if (totalShares == 0) return 1e18;
         return (totalDeposited * 1e18) / totalShares;
+    }
+
+    function _updatePricePerShare() private {
+        lastPricePerShare = totalShares > 0 ? (totalDeposited * 1e18) / totalShares : 1e18;
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,8 +2,9 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
+    version: "0.8.24",
     settings: {
+      evmVersion: "cancun",
       optimizer: {
         enabled: true,
         runs: 200,

--- a/test/CompoundVault.test.js
+++ b/test/CompoundVault.test.js
@@ -1,0 +1,83 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CompoundVault", function () {
+  const ONE_HUNDRED = ethers.parseEther("100");
+
+  let owner, depositor, feeRecipient;
+  let baseToken, rewardToken, strategy, vault;
+
+  beforeEach(async function () {
+    [owner, depositor, feeRecipient] = await ethers.getSigners();
+
+    const MockVaultToken = await ethers.getContractFactory("MockVaultToken");
+    baseToken = await MockVaultToken.deploy("Base Token", "BASE");
+    rewardToken = await MockVaultToken.deploy("Reward Token", "RWD");
+
+    const MockCompoundStrategy = await ethers.getContractFactory("MockCompoundStrategy");
+    strategy = await MockCompoundStrategy.deploy(await baseToken.getAddress());
+
+    const CompoundVault = await ethers.getContractFactory("CompoundVault");
+    vault = await CompoundVault.deploy(
+      await baseToken.getAddress(),
+      await rewardToken.getAddress(),
+      await strategy.getAddress(),
+      feeRecipient.address,
+      1_000
+    );
+
+    await baseToken.mint(depositor.address, ONE_HUNDRED);
+    await baseToken.connect(depositor).approve(await vault.getAddress(), ONE_HUNDRED);
+    await vault.connect(depositor).deposit(ONE_HUNDRED);
+  });
+
+  it("increases share price when the strategy returns positive yield", async function () {
+    const yieldAmount = ethers.parseEther("10");
+
+    await strategy.setNextReturn(yieldAmount);
+
+    await expect(vault.connect(owner).compound())
+      .to.emit(vault, "Compounded")
+      .withArgs(yieldAmount, ethers.parseEther("1.1"));
+
+    expect(await vault.totalDeposited()).to.equal(ethers.parseEther("110"));
+    expect(await vault.totalLoss()).to.equal(0n);
+    expect(await vault.pricePerShare()).to.equal(ethers.parseEther("1.1"));
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("1.1"));
+  });
+
+  it("keeps share price unchanged when the strategy returns zero yield", async function () {
+    await expect(vault.connect(owner).compound())
+      .to.emit(vault, "Compounded")
+      .withArgs(0, ethers.parseEther("1"));
+
+    expect(await vault.totalDeposited()).to.equal(ONE_HUNDRED);
+    expect(await vault.totalLoss()).to.equal(0n);
+    expect(await vault.pricePerShare()).to.equal(ethers.parseEther("1"));
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("1"));
+  });
+
+  it("decreases share price proportionally and accumulates totalLoss on strategy losses", async function () {
+    await strategy.setNextReturn(-ethers.parseEther("15"));
+
+    await expect(vault.connect(owner).compound())
+      .to.emit(vault, "StrategyLoss")
+      .withArgs(ethers.parseEther("15"));
+
+    expect(await vault.totalDeposited()).to.equal(ethers.parseEther("85"));
+    expect(await vault.totalLoss()).to.equal(ethers.parseEther("15"));
+    expect(await vault.pricePerShare()).to.equal(ethers.parseEther("0.85"));
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("0.85"));
+
+    await strategy.setNextReturn(-ethers.parseEther("5"));
+
+    await expect(vault.connect(owner).compound())
+      .to.emit(vault, "StrategyLoss")
+      .withArgs(ethers.parseEther("5"));
+
+    expect(await vault.totalDeposited()).to.equal(ethers.parseEther("80"));
+    expect(await vault.totalLoss()).to.equal(ethers.parseEther("20"));
+    expect(await vault.pricePerShare()).to.equal(ethers.parseEther("0.8"));
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("0.8"));
+  });
+});

--- a/test/StakingRewards.test.js
+++ b/test/StakingRewards.test.js
@@ -5,31 +5,34 @@ describe("StakingRewards", function () {
   let stakingRewards, stakingToken, rewardToken;
   let owner, staker1, staker2;
 
-  // BUG: Setup runs once but tests mutate state - no beforeEach to reset between tests
-  before(async function () {
+  beforeEach(async function () {
     [owner, staker1, staker2] = await ethers.getSigners();
 
     const StakingToken = await ethers.getContractFactory("StakingToken");
     stakingToken = await StakingToken.deploy();
-    await stakingToken.deployed();
+    await stakingToken.waitForDeployment();
 
     const RewardToken = await ethers.getContractFactory("RewardToken");
     rewardToken = await RewardToken.deploy();
-    await rewardToken.deployed();
+    await rewardToken.waitForDeployment();
 
     const StakingRewards = await ethers.getContractFactory("StakingRewards");
-    stakingRewards = await StakingRewards.deploy(stakingToken.address, rewardToken.address);
-    await stakingRewards.deployed();
+    stakingRewards = await StakingRewards.deploy(
+      await stakingToken.getAddress(),
+      await rewardToken.getAddress()
+    );
+    await stakingRewards.waitForDeployment();
 
     // Mint tokens for testing
-    await stakingToken.mint(staker1.address, ethers.utils.parseEther("1000"));
-    await stakingToken.mint(staker2.address, ethers.utils.parseEther("1000"));
-    await rewardToken.mint(stakingRewards.address, ethers.utils.parseEther("10000"));
+    await stakingToken.mint(staker1.address, ethers.parseEther("1000"));
+    await stakingToken.mint(staker2.address, ethers.parseEther("1000"));
+    await rewardToken.mint(await stakingRewards.getAddress(), ethers.parseEther("10000"));
+    await stakingRewards.notifyRewardAmount(ethers.parseEther("700"));
   });
 
   it("should allow staking tokens", async function () {
-    const amount = ethers.utils.parseEther("100");
-    await stakingToken.connect(staker1).approve(stakingRewards.address, amount);
+    const amount = ethers.parseEther("100");
+    await stakingToken.connect(staker1).approve(await stakingRewards.getAddress(), amount);
     await stakingRewards.connect(staker1).stake(amount);
 
     const staked = await stakingRewards.balanceOf(staker1.address);
@@ -37,8 +40,11 @@ describe("StakingRewards", function () {
   });
 
   it("should accrue rewards over time", async function () {
-    // BUG: Hardcoded block timestamp - test is brittle and environment-dependent
-    await ethers.provider.send("evm_setNextBlockTimestamp", [1747400000]);
+    const amount = ethers.parseEther("100");
+    await stakingToken.connect(staker1).approve(await stakingRewards.getAddress(), amount);
+    await stakingRewards.connect(staker1).stake(amount);
+
+    await ethers.provider.send("evm_increaseTime", [24 * 60 * 60]);
     await ethers.provider.send("evm_mine");
 
     const earned = await stakingRewards.earned(staker1.address);
@@ -46,28 +52,33 @@ describe("StakingRewards", function () {
   });
 
   it("should allow withdrawal", async function () {
-    // BUG: depends on state from previous test (staker1 having staked 100 tokens)
-    const amount = ethers.utils.parseEther("50");
-    await stakingRewards.connect(staker1).withdraw(amount);
+    const stakedAmount = ethers.parseEther("100");
+    await stakingToken.connect(staker1).approve(await stakingRewards.getAddress(), stakedAmount);
+    await stakingRewards.connect(staker1).stake(stakedAmount);
+
+    const withdrawAmount = ethers.parseEther("50");
+    await stakingRewards.connect(staker1).withdraw(withdrawAmount);
 
     const remaining = await stakingRewards.balanceOf(staker1.address);
-    expect(remaining).to.equal(ethers.utils.parseEther("50"));
+    expect(remaining).to.equal(ethers.parseEther("50"));
   });
 
   it("should distribute rewards correctly to multiple stakers", async function () {
-    const amount = ethers.utils.parseEther("200");
-    await stakingToken.connect(staker2).approve(stakingRewards.address, amount);
-    await stakingRewards.connect(staker2).stake(amount);
+    const amount1 = ethers.parseEther("100");
+    const amount2 = ethers.parseEther("200");
+    await stakingToken.connect(staker1).approve(await stakingRewards.getAddress(), amount1);
+    await stakingToken.connect(staker2).approve(await stakingRewards.getAddress(), amount2);
+    await stakingRewards.connect(staker1).stake(amount1);
+    await stakingRewards.connect(staker2).stake(amount2);
 
-    // BUG: Hardcoded timestamp again - assumes previous evm_setNextBlockTimestamp succeeded
-    await ethers.provider.send("evm_setNextBlockTimestamp", [1747500000]);
+    await ethers.provider.send("evm_increaseTime", [24 * 60 * 60]);
     await ethers.provider.send("evm_mine");
 
     const earned1 = await stakingRewards.earned(staker1.address);
     const earned2 = await stakingRewards.earned(staker2.address);
 
-    // staker2 staked 4x more, so should earn proportionally more from this point
+    // staker2 staked 2x more, so should earn proportionally more.
     expect(earned2).to.be.gt(0);
-    expect(earned1).to.be.gt(0);
+    expect(earned2).to.be.gt(earned1);
   });
 });


### PR DESCRIPTION
## Summary
- Call the configured CompoundVault strategy during `compound()` and account from the observed base-token balance delta.
- Increase `totalDeposited` and share price for positive strategy returns, keep accounting unchanged for zero returns, and reduce `totalDeposited` while accumulating `totalLoss` for losses.
- Emit `StrategyLoss` with the loss amount and add tests for positive, zero, and negative strategy outcomes.
- Restore the local Hardhat suite so the vault tests run under the current dependency set.

## Tests
- `npm run compile`
- `npm test`

Fixes #168