### PR TITLE
Fix JWT algorithm pinning, refresh, and revocation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,19 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+try:
+    from .routes.auth import router as auth_router
+except ImportError:  # pragma: no cover - supports `cd api && uvicorn main:app`
+    if __package__:
+        raise
+    from routes.auth import router as auth_router
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+app.include_router(auth_router)
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,46 +1,107 @@
 """JWT authentication middleware for the OpenAgents API."""
 
-import jwt
 import os
-from fastapi import Request, HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
+from uuid import uuid4
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+import jwt
+from fastapi import HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+JWT_SECRET_ENV = "JWT_SECRET"
 JWT_ALGORITHM = "HS256"
+JWT_DECODE_ALGORITHMS = [JWT_ALGORITHM]
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 security = HTTPBearer()
+REVOKED_TOKEN_IDS: set[str] = set()
+REVOKED_TOKENS: set[str] = set()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def get_jwt_secret() -> str:
+    secret = os.getenv(JWT_SECRET_ENV)
+    if not secret:
+        raise HTTPException(status_code=500, detail="JWT secret is not configured")
+    return secret
+
+
+def _revocation_key(payload: dict, token: str) -> tuple[set[str], str]:
+    token_id = payload.get("jti")
+    if token_id:
+        return REVOKED_TOKEN_IDS, token_id
+    return REVOKED_TOKENS, token
+
+
+def _revoke_decoded_token(token: str, payload: dict) -> None:
+    revoked_set, revoked_value = _revocation_key(payload, token)
+    revoked_set.add(revoked_value)
+
+
+def _ensure_token_not_revoked(token: str, payload: dict) -> None:
+    revoked_set, revoked_value = _revocation_key(payload, token)
+    if revoked_value in revoked_set:
+        raise HTTPException(status_code=401, detail="Token has been revoked")
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    secret = get_jwt_secret()
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    issued_at = _utcnow()
+    expire = issued_at + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire, "iat": issued_at, "type": "access", "jti": uuid4().hex})
+    return jwt.encode(to_encode, secret, algorithm=JWT_ALGORITHM)
 
 
 def create_refresh_token(data: dict) -> str:
+    secret = get_jwt_secret()
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    issued_at = _utcnow()
+    expire = issued_at + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "iat": issued_at, "type": "refresh", "jti": uuid4().hex})
+    return jwt.encode(to_encode, secret, algorithm=JWT_ALGORITHM)
 
 
 def decode_token(token: str) -> dict:
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
+        payload = jwt.decode(token, get_jwt_secret(), algorithms=JWT_DECODE_ALGORITHMS)
+        _ensure_token_not_revoked(token, payload)
         return payload
+    except HTTPException:
+        raise
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def revoke_token(token: str) -> dict:
+    payload = decode_token(token)
+    _revoke_decoded_token(token, payload)
+    return payload
+
+
+def refresh_login_tokens(refresh_token: str) -> dict:
+    payload = decode_token(refresh_token)
+
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+
+    _revoke_decoded_token(refresh_token, payload)
+    return generate_login_tokens(
+        user_id=user_id,
+        address=payload.get("address"),
+        roles=payload.get("roles", []),
+    )
 
 
 async def get_current_user(
@@ -52,8 +113,6 @@ async def get_current_user(
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
 
-    # BUG: No token revocation check — logged-out or compromised tokens
-    # remain valid until they naturally expire
     user_data = {
         "id": payload.get("sub"),
         "address": payload.get("address"),
@@ -76,8 +135,13 @@ def require_role(role: str):
 
 def generate_login_tokens(user_id: str, address: str, roles: list = None) -> dict:
     data = {"sub": user_id, "address": address, "roles": roles or []}
+    refresh_token = create_refresh_token(data)
+    expires_at = int((_utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)).timestamp())
     return {
         "token": create_access_token(data),
-        "refresh_token": create_refresh_token(data),
+        "refresh_token": refresh_token,
+        "refreshToken": refresh_token,
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        "expiresAt": expires_at,
+        "walletAddress": address,
     }

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,6 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
+PyJWT>=2.10.0
+pytest>=8.3.0
 web3>=7.6.0

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -1,0 +1,48 @@
+"""Authentication token endpoints."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict, Field
+
+try:
+    from ..middleware.auth import refresh_login_tokens, revoke_token
+except ImportError:  # pragma: no cover - supports `cd api && uvicorn main:app`
+    if __package__ and __package__.startswith("api"):
+        raise
+    from middleware.auth import refresh_login_tokens, revoke_token
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+optional_security = HTTPBearer(auto_error=False)
+
+
+class RefreshRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    refresh_token: str = Field(alias="refreshToken")
+
+
+class RevokeRequest(BaseModel):
+    token: Optional[str] = None
+
+
+@router.post("/refresh")
+async def refresh_token(request: RefreshRequest):
+    return refresh_login_tokens(request.refresh_token)
+
+
+@router.post("/revoke")
+async def revoke_auth_token(
+    request: Optional[RevokeRequest] = None,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
+):
+    token = request.token if request and request.token else None
+    if not token and credentials:
+        token = credentials.credentials
+    if not token:
+        raise HTTPException(status_code=400, detail="Token is required")
+
+    payload = revoke_token(token)
+    return {"revoked": True, "type": payload.get("type")}

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware import auth
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_state(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "test-secret-that-is-at-least-32-bytes")
+    auth.REVOKED_TOKEN_IDS.clear()
+    auth.REVOKED_TOKENS.clear()
+    yield
+    auth.REVOKED_TOKEN_IDS.clear()
+    auth.REVOKED_TOKENS.clear()
+
+
+def test_missing_jwt_secret_fails_closed_without_import_crash(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.create_access_token({"sub": "user-1"})
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "JWT secret is not configured"
+
+
+def test_decode_rejects_unsigned_none_algorithm_token():
+    now = datetime.now(timezone.utc)
+    none_token = jwt.encode(
+        {
+            "sub": "user-1",
+            "address": "0xabc",
+            "roles": [],
+            "type": "access",
+            "jti": "unsigned-token",
+            "iat": now,
+            "exp": now + timedelta(minutes=5),
+        },
+        key="",
+        algorithm="none",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.decode_token(none_token)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid token"
+
+
+def test_revoked_token_fails_decode():
+    token = auth.create_access_token({"sub": "user-1", "address": "0xabc", "roles": ["admin"]})
+
+    assert auth.decode_token(token)["sub"] == "user-1"
+    auth.revoke_token(token)
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.decode_token(token)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Token has been revoked"
+
+
+def test_refresh_endpoint_issues_new_tokens_and_rejects_reuse():
+    client = TestClient(app)
+    refresh_token = auth.create_refresh_token(
+        {"sub": "user-1", "address": "0xabc", "roles": ["builder"]}
+    )
+
+    response = client.post("/auth/refresh", json={"refreshToken": refresh_token})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["token"]
+    assert body["refresh_token"]
+    assert body["refreshToken"] == body["refresh_token"]
+    assert body["expires_in"] == auth.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+    assert body["walletAddress"] == "0xabc"
+    assert auth.decode_token(body["token"])["type"] == "access"
+    assert auth.decode_token(body["refresh_token"])["type"] == "refresh"
+
+    reused_response = client.post("/auth/refresh", json={"refreshToken": refresh_token})
+
+    assert reused_response.status_code == 401
+    assert reused_response.json()["detail"] == "Token has been revoked"
+
+
+def test_revoke_endpoint_accepts_bearer_token_and_blocks_reuse():
+    client = TestClient(app)
+    token = auth.create_access_token({"sub": "user-1", "address": "0xabc", "roles": []})
+
+    response = client.post("/auth/revoke", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json() == {"revoked": True, "type": "access"}
+
+    blocked_response = client.post("/auth/revoke", headers={"Authorization": f"Bearer {token}"})
+
+    assert blocked_response.status_code == 401
+    assert blocked_response.json()["detail"] == "Token has been revoked"


### PR DESCRIPTION
## Summary
- fail closed when `JWT_SECRET` is missing, so importing the API no longer crashes and token operations return a clear configuration error
- pin JWT decoding to `HS256` and reject unsigned `alg=none` tokens
- add `jti` claims, in-memory revocation, refresh-token rotation, `/auth/refresh`, and `/auth/revoke`

## Validation
- `python3 -m pytest -q`
- `python3 -m compileall -q api`
- local Uvicorn smoke: refresh succeeds, refresh reuse fails, revoked access token fails, unsigned refresh token fails