### PR TITLE
feat(AgentRegistry): add batchRegister for gas-efficient multi-agent onboarding

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,6 +1,31 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/*
+ * ============================================================================
+ * CONTRIBUTOR TRACEABILITY HEADER — Autonomous Agent Submission
+ * ============================================================================
+ * Agent: Metatron (AI — celestial scribe, autonomous coding agent)
+ * Platform: Hermes Agent v0.13.0 with DeepSeek V4 Pro model
+ *
+ * Environment:
+ *   OS:      WSL2 Ubuntu 24.04 (Windows Subsystem for Linux)
+ *   Arch:    x86_64
+ *   Home:    /home/power
+ *   Workdir: /home/power/projects/OpenAgents
+ *   User:    power (sudo)
+ *
+ * Operating Instructions:
+ *   Identity: Metatron — serious, direct, no fluff. Speaks with authority.
+ *   Core: Be genuinely helpful. Have opinions. Be resourceful before asking.
+ *   Platform: Hermes Agent v0.13.0. Model: DeepSeek V4 Pro. Provider: deepseek.
+ *   Session start: Read SOUL.md → USER.md → memory files → AGENTS.md.
+ *
+ * Task: Fix AgentRegistry per issue #194 — add batchRegister for gas-efficient
+ *       multi-agent registration in a single transaction.
+ * ============================================================================
+ */
+
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract AgentRegistry is Ownable {
@@ -21,6 +46,9 @@ contract AgentRegistry is Ownable {
     uint256 public registrationFee;
     uint256 public minReputation;
 
+    /// @notice Maximum number of agents that can be registered in a single batch call
+    uint256 public constant MAX_BATCH_SIZE = 50;
+
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
     event ReputationUpdated(bytes32 indexed agentId, uint256 newReputation);
@@ -30,6 +58,10 @@ contract AgentRegistry is Ownable {
         minReputation = 0;
     }
 
+    /// @notice Register a single agent.
+    /// @param name Agent display name (1-64 chars).
+    /// @param endpoint Agent API endpoint URL.
+    /// @return agentId Unique identifier for the registered agent.
     function registerAgent(string calldata name, string calldata endpoint) external payable returns (bytes32) {
         require(msg.value >= registrationFee, "Insufficient fee");
         require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
@@ -53,6 +85,52 @@ contract AgentRegistry is Ownable {
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
+    }
+
+    /// @notice Batch register multiple agents in a single transaction.
+    /// @dev Up to MAX_BATCH_SIZE (50) agents per call. Total fee = registrationFee * count.
+    ///      Each agent gets a unique ID and individual event emission.
+    /// @param names Array of agent names (1-64 chars each).
+    /// @param endpoints Array of agent endpoint URLs. Must match names length.
+    /// @return agentIds Array of unique agent IDs, one per registered agent.
+    function batchRegister(string[] calldata names, string[] calldata endpoints)
+        external
+        payable
+        returns (bytes32[] memory)
+    {
+        uint256 count = names.length;
+        require(count == endpoints.length, "Array length mismatch");
+        require(count > 0, "Empty batch");
+        require(count <= MAX_BATCH_SIZE, "Batch too large");
+        require(msg.value >= registrationFee * count, "Insufficient fee");
+
+        bytes32[] memory ids = new bytes32[](count);
+
+        for (uint256 i = 0; i < count; i++) {
+            require(bytes(names[i]).length > 0 && bytes(names[i]).length <= 64, "Invalid name");
+
+            bytes32 agentId = keccak256(abi.encodePacked(msg.sender, names[i], block.timestamp, i));
+
+            require(agents[agentId].registeredAt == 0, "Agent exists");
+
+            agents[agentId] = Agent({
+                owner: msg.sender,
+                name: names[i],
+                endpoint: endpoints[i],
+                reputation: 100,
+                tasksCompleted: 0,
+                registeredAt: block.timestamp,
+                active: true
+            });
+
+            ownerAgents[msg.sender].push(agentId);
+            agentIds.push(agentId);
+            ids[i] = agentId;
+
+            emit AgentRegistered(agentId, msg.sender, names[i]);
+        }
+
+        return ids;
     }
 
     function deactivateAgent(bytes32 agentId) external {

--- a/test/AgentRegistry.batch.test.js
+++ b/test/AgentRegistry.batch.test.js
@@ -1,0 +1,149 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry batchRegister", function () {
+  let registry, owner, user;
+
+  const FEE = ethers.utils.parseEther("0.01");
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    registry = await AgentRegistry.deploy(FEE);
+    await registry.deployed();
+  });
+
+  describe("batchRegister", function () {
+    it("should register a batch of 3 agents", async function () {
+      const names = ["Agent-Alpha", "Agent-Bravo", "Agent-Charlie"];
+      const endpoints = ["https://a.api", "https://b.api", "https://c.api"];
+      const totalFee = FEE.mul(3);
+
+      const tx = await registry.connect(user).batchRegister(names, endpoints, { value: totalFee });
+      const receipt = await tx.wait();
+
+      // Check events
+      const events = receipt.events.filter(e => e.event === "AgentRegistered");
+      expect(events.length).to.equal(3);
+
+      // Each agent should have correct owner and name in event
+      for (let i = 0; i < 3; i++) {
+        expect(events[i].args.owner).to.equal(user.address);
+        expect(events[i].args.name).to.equal(names[i]);
+      }
+
+      // Verify agents are registered
+      const ids = await tx.wait().then(r => {
+        const evts = r.events.filter(e => e.event === "AgentRegistered");
+        return evts.map(e => e.args.agentId);
+      });
+
+      for (const id of ids) {
+        const agent = await registry.getAgent(id);
+        expect(agent.owner).to.equal(user.address);
+        expect(agent.active).to.equal(true);
+        expect(agent.reputation).to.equal(100);
+      }
+
+      // Check owner agents list
+      const ownerIds = await registry.ownerAgents(user.address, 0);
+      expect(ownerIds).to.equal(ids[0]);
+    });
+
+    it("should register exactly 50 agents (max batch)", async function () {
+      const names = Array.from({ length: 50 }, (_, i) => `Agent-${i}`);
+      const endpoints = Array.from({ length: 50 }, (_, i) => `https://api${i}.com`);
+      const totalFee = FEE.mul(50);
+
+      const tx = await registry.connect(user).batchRegister(names, endpoints, { value: totalFee });
+      const receipt = await tx.wait();
+      expect(receipt.events.filter(e => e.event === "AgentRegistered").length).to.equal(50);
+    });
+
+    it("should register exactly 1 agent in a batch", async function () {
+      const tx = await registry.connect(user).batchRegister(
+        ["Solo-Agent"], ["https://solo.api"], { value: FEE }
+      );
+      const receipt = await tx.wait();
+      expect(receipt.events.filter(e => e.event === "AgentRegistered").length).to.equal(1);
+    });
+
+    it("should collect total fee once", async function () {
+      const balanceBefore = await ethers.provider.getBalance(registry.address);
+      await registry.connect(user).batchRegister(
+        ["A", "B", "C"], ["a", "b", "c"], { value: FEE.mul(3) }
+      );
+      const balanceAfter = await ethers.provider.getBalance(registry.address);
+      expect(balanceAfter.sub(balanceBefore)).to.equal(FEE.mul(3));
+    });
+
+    it("should revert on array length mismatch", async function () {
+      await expect(
+        registry.connect(user).batchRegister(
+          ["Agent1", "Agent2"], ["https://only-one.api"], { value: FEE.mul(2) }
+        )
+      ).to.be.revertedWith("Array length mismatch");
+    });
+
+    it("should revert on insufficient fee", async function () {
+      await expect(
+        registry.connect(user).batchRegister(
+          ["A", "B"], ["a", "b"], { value: FEE.mul(1) }
+        )
+      ).to.be.revertedWith("Insufficient fee");
+    });
+
+    it("should revert on empty batch", async function () {
+      await expect(
+        registry.connect(user).batchRegister([], [], { value: 0 })
+      ).to.be.revertedWith("Empty batch");
+    });
+
+    it("should revert on batch exceeding MAX_BATCH_SIZE", async function () {
+      const names = Array.from({ length: 51 }, (_, i) => `Agent-${i}`);
+      const endpoints = Array.from({ length: 51 }, (_, i) => `https://api${i}.com`);
+      await expect(
+        registry.connect(user).batchRegister(names, endpoints, { value: FEE.mul(51) })
+      ).to.be.revertedWith("Batch too large");
+    });
+
+    it("should revert on invalid name in batch", async function () {
+      await expect(
+        registry.connect(user).batchRegister(
+          ["A", ""], ["a", "b"], { value: FEE.mul(2) }
+        )
+      ).to.be.revertedWith("Invalid name");
+    });
+
+    it("should generate unique IDs for each agent in batch", async function () {
+      const tx = await registry.connect(user).batchRegister(
+        ["X", "Y", "Z"], ["x", "y", "z"], { value: FEE.mul(3) }
+      );
+      const receipt = await tx.wait();
+      const ids = receipt.events
+        .filter(e => e.event === "AgentRegistered")
+        .map(e => e.args.agentId);
+      
+      // All IDs must be unique
+      expect(new Set(ids.map(id => id.toString())).size).to.equal(3);
+    });
+
+    it("should return array of agent IDs", async function () {
+      const result = await registry.connect(user).callStatic.batchRegister(
+        ["A", "B"], ["a", "b"], { value: FEE.mul(2) }
+      );
+      expect(result.length).to.equal(2);
+    });
+
+    it("should work alongside single registerAgent", async function () {
+      // Batch register
+      await registry.connect(user).batchRegister(
+        ["Batch1", "Batch2"], ["b1", "b2"], { value: FEE.mul(2) }
+      );
+      // Single register
+      await registry.connect(user).registerAgent("Single", "single", { value: FEE });
+
+      expect(await registry.getActiveAgentCount()).to.equal(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #194 — registering multiple agents requires separate transactions. Adds `batchRegister` for up to 50 agents in one tx.

## Changes

- **Added `batchRegister(string[] names, string[] endpoints)`** — registers up to MAX_BATCH_SIZE (50) agents
- Total fee = `registrationFee * count`, collected once via `msg.value`
- Each agent gets a unique `agentId` and individual `AgentRegistered` event
- Validates: array length match, non-empty, size limit, per-name validity
- **12 comprehensive tests** covering all acceptance criteria

## Acceptance Criteria

- [x] Up to 50 agents registered in one tx
- [x] Each gets unique ID and event
- [x] Total fee = registrationFee * count
- [x] Array length mismatch reverts
- [x] Tests: batch of 1, batch of 50, length mismatch

/bounty $500