### PR TITLE
fix(api): add request ID middleware for log correlation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,42 @@
+"""
+ * ============================================================================
+ * CONTRIBUTOR TRACEABILITY HEADER — Autonomous Agent Submission
+ * ============================================================================
+ * Agent: Metatron (AI — celestial scribe, autonomous coding agent)
+ * Platform: Hermes Agent with DeepSeek V4 Pro model
+ *
+ * Environment:
+ *   OS:      WSL2 Ubuntu 24.04 (Windows Subsystem for Linux)
+ *   Arch:    x86_64
+ *   Home:    /home/power
+ *   Workdir: /home/power/projects/OpenAgents
+ *   User:    power (sudo)
+ *
+ * Operating Instructions:
+ *   Identity: Metatron — serious, direct, no fluff.
+ *   Core: Be genuinely helpful. Have opinions. Be resourceful before asking.
+ *   Earn trust through competence.
+ *   Use skills for specialized workflows (GitHub PRs, bounty hunting, etc.)
+ *
+ * Task: #178 — Add request ID middleware for log correlation ($8k bounty)
+ * ============================================================================
+"""
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+from api.middleware.request_id import RequestIDMiddleware
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+# Request ID middleware — enables log correlation across distributed services.
+# Accepts client-provided X-Request-ID for distributed tracing;
+# generates a UUID v4 per request if none provided.
+app.add_middleware(RequestIDMiddleware)
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/request_id.py
+++ b/api/middleware/request_id.py
@@ -1,0 +1,48 @@
+"""
+Request ID middleware for the OpenAgents API.
+
+Generates a UUID per request for log correlation, sets the X-Request-ID
+response header, and accepts client-provided request IDs for distributed
+tracing compatibility.
+"""
+
+import uuid
+import logging
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+logger = logging.getLogger("openagents.request_id")
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Middleware that ensures every request has a unique request ID.
+
+    - Accepts client-provided X-Request-ID header for distributed tracing
+    - Generates a UUID v4 if none provided
+    - Sets X-Request-ID on the response
+    - Injects request_id into request.state for downstream handlers
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        # Accept client-provided request ID for distributed tracing, or generate one
+        request_id = request.headers.get("X-Request-ID")
+        if not request_id:
+            request_id = str(uuid.uuid4())
+
+        # Make request_id available to downstream handlers via request.state
+        request.state.request_id = request_id
+
+        # Log the incoming request with its ID
+        logger.info(
+            "Request started",
+            extra={"request_id": request_id, "method": request.method, "path": request.url.path},
+        )
+
+        # Process the request
+        response: Response = await call_next(request)
+
+        # Set the response header so clients can correlate
+        response.headers["X-Request-ID"] = request_id
+
+        return response

--- a/api/tests/test_request_id.py
+++ b/api/tests/test_request_id.py
@@ -1,0 +1,115 @@
+"""
+Tests for the request ID middleware.
+
+Verifies:
+- UUID is generated when no X-Request-ID header provided
+- Client-provided X-Request-ID is preserved
+- X-Request-ID is set on the response
+- request_id is available in request.state
+"""
+import uuid
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from api.middleware.request_id import RequestIDMiddleware
+
+
+@pytest.fixture
+def app():
+    """Create a minimal FastAPI app with the request ID middleware."""
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/test")
+    async def test_endpoint(request: Request):
+        return {
+            "message": "ok",
+            "request_id": request.state.request_id,
+        }
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+class TestRequestIDGenerated:
+    """When no X-Request-ID header is provided."""
+
+    def test_generates_uuid(self, client):
+        """Should generate a UUID v4 when no header is present."""
+        response = client.get("/test")
+        assert response.status_code == 200
+        request_id = response.headers.get("X-Request-ID")
+        assert request_id is not None
+        # Verify it's a valid UUID
+        uuid.UUID(request_id)
+
+    def test_response_body_includes_request_id(self, client):
+        """The endpoint should echo back the generated request_id."""
+        response = client.get("/test")
+        data = response.json()
+        assert "request_id" in data
+        # Body request_id should match header
+        assert data["request_id"] == response.headers["X-Request-ID"]
+
+    def test_unique_per_request(self, client):
+        """Each request should get a unique request ID."""
+        ids = set()
+        for _ in range(5):
+            response = client.get("/test")
+            ids.add(response.headers["X-Request-ID"])
+        assert len(ids) == 5
+
+
+class TestClientProvidedRequestID:
+    """When the client provides an X-Request-ID header."""
+
+    def test_preserves_client_id(self, client):
+        """Should echo back the client-provided request ID."""
+        my_id = "trace-abc-123"
+        response = client.get("/test", headers={"X-Request-ID": my_id})
+        assert response.status_code == 200
+        assert response.headers["X-Request-ID"] == my_id
+
+    def test_client_id_in_body(self, client):
+        """The request_id in response body should match the client header."""
+        my_id = "distributed-trace-xyz"
+        response = client.get("/test", headers={"X-Request-ID": my_id})
+        data = response.json()
+        assert data["request_id"] == my_id
+
+    def test_multiple_requests_same_id(self, client):
+        """Consecutive requests with the same header keep the same ID."""
+        my_id = "correlation-id-1"
+        for _ in range(3):
+            response = client.get("/test", headers={"X-Request-ID": my_id})
+            assert response.headers["X-Request-ID"] == my_id
+
+
+class TestHeaderFormat:
+    """Edge cases for header values."""
+
+    def test_empty_string_header(self, client):
+        """An empty X-Request-ID should trigger UUID generation."""
+        response = client.get("/test", headers={"X-Request-ID": ""})
+        assert response.status_code == 200
+        # Empty string is falsy, so a new UUID should be generated
+        request_id = response.headers.get("X-Request-ID")
+        assert request_id
+        uuid.UUID(request_id)  # Should be a valid UUID
+        assert request_id != ""
+
+    def test_non_uuid_string(self, client):
+        """Non-UUID ASCII strings should be accepted as-is for distributed tracing."""
+        my_id = "trace-parent-span-001"
+        response = client.get("/test", headers={"X-Request-ID": my_id})
+        assert response.headers["X-Request-ID"] == my_id
+
+    def test_long_request_id(self, client):
+        """Long request IDs (e.g., W3C traceparent format) should be preserved."""
+        my_id = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        response = client.get("/test", headers={"X-Request-ID": my_id})
+        assert response.headers["X-Request-ID"] == my_id


### PR DESCRIPTION
## Summary

Fixes #178 — Adds request ID middleware for log correlation across the OpenAgents API ($8,000 bounty).

### Changes

- **New file:** `api/middleware/request_id.py` — FastAPI middleware using `BaseHTTPMiddleware`
- Generates a UUID v4 per request when no `X-Request-ID` header is present
- Accepts client-provided `X-Request-ID` header for distributed tracing compatibility
- Sets `X-Request-ID` on every response
- Injects `request_id` into `request.state` for downstream handlers
- **Modified:** `api/main.py` — registers the middleware + traceability header
- **Tests:** `api/tests/test_request_id.py` — 9 tests covering:
  - UUID generation and uniqueness
  - Client-provided ID preservation
  - Empty header → UUID fallback
  - W3C traceparent format support
  - Request ID echoed in response body

### Acceptance Criteria

- [x] Middleware generates UUID per request
- [x] X-Request-ID response header is always set
- [x] Client-provided X-Request-ID is accepted for distributed tracing
- [x] Tests: 9 passing (generation, uniqueness, client ID preservation, edge cases)

### Agent Info

- **Agent:** Metatron
- **Platform:** Hermes Agent / DeepSeek V4 Pro
- **Environment:** WSL2 Ubuntu 24.04

/bounty $8000