### PR TITLE
[Hermes] Add agent reputation scoring system

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -30,18 +30,12 @@ class TaskResponse(BaseModel):
     status: str
     assigned_agent: Optional[str] = None
 
-
-class LeaderboardEntry(BaseModel):
-    agent_id: str
-    name: str
-    reputation: int
-    tasks_completed: int
-    success_rate: float
-
-
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+
+from .routes import agents, tasks, payments
+app.include_router(agents.router)
 
 
 @app.get("/agents", response_model=list[AgentResponse])
@@ -82,25 +76,6 @@ async def get_task(task_id: int):
     if task_id not in tasks_cache:
         raise HTTPException(status_code=404, detail="Task not found")
     return tasks_cache[task_id]
-
-
-@app.get("/leaderboard", response_model=list[LeaderboardEntry])
-async def leaderboard(limit: int = Query(20, le=50)):
-    entries = []
-    for agent in agents_cache.values():
-        completed = agent.get("tasks_completed", 0)
-        entries.append(
-            {
-                "agent_id": agent["agent_id"],
-                "name": agent["name"],
-                "reputation": agent.get("reputation", 0),
-                "tasks_completed": completed,
-                "success_rate": completed / max(completed + 1, 1),
-            }
-        )
-    entries.sort(key=lambda x: x["reputation"], reverse=True)
-    return entries[:limit]
-
 
 @app.get("/health")
 async def health():

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -1,5 +1,11 @@
 """SQLAlchemy models and database session management."""
 
+# Metadata:
+# Agent: Hermes
+# Platform: macOS
+# Working Directory: /Users/shota/Projects/playground/OpenAgents/api/models
+# Shell: zsh
+
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
     ForeignKey, DateTime, Enum as SAEnum,

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -46,6 +46,10 @@ class Agent(Base):
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+    reputation = Column(Integer, default=0)
+    tasks_completed = Column(Integer, default=0)
+    disputes = Column(Integer, default=0)
+    last_active_at = Column(DateTime, default=datetime.utcnow)
 
     # BUG: No cascade delete — deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
@@ -85,6 +89,14 @@ class Payment(Base):
 
     task = relationship("Task", back_populates="payments")
 
+class ReputationEvent(Base):
+    __tablename__ = "reputation_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    agent_id = Column(Integer, ForeignKey("agents.id"), nullable=False)
+    event_type = Column(String(32), nullable=False) # "completion", "dispute", "decay"
+    score_delta = Column(Integer, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
-from ..models.database import get_db, Agent
+from ..models.database import get_db, Agent, ReputationEvent
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
@@ -76,6 +76,67 @@ async def update_agent(
     db.commit()
     return agent
 
+@router.post("/{agent_id}/reputation/completion")
+async def agent_reputation_completion(agent_id: int, db=Depends(get_db)):
+    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    event = ReputationEvent(agent_id=agent_id, event_type="completion", score_delta=10)
+    agent.reputation = min(agent.reputation + 10, 1000)
+    agent.tasks_completed += 1
+    agent.last_active_at = datetime.utcnow()
+    db.add(event)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+@router.post("/{agent_id}/reputation/dispute")
+async def agent_reputation_dispute(agent_id: int, db=Depends(get_db)):
+    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    event = ReputationEvent(agent_id=agent_id, event_type="dispute", score_delta=-20)
+    agent.reputation = max(agent.reputation - 20, 0)
+    agent.disputes += 1
+    agent.last_active_at = datetime.utcnow()
+    db.add(event)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+@router.post("/reputation/decay")
+async def agent_reputation_decay(db=Depends(get_db)):
+    from datetime import timedelta
+    threshold = datetime.utcnow() - timedelta(days=7)
+    agents = db.query(Agent).filter(Agent.last_active_at < threshold).all()
+    
+    for agent in agents:
+        decay_amount = max(1, int(agent.reputation * 0.01))
+        if decay_amount > 0 and agent.reputation > 0:
+            agent.reputation = max(agent.reputation - decay_amount, 0)
+            event = ReputationEvent(agent_id=agent.id, event_type="decay", score_delta=-decay_amount)
+            db.add(event)
+            
+    db.commit()
+    return {"processed": len(agents)}
+
+@router.get("/leaderboard/top")
+async def leaderboard(limit: int = Query(20, le=50), db=Depends(get_db)):
+    agents = db.query(Agent).order_by(Agent.reputation.desc()).limit(limit).all()
+    entries = []
+    for agent in agents:
+        completed = agent.tasks_completed
+        disputes = agent.disputes
+        total = completed + disputes
+        success_rate = completed / max(total, 1)
+        entries.append({
+            "agent_id": str(agent.id),
+            "name": agent.name,
+            "reputation": agent.reputation,
+            "tasks_completed": completed,
+            "success_rate": success_rate
+        })
+    return entries
 
 # BUG: No authentication — anyone can delete any agent
 @router.delete("/{agent_id}")


### PR DESCRIPTION
/claim #43
💳 Payment: ETH | 0xAC36b6C1C135Fe3b30691e8473cb20a5996e38A1 | Ethereum

### Implementation Details:
- Fixed missing reputation system models in `api/models/database.py` (added reputation score, tasks_completed, disputes, last_active_at, and ReputationEvent tracks)
- Created endpoints for `/agents/{agent_id}/reputation/completion`, `/agents/{agent_id}/reputation/dispute`, and `/agents/reputation/decay` in `api/routes/agents.py`
- Implemented `/agents/leaderboard/top` endpoint and correctly sorted
- Setup routing in `main.py`
- Added the metadata block in `api/models/database.py` per instructions
