### PR TITLE
fix: protect task completion flow

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+SQLAlchemy>=2.0.0
+PyJWT>=2.10.0
+pytest>=8.0.0

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,16 +1,25 @@
 """Task management endpoints for bounty assignments."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Optional
 
-from ..models.database import get_db, Task
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, field_validator
+
 from ..middleware.auth import get_current_user
+from ..models.database import Agent, Task, get_db
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled"}
+STATUS_TRANSITIONS = {
+    "open": {"assigned", "cancelled"},
+    "assigned": {"in_progress", "cancelled"},
+    "in_progress": {"review", "cancelled"},
+    "review": {"completed", "in_progress", "cancelled"},
+    "completed": set(),
+    "cancelled": set(),
+}
 
 
 class TaskCreate(BaseModel):
@@ -22,7 +31,14 @@ class TaskCreate(BaseModel):
 
 
 class TaskStatusUpdate(BaseModel):
-    status: str  # BUG: Not validated against VALID_STATUSES enum — any string accepted
+    status: str
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: str) -> str:
+        if value not in VALID_STATUSES:
+            raise ValueError(f"status must be one of: {', '.join(sorted(VALID_STATUSES))}")
+        return value
 
 
 @router.post("/")
@@ -48,9 +64,7 @@ async def list_tasks(
     status: Optional[str] = None,
     creator: Optional[str] = None,
     skip: int = Query(0, ge=0),
-    # BUG: No upper bound on limit — clients can request millions of rows,
-    # causing DB strain and potential OOM
-    limit: int = Query(50, ge=1),
+    limit: int = Query(50, ge=1, le=100),
     db=Depends(get_db),
 ):
     query = db.query(Task)
@@ -80,9 +94,24 @@ async def update_task_status(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    # BUG: Creator can mark their own task as completed — should require
-    # a third party or the assignee to confirm completion
-    if task.creator_id != user["id"]:
+    if update.status == task.status:
+        return {"id": task.id, "status": task.status}
+
+    allowed_statuses = STATUS_TRANSITIONS.get(task.status, set())
+    if update.status not in allowed_statuses:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot transition task from {task.status} to {update.status}",
+        )
+
+    if update.status == "completed":
+        if _same_id(task.creator_id, user["id"]):
+            raise HTTPException(status_code=403, detail="Task creator cannot complete their own task")
+
+        agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
+        if not agent or not _same_id(agent.owner_id, user["id"]):
+            raise HTTPException(status_code=403, detail="Only the assigned agent can complete task")
+    elif not _same_id(task.creator_id, user["id"]):
         raise HTTPException(status_code=403, detail="Only the creator can update status")
 
     task.status = update.status
@@ -96,10 +125,14 @@ async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(g
     task = db.query(Task).filter(Task.id == task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
-    if task.creator_id != user["id"]:
+    if not _same_id(task.creator_id, user["id"]):
         raise HTTPException(status_code=403, detail="Only the creator can cancel")
     if task.status not in ("open", "assigned"):
         raise HTTPException(status_code=400, detail="Cannot cancel an active task")
     task.status = "cancelled"
     db.commit()
     return {"id": task.id, "status": "cancelled"}
+
+
+def _same_id(left, right) -> bool:
+    return str(left) == str(right)

--- a/api/tests/test_tasks.py
+++ b/api/tests/test_tasks.py
@@ -1,0 +1,103 @@
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import Agent, Base, Task, User
+from api.routes import tasks
+
+
+def make_client(tmp_path, current_user):
+    database_url = f"sqlite:///{tmp_path / 'test.db'}"
+    engine = create_engine(database_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_user():
+        return current_user
+
+    app = FastAPI()
+    app.include_router(tasks.router)
+    app.dependency_overrides[tasks.get_db] = override_db
+    app.dependency_overrides[tasks.get_current_user] = override_user
+    return TestClient(app), TestingSessionLocal
+
+
+def seed_task(SessionLocal, status="review"):
+    db = SessionLocal()
+    try:
+        creator = User(id=1, address="0x1111111111111111111111111111111111111111")
+        worker = User(id=2, address="0x2222222222222222222222222222222222222222")
+        agent = Agent(id=7, name="Worker", owner_id=worker.id)
+        task = Task(
+            id=42,
+            title="Fix route",
+            description="Patch task status authorization",
+            reward_amount=100.0,
+            creator_id=creator.id,
+            agent_id=agent.id,
+            status=status,
+        )
+        db.add_all([creator, worker, agent, task])
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_creator_cannot_complete_own_task(tmp_path):
+    client, SessionLocal = make_client(tmp_path, {"id": 1, "address": "0x1"})
+    seed_task(SessionLocal)
+
+    response = client.patch("/tasks/42/status", json={"status": "completed"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Task creator cannot complete their own task"
+
+
+def test_assigned_agent_owner_can_complete_review_task(tmp_path):
+    client, SessionLocal = make_client(tmp_path, {"id": 2, "address": "0x2"})
+    seed_task(SessionLocal)
+
+    response = client.patch("/tasks/42/status", json={"status": "completed"})
+
+    assert response.status_code == 200
+    assert response.json() == {"id": 42, "status": "completed"}
+
+
+def test_invalid_status_is_rejected(tmp_path):
+    client, SessionLocal = make_client(tmp_path, {"id": 1, "address": "0x1"})
+    seed_task(SessionLocal)
+
+    response = client.patch("/tasks/42/status", json={"status": "paid"})
+
+    assert response.status_code == 422
+
+
+def test_invalid_transition_is_rejected(tmp_path):
+    client, SessionLocal = make_client(tmp_path, {"id": 1, "address": "0x1"})
+    seed_task(SessionLocal, status="open")
+
+    response = client.patch("/tasks/42/status", json={"status": "review"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Cannot transition task from open to review"
+
+
+def test_list_limit_is_capped_at_100(tmp_path):
+    client, SessionLocal = make_client(tmp_path, {"id": 1, "address": "0x1"})
+    seed_task(SessionLocal)
+
+    response = client.get("/tasks/?limit=101")
+
+    assert response.status_code == 422


### PR DESCRIPTION
Fixes #48.

## Summary
- validates task status values at request parsing time
- caps task listing pagination at 100 rows
- enforces explicit task status transitions
- prevents creators from completing their own tasks; only the owner of the assigned agent can mark a review task completed
- adds focused FastAPI tests for creator completion denial, assigned-agent completion, invalid status rejection, invalid transitions, and pagination limits

No private prompt/session initialization text is included in source comments.

## Verification
- python -m pytest api\\tests\\test_tasks.py -q
- python -m py_compile api\\routes\\tasks.py api\\tests\\test_tasks.py
- git diff --check

Preferred payout if approved: Base USDC 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92
Alternative: USDT TRC20 TPwPFww7zxXFQ7zugo22gktQhckWVarRqi