### PR TITLE
fix: make escrow claims safe

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, UniqueConstraint,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -30,7 +30,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     address = Column(String(42), unique=True, nullable=False)
     username = Column(String(64), unique=True, nullable=True)
-    # BUG: No index on address — wallet lookups on every auth request do full table scans
+    # BUG: No index on address - wallet lookups on every auth request do full table scans
     created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
 
     agents = relationship("Agent", back_populates="owner")
@@ -47,7 +47,7 @@ class Agent(Base):
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 
-    # BUG: No cascade delete — deleting a user leaves orphaned agents
+    # BUG: No cascade delete - deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
     tasks = relationship("Task", back_populates="agent")
 
@@ -72,6 +72,9 @@ class Task(Base):
 
 class Payment(Base):
     __tablename__ = "payments"
+    __table_args__ = (
+        UniqueConstraint("from_address", "idempotency_key", name="uq_payment_from_idempotency"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
@@ -79,6 +82,7 @@ class Payment(Base):
     to_address = Column(String(42), nullable=True)
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
+    idempotency_key = Column(String(128), nullable=True, index=True)
     status = Column(String(32), default="pending")
     created_at = Column(DateTime, default=datetime.utcnow)
     claimed_at = Column(DateTime, nullable=True)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+SQLAlchemy>=2.0.0
+PyJWT>=2.10.0
+pytest>=8.0.0

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,22 +1,29 @@
 """Payment and escrow endpoints for bounty payouts."""
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Optional
 
-from ..models.database import get_db, Payment, Task
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+
 from ..middleware.auth import get_current_user
+from ..models.database import Payment, Task, get_db
 
 router = APIRouter(prefix="/payments", tags=["payments"])
 
 
 class EscrowDeposit(BaseModel):
     task_id: int
-    # BUG: Amount is not validated as positive — negative or zero deposits
-    # could corrupt escrow balances or drain funds
     amount: float
     token_address: Optional[str] = "0x0000000000000000000000000000000000000000"
+    idempotency_key: Optional[str] = None
+
+    @field_validator("amount")
+    @classmethod
+    def validate_positive_amount(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("amount must be greater than zero")
+        return value
 
 
 class ClaimRequest(BaseModel):
@@ -34,13 +41,25 @@ async def deposit_escrow(
     if task.creator_id != user["id"]:
         raise HTTPException(status_code=403, detail="Only task creator can fund escrow")
 
-    # BUG: No idempotency key — retried requests create duplicate escrow entries,
-    # locking more funds than intended
+    if deposit.idempotency_key:
+        existing_payment = db.query(Payment).filter(
+            Payment.from_address == user["address"],
+            Payment.idempotency_key == deposit.idempotency_key,
+        ).first()
+        if existing_payment:
+            return {
+                "payment_id": existing_payment.id,
+                "status": existing_payment.status,
+                "amount": existing_payment.amount,
+                "idempotent": True,
+            }
+
     payment = Payment(
         task_id=deposit.task_id,
         from_address=user["address"],
         amount=deposit.amount,
         token_address=deposit.token_address,
+        idempotency_key=deposit.idempotency_key,
         status="escrowed",
         created_at=datetime.utcnow(),
     )
@@ -53,7 +72,8 @@ async def deposit_escrow(
 @router.get("/escrow/{task_id}")
 async def get_escrow_balance(task_id: int, db=Depends(get_db)):
     payments = db.query(Payment).filter(
-        Payment.task_id == task_id, Payment.status == "escrowed"
+        Payment.task_id == task_id,
+        Payment.status == "escrowed",
     ).all()
     total = sum(p.amount for p in payments)
     return {"task_id": task_id, "escrowed_total": total, "deposits": len(payments)}
@@ -63,17 +83,17 @@ async def get_escrow_balance(task_id: int, db=Depends(get_db)):
 async def claim_payment(
     claim: ClaimRequest, user=Depends(get_current_user), db=Depends(get_db)
 ):
-    task = db.query(Task).filter(Task.id == claim.task_id).first()
+    task = db.query(Task).filter(Task.id == claim.task_id).with_for_update().first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     if task.status != "completed":
         raise HTTPException(status_code=400, detail="Task not yet completed")
 
-    # BUG: Race condition — two concurrent claims can both read status="escrowed"
-    # before either updates it, causing a double-payout
     payments = db.query(Payment).filter(
-        Payment.task_id == claim.task_id, Payment.status == "escrowed"
-    ).all()
+        Payment.task_id == claim.task_id,
+        Payment.status == "escrowed",
+        Payment.amount > 0,
+    ).with_for_update().all()
 
     if not payments:
         raise HTTPException(status_code=400, detail="No escrowed funds available")

--- a/api/tests/test_payments.py
+++ b/api/tests/test_payments.py
@@ -1,0 +1,123 @@
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import Base, Payment, Task, User
+from api.routes import payments
+
+
+def make_client(tmp_path, current_user):
+    database_url = f"sqlite:///{tmp_path / 'test.db'}"
+    engine = create_engine(database_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_user():
+        return current_user
+
+    app = FastAPI()
+    app.include_router(payments.router)
+    app.dependency_overrides[payments.get_db] = override_db
+    app.dependency_overrides[payments.get_current_user] = override_user
+    return TestClient(app), TestingSessionLocal
+
+
+def seed_task(SessionLocal, status="open"):
+    db = SessionLocal()
+    try:
+        creator = User(id=1, address="0x1111111111111111111111111111111111111111")
+        worker = User(id=2, address="0x2222222222222222222222222222222222222222")
+        task = Task(
+            id=50,
+            title="Escrow fix",
+            description="Patch claim safety",
+            reward_amount=100.0,
+            creator_id=creator.id,
+            status=status,
+        )
+        db.add_all([creator, worker, task])
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_deposit_rejects_non_positive_amount(tmp_path):
+    client, SessionLocal = make_client(
+        tmp_path,
+        {"id": 1, "address": "0x1111111111111111111111111111111111111111"},
+    )
+    seed_task(SessionLocal)
+
+    response = client.post("/payments/escrow/deposit", json={"task_id": 50, "amount": 0})
+
+    assert response.status_code == 422
+
+
+def test_deposit_idempotency_key_reuses_existing_payment(tmp_path):
+    client, SessionLocal = make_client(
+        tmp_path,
+        {"id": 1, "address": "0x1111111111111111111111111111111111111111"},
+    )
+    seed_task(SessionLocal)
+    payload = {"task_id": 50, "amount": 12.5, "idempotency_key": "deposit-50-a"}
+
+    first = client.post("/payments/escrow/deposit", json=payload)
+    second = client.post("/payments/escrow/deposit", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["idempotent"] is True
+    assert second.json()["payment_id"] == first.json()["payment_id"]
+
+    db = SessionLocal()
+    try:
+        assert db.query(Payment).count() == 1
+    finally:
+        db.close()
+
+
+def test_claim_uses_positive_escrow_once(tmp_path):
+    client, SessionLocal = make_client(
+        tmp_path,
+        {"id": 2, "address": "0x2222222222222222222222222222222222222222"},
+    )
+    seed_task(SessionLocal, status="completed")
+    db = SessionLocal()
+    try:
+        db.add(
+            Payment(
+                task_id=50,
+                from_address="0x1111111111111111111111111111111111111111",
+                amount=8.0,
+                status="escrowed",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    first = client.post(
+        "/payments/claim",
+        json={"task_id": 50, "recipient_address": "0x2222222222222222222222222222222222222222"},
+    )
+    second = client.post(
+        "/payments/claim",
+        json={"task_id": 50, "recipient_address": "0x2222222222222222222222222222222222222222"},
+    )
+
+    assert first.status_code == 200
+    assert first.json()["claimed_amount"] == 8.0
+    assert second.status_code == 400
+    assert second.json()["detail"] == "No escrowed funds available"


### PR DESCRIPTION
Fixes #30.

## Summary
- rejects zero and negative escrow deposits at request validation time
- adds deposit idempotency keys and a database uniqueness guard per funder/key
- reuses existing escrow rows on idempotent deposit retries instead of creating duplicate deposits
- locks the completed task and escrow payment rows during claim processing
- claims only positive escrowed payments and leaves repeated claims with a clear no-funds response
- adds focused FastAPI tests for non-positive deposits, idempotent retry behavior, and single-use escrow claims

No private prompt/session initialization text is included in source comments.

## Verification
- python -m pytest api\\tests\\test_payments.py -q
- python -m py_compile api\\routes\\payments.py api\\models\\database.py api\\tests\\test_payments.py
- git diff --check

Preferred payout if approved: Base USDC 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92
Alternative: USDT TRC20 TPwPFww7zxXFQ7zugo22gktQhckWVarRqi