### PR TITLE
fix: harden yield aggregator accounting

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -72,13 +72,7 @@ contract ChainlinkAdapter {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (, int256 answer,,,) = config.feed.latestRoundData();
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "ERC20: insufficient allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+            emit Approval(from, msg.sender, allowance[from][msg.sender]);
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "ERC20: transfer to zero");
+        require(balanceOf[from] >= amount, "ERC20: insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/contracts/vault/YieldAggregator.sol
+++ b/contracts/vault/YieldAggregator.sol
@@ -3,16 +3,17 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title YieldAggregator
 /// @notice Vault that accepts deposits and allocates capital across yield strategies.
-/// @dev Implements a simplified vault pattern. Users deposit a base token and receive
-///      shares proportional to their ownership of the vault's total assets.
+/// @dev Uses internal asset accounting so direct token donations cannot manipulate share pricing.
 contract YieldAggregator is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
+
+    uint256 public constant MAX_PRICE_DEVIATION_BPS = 500;
+    uint256 private constant BPS_DENOMINATOR = 10_000;
 
     struct Strategy {
         address target;
@@ -33,23 +34,25 @@ contract YieldAggregator is Ownable, ReentrancyGuard {
     event StrategyAllocated(uint256 indexed strategyId, uint256 amount);
 
     constructor(address _asset) Ownable(msg.sender) {
+        require(_asset != address(0), "Vault: zero asset");
         asset = IERC20(_asset);
     }
 
     /// @notice Deposit tokens into the vault and receive shares.
     /// @param amount Amount of base token to deposit.
+    /// @param minShares Minimum acceptable shares to mint.
     /// @return sharesMinted Number of shares issued to the depositor.
-    // BUG: No slippage check on deposit — the share price can be manipulated via
-    // donation attacks (sending tokens directly to the vault) between the user's
-    // approval and deposit, causing them to receive far fewer shares than expected.
-    function deposit(uint256 amount) external nonReentrant returns (uint256 sharesMinted) {
+    function deposit(uint256 amount, uint256 minShares) external nonReentrant returns (uint256 sharesMinted) {
         require(amount > 0, "Vault: zero deposit");
+        _enforcePriceSanity();
 
         if (totalShares == 0) {
             sharesMinted = amount;
         } else {
             sharesMinted = (amount * totalShares) / totalAssets();
         }
+        require(sharesMinted > 0, "Vault: zero shares");
+        require(sharesMinted >= minShares, "Vault: insufficient shares");
 
         asset.safeTransferFrom(msg.sender, address(this), amount);
         totalShares += sharesMinted;
@@ -65,15 +68,13 @@ contract YieldAggregator is Ownable, ReentrancyGuard {
     function withdraw(uint256 shareAmount) external nonReentrant returns (uint256 assetsReturned) {
         require(shareAmount > 0, "Vault: zero shares");
         require(shares[msg.sender] >= shareAmount, "Vault: insufficient shares");
+        _enforcePriceSanity();
 
-        // BUG: Uses balanceOf instead of internal accounting (totalDeposited + strategy gains).
-        // If tokens are donated directly to the vault or a strategy returns funds outside
-        // the normal flow, this inflates the withdrawal amount, allowing early withdrawers
-        // to drain more than their share at the expense of later users.
-        assetsReturned = (shareAmount * asset.balanceOf(address(this))) / totalShares;
+        assetsReturned = (shareAmount * totalAssets()) / totalShares;
 
         shares[msg.sender] -= shareAmount;
         totalShares -= shareAmount;
+        totalDeposited -= assetsReturned;
 
         asset.safeTransfer(msg.sender, assetsReturned);
         emit Withdraw(msg.sender, assetsReturned, shareAmount);
@@ -81,9 +82,8 @@ contract YieldAggregator is Ownable, ReentrancyGuard {
 
     /// @notice Add a new yield strategy.
     /// @param target Address of the strategy contract.
-    // BUG: Strategy target can be zero address — allocating funds to address(0)
-    // would burn them permanently via the external call.
     function addStrategy(address target) external onlyOwner {
+        require(target != address(0), "Vault: zero strategy");
         strategies.push(Strategy({
             target: target,
             allocated: 0,
@@ -111,13 +111,16 @@ contract YieldAggregator is Ownable, ReentrancyGuard {
         strategies[strategyId].active = false;
     }
 
-    /// @notice Total assets under management (vault balance + allocated to strategies).
+    /// @notice Total assets tracked by vault accounting.
     function totalAssets() public view returns (uint256) {
+        return totalDeposited;
+    }
+
+    /// @notice Current token balance plus internally allocated strategy principal.
+    function actualManagedAssets() public view returns (uint256) {
         uint256 total = asset.balanceOf(address(this));
         for (uint256 i = 0; i < strategies.length; i++) {
-            if (strategies[i].active) {
-                total += strategies[i].allocated;
-            }
+            total += strategies[i].allocated;
         }
         return total;
     }
@@ -126,5 +129,25 @@ contract YieldAggregator is Ownable, ReentrancyGuard {
     function previewDeposit(uint256 amount) external view returns (uint256) {
         if (totalShares == 0) return amount;
         return (amount * totalShares) / totalAssets();
+    }
+
+    /// @notice Preview assets returned for a share redemption.
+    function previewWithdraw(uint256 shareAmount) external view returns (uint256) {
+        if (totalShares == 0) return 0;
+        return (shareAmount * totalAssets()) / totalShares;
+    }
+
+    function _enforcePriceSanity() internal view {
+        uint256 accounted = totalAssets();
+        if (accounted == 0) {
+            return;
+        }
+
+        uint256 actual = actualManagedAssets();
+        uint256 deviation = actual > accounted ? actual - accounted : accounted - actual;
+        require(
+            deviation * BPS_DENOMINATOR <= accounted * MAX_PRICE_DEVIATION_BPS,
+            "Vault: price deviation"
+        );
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,8 +2,10 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
+    version: "0.8.24",
     settings: {
+      evmVersion: "cancun",
+      viaIR: true,
       optimizer: {
         enabled: true,
         runs: 200,

--- a/test/YieldAggregator.test.js
+++ b/test/YieldAggregator.test.js
@@ -1,0 +1,92 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("YieldAggregator", function () {
+  let token;
+  let vault;
+  let owner;
+  let alice;
+  let bob;
+  let attacker;
+
+  const depositAmount = ethers.parseEther("100");
+
+  beforeEach(async function () {
+    [owner, alice, bob, attacker] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    token = await MockERC20.deploy("Mock Asset", "MA");
+    await token.waitForDeployment();
+
+    const YieldAggregator = await ethers.getContractFactory("YieldAggregator");
+    vault = await YieldAggregator.deploy(await token.getAddress());
+    await vault.waitForDeployment();
+  });
+
+  async function mintAndApprove(user, amount) {
+    await token.mint(user.address, amount);
+    await token.connect(user).approve(await vault.getAddress(), amount);
+  }
+
+  it("reverts when minted shares are below minShares", async function () {
+    await mintAndApprove(alice, depositAmount);
+
+    await expect(
+      vault.connect(alice).deposit(depositAmount, depositAmount + 1n)
+    ).to.be.revertedWith("Vault: insufficient shares");
+  });
+
+  it("prices deposits from internal accounting instead of donated balance", async function () {
+    await mintAndApprove(alice, depositAmount);
+    await vault.connect(alice).deposit(depositAmount, depositAmount);
+
+    const smallDonation = ethers.parseEther("4");
+    await token.mint(attacker.address, smallDonation);
+    await token.connect(attacker).transfer(await vault.getAddress(), smallDonation);
+
+    await mintAndApprove(bob, depositAmount);
+    await vault.connect(bob).deposit(depositAmount, depositAmount);
+
+    expect(await vault.totalAssets()).to.equal(ethers.parseEther("200"));
+    expect(await vault.actualManagedAssets()).to.equal(ethers.parseEther("204"));
+    expect(await vault.shares(bob.address)).to.equal(depositAmount);
+  });
+
+  it("reverts deposits when actual assets deviate by more than five percent", async function () {
+    await mintAndApprove(alice, depositAmount);
+    await vault.connect(alice).deposit(depositAmount, depositAmount);
+
+    const largeDonation = ethers.parseEther("6");
+    await token.mint(attacker.address, largeDonation);
+    await token.connect(attacker).transfer(await vault.getAddress(), largeDonation);
+
+    await mintAndApprove(bob, depositAmount);
+    await expect(
+      vault.connect(bob).deposit(depositAmount, 0)
+    ).to.be.revertedWith("Vault: price deviation");
+  });
+
+  it("withdraws against accounted assets, not donated token balance", async function () {
+    await mintAndApprove(alice, depositAmount);
+    await vault.connect(alice).deposit(depositAmount, depositAmount);
+
+    const smallDonation = ethers.parseEther("4");
+    await token.mint(attacker.address, smallDonation);
+    await token.connect(attacker).transfer(await vault.getAddress(), smallDonation);
+
+    const before = await token.balanceOf(alice.address);
+    const redeemedShares = ethers.parseEther("50");
+    await vault.connect(alice).withdraw(redeemedShares);
+    const after = await token.balanceOf(alice.address);
+
+    expect(after - before).to.equal(redeemedShares);
+    expect(await vault.totalAssets()).to.equal(ethers.parseEther("50"));
+    expect(await vault.totalShares()).to.equal(ethers.parseEther("50"));
+  });
+
+  it("rejects zero-address strategies", async function () {
+    await expect(
+      vault.connect(owner).addStrategy(ethers.ZeroAddress)
+    ).to.be.revertedWith("Vault: zero strategy");
+  });
+});


### PR DESCRIPTION
Fixes #95
/claim #95

## Summary
- adds `deposit(amount, minShares)` so callers can enforce minimum minted shares
- prices deposits and withdrawals from internal accounted assets instead of raw token balance, so direct donations cannot skew share math
- adds a 5% actual-vs-accounted asset deviation guard for active vault operations
- rejects zero-address strategy targets
- updates the Solidity compiler target to match the installed OpenZeppelin contracts and fixes an existing ChainlinkAdapter tuple destructuring syntax blocker so Hardhat tests can compile
- adds a focused MockERC20 plus YieldAggregator test coverage for minShares, donation accounting, deviation reverts, internal-accounting withdrawals, and zero strategy rejection

## Verification
- `npx hardhat test test\YieldAggregator.test.js` (5 passing)
- `npx hardhat compile`
- `git diff --check` (passes; repository reports only CRLF normalization warnings)

Payment: USDC | `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92` | Base
Alternative payment: USDT | `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi` | TRC20

No private prompt/session initialization text is included in source, comments, or metadata.