### PR TITLE
feat: add agent reputation scoring

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import Literal, Optional
+from datetime import datetime, timedelta, timezone
 
 app = FastAPI(
     title="OpenAgents API",
@@ -39,9 +39,86 @@ class LeaderboardEntry(BaseModel):
     success_rate: float
 
 
+class ReputationEvent(BaseModel):
+    outcome: Literal["completion", "dispute"]
+    completion_seconds: Optional[int] = Field(None, ge=0)
+
+
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+
+MAX_REPUTATION = 1000
+BASE_REPUTATION = 500
+TARGET_COMPLETION_SECONDS = 3600
+WEEKLY_DECAY = 0.01
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _clamp_reputation(score: float) -> int:
+    return max(0, min(MAX_REPUTATION, round(score)))
+
+
+def _coerce_datetime(value) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    return _utcnow()
+
+
+def _metrics_for(agent: dict) -> dict:
+    metrics = agent.setdefault("reputation_metrics", {})
+    metrics.setdefault("successful_tasks", int(agent.get("tasks_completed", 0)))
+    metrics.setdefault("disputed_tasks", int(agent.get("disputed_tasks", 0)))
+    metrics.setdefault("average_completion_seconds", agent.get("average_completion_seconds"))
+    metrics.setdefault("last_activity_at", agent.get("registered_at", _utcnow()))
+    return metrics
+
+
+def _score_agent(agent: dict, now: Optional[datetime] = None) -> int:
+    now = now or _utcnow()
+    metrics = _metrics_for(agent)
+    successful = int(metrics.get("successful_tasks", 0))
+    disputed = int(metrics.get("disputed_tasks", 0))
+    total = successful + disputed
+
+    completion_rate = successful / total if total else 0.0
+    dispute_rate = disputed / total if total else 0.0
+    avg_seconds = metrics.get("average_completion_seconds")
+    speed_score = 0.0
+    if avg_seconds:
+        speed_score = min(1.0, TARGET_COMPLETION_SECONDS / max(float(avg_seconds), 1.0))
+
+    raw_score = (
+        BASE_REPUTATION
+        + completion_rate * 350
+        + speed_score * 150
+        - dispute_rate * 400
+    )
+
+    last_activity = _coerce_datetime(metrics.get("last_activity_at"))
+    inactive_weeks = max(0, (now - last_activity).days // 7)
+    decayed_score = raw_score * ((1 - WEEKLY_DECAY) ** inactive_weeks)
+    return _clamp_reputation(decayed_score)
+
+
+def _refresh_reputation(agent: dict, now: Optional[datetime] = None) -> dict:
+    metrics = _metrics_for(agent)
+    agent["tasks_completed"] = int(metrics.get("successful_tasks", 0))
+    agent["reputation"] = _score_agent(agent, now=now)
+    return agent
+
+
+def _success_rate(agent: dict) -> float:
+    metrics = _metrics_for(agent)
+    successful = int(metrics.get("successful_tasks", 0))
+    disputed = int(metrics.get("disputed_tasks", 0))
+    total = successful + disputed
+    return successful / total if total else 0.0
 
 
 @app.get("/agents", response_model=list[AgentResponse])
@@ -51,6 +128,8 @@ async def list_agents(
     limit: int = Query(50, le=100),
     offset: int = Query(0),
 ):
+    for agent in agents_cache.values():
+        _refresh_reputation(agent)
     results = list(agents_cache.values())
     if active_only:
         results = [a for a in results if a.get("active")]
@@ -62,7 +141,34 @@ async def list_agents(
 async def get_agent(agent_id: str):
     if agent_id not in agents_cache:
         raise HTTPException(status_code=404, detail="Agent not found")
-    return agents_cache[agent_id]
+    return _refresh_reputation(agents_cache[agent_id])
+
+
+@app.post("/agents/{agent_id}/reputation", response_model=AgentResponse)
+async def record_reputation_event(agent_id: str, event: ReputationEvent):
+    if agent_id not in agents_cache:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    agent = agents_cache[agent_id]
+    metrics = _metrics_for(agent)
+    now = _utcnow()
+
+    if event.outcome == "completion":
+        successful = int(metrics.get("successful_tasks", 0)) + 1
+        previous_avg = metrics.get("average_completion_seconds")
+        if event.completion_seconds is not None:
+            if previous_avg is None:
+                metrics["average_completion_seconds"] = event.completion_seconds
+            else:
+                metrics["average_completion_seconds"] = (
+                    float(previous_avg) * (successful - 1) + event.completion_seconds
+                ) / successful
+        metrics["successful_tasks"] = successful
+    else:
+        metrics["disputed_tasks"] = int(metrics.get("disputed_tasks", 0)) + 1
+
+    metrics["last_activity_at"] = now
+    return _refresh_reputation(agent, now=now)
 
 
 @app.get("/tasks", response_model=list[TaskResponse])
@@ -88,6 +194,7 @@ async def get_task(task_id: int):
 async def leaderboard(limit: int = Query(20, le=50)):
     entries = []
     for agent in agents_cache.values():
+        _refresh_reputation(agent)
         completed = agent.get("tasks_completed", 0)
         entries.append(
             {
@@ -95,10 +202,10 @@ async def leaderboard(limit: int = Query(20, le=50)):
                 "name": agent["name"],
                 "reputation": agent.get("reputation", 0),
                 "tasks_completed": completed,
-                "success_rate": completed / max(completed + 1, 1),
+                "success_rate": _success_rate(agent),
             }
         )
-    entries.sort(key=lambda x: x["reputation"], reverse=True)
+    entries.sort(key=lambda x: (x["reputation"], x["tasks_completed"], x["name"]), reverse=True)
     return entries[:limit]
 
 
@@ -108,5 +215,5 @@ async def health():
         "status": "ok",
         "agents_indexed": len(agents_cache),
         "tasks_indexed": len(tasks_cache),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": _utcnow().isoformat(),
     }

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+pytest>=8.0.0

--- a/api/tests/test_reputation.py
+++ b/api/tests/test_reputation.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from api.main import agents_cache, app
+
+
+client = TestClient(app)
+
+
+def utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def setup_function():
+    agents_cache.clear()
+
+
+def seed_agent(agent_id: str, name: str = "Agent", reputation: int = 500):
+    agents_cache[agent_id] = {
+        "agent_id": agent_id,
+        "name": name,
+        "owner": "0xowner",
+        "endpoint": "https://example.com/agent",
+        "reputation": reputation,
+        "tasks_completed": 0,
+        "registered_at": utcnow(),
+        "active": True,
+    }
+    return agents_cache[agent_id]
+
+
+def test_completion_increases_reputation():
+    seed_agent("agent-1")
+
+    response = client.post(
+        "/agents/agent-1/reputation",
+        json={"outcome": "completion", "completion_seconds": 1800},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reputation"] > 500
+    assert body["tasks_completed"] == 1
+
+
+def test_dispute_decreases_reputation_after_success():
+    seed_agent("agent-1")
+
+    first = client.post(
+        "/agents/agent-1/reputation",
+        json={"outcome": "completion", "completion_seconds": 1800},
+    )
+    second = client.post("/agents/agent-1/reputation", json={"outcome": "dispute"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["reputation"] < first.json()["reputation"]
+
+
+def test_weekly_decay_applies_to_inactive_agents():
+    agent = seed_agent("agent-1")
+    agent["reputation_metrics"] = {
+        "successful_tasks": 10,
+        "disputed_tasks": 0,
+        "average_completion_seconds": 1800,
+        "last_activity_at": utcnow() - timedelta(days=14),
+    }
+
+    response = client.get("/leaderboard")
+
+    assert response.status_code == 200
+    assert response.json()[0]["reputation"] == 980
+
+
+def test_leaderboard_sorts_by_reputation_and_success_rate():
+    slower = seed_agent("agent-low", name="Slow")
+    slower["reputation_metrics"] = {
+        "successful_tasks": 2,
+        "disputed_tasks": 2,
+        "average_completion_seconds": 7200,
+        "last_activity_at": utcnow(),
+    }
+    faster = seed_agent("agent-high", name="Fast")
+    faster["reputation_metrics"] = {
+        "successful_tasks": 3,
+        "disputed_tasks": 0,
+        "average_completion_seconds": 1800,
+        "last_activity_at": utcnow(),
+    }
+
+    response = client.get("/leaderboard")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["agent_id"] == "agent-high"
+    assert body[0]["success_rate"] == 1.0
+    assert 0 <= body[0]["reputation"] <= 1000
+
+
+def test_unknown_agent_reputation_event_returns_404():
+    response = client.post("/agents/missing/reputation", json={"outcome": "completion"})
+
+    assert response.status_code == 404


### PR DESCRIPTION
Fixes #43
/claim #43

## Summary
- adds an agent reputation scoring model based on successful completions, dispute rate, and completion speed
- adds a `POST /agents/{agent_id}/reputation` endpoint to update reputation after completions or disputes
- applies 1% weekly inactivity decay when agents are fetched or rendered in the leaderboard
- keeps scores clamped to the 0-1000 range and updates `tasks_completed` from successful completions
- updates the leaderboard to sort by live reputation and report real success rate
- adds focused API tests for success increases, dispute decreases, weekly decay, leaderboard ordering, and missing-agent errors

## Verification
- `python -m pytest api\tests\test_reputation.py -q` (5 passed)
- `python -m py_compile api\main.py api\tests\test_reputation.py`
- `git diff --check` (passes; repository reports only CRLF normalization warnings)

Payment: USDC | `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92` | Base
Alternative payment: USDT | `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi` | TRC20

No private prompt/session initialization text is included in source, comments, or metadata.