### PR TITLE
fix: add configurable CORS

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,52 @@
+import os
+
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+
+def _csv_env(name: str) -> list[str]:
+    return [
+        item.strip()
+        for item in os.getenv(name, "").split(",")
+        if item.strip()
+    ]
+
+
+def _is_development() -> bool:
+    env = os.getenv("APP_ENV") or os.getenv("ENVIRONMENT") or "production"
+    return env.lower() in {"dev", "development", "local", "test"}
+
+
+def _cors_config() -> dict:
+    origins = _csv_env("ALLOWED_ORIGINS")
+    allow_any_origin = "*" in origins and _is_development()
+    if "*" in origins and not allow_any_origin:
+        origins = [origin for origin in origins if origin != "*"]
+
+    return {
+        "allow_origins": [] if allow_any_origin else origins,
+        "allow_origin_regex": ".*" if allow_any_origin else None,
+        "allow_credentials": True,
+        "allow_methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        "allow_headers": ["Authorization", "Content-Type", "X-API-Key"],
+        "max_age": 600,
+    }
+
+
+app.add_middleware(CORSMiddleware, **_cors_config())
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class AgentResponse(BaseModel):
@@ -108,5 +147,5 @@ async def health():
         "status": "ok",
         "agents_indexed": len(agents_cache),
         "tasks_indexed": len(tasks_cache),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": _utcnow().isoformat(),
     }

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+pytest>=8.0.0

--- a/api/tests/test_cors.py
+++ b/api/tests/test_cors.py
@@ -1,0 +1,66 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def load_app(monkeypatch, origins: str, app_env: str = "production"):
+    monkeypatch.setenv("ALLOWED_ORIGINS", origins)
+    monkeypatch.setenv("APP_ENV", app_env)
+    import api.main as main
+
+    return importlib.reload(main).app
+
+
+def test_preflight_allows_configured_origin(monkeypatch):
+    origin = "https://app.example.com"
+    client = TestClient(load_app(monkeypatch, origin))
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "GET" in response.headers["access-control-allow-methods"]
+
+
+def test_cross_origin_get_includes_cors_headers(monkeypatch):
+    origin = "https://dashboard.example.com"
+    client = TestClient(load_app(monkeypatch, origin))
+
+    response = client.get("/health", headers={"Origin": origin})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_wildcard_origin_is_rejected_in_production(monkeypatch):
+    client = TestClient(load_app(monkeypatch, "*", "production"))
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://untrusted.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_wildcard_origin_is_allowed_in_development(monkeypatch):
+    origin = "https://local-dev.example.com"
+    client = TestClient(load_app(monkeypatch, "*", "development"))
+
+    response = client.get("/health", headers={"Origin": origin})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin
+    assert response.headers["access-control-allow-credentials"] == "true"


### PR DESCRIPTION
Fixes #166
/claim #166

## Summary
- adds FastAPI CORSMiddleware configured from `ALLOWED_ORIGINS`
- allows `GET`, `POST`, `PUT`, `DELETE`, and `OPTIONS`
- enables credentials for authenticated cross-origin requests
- keeps production restrictive by ignoring wildcard `*` unless `APP_ENV`/`ENVIRONMENT` is development-like
- supports development wildcard behavior by reflecting the request origin
- adds CORS tests for preflight, cross-origin GET, production wildcard rejection, and development wildcard allowance

## Verification
- `python -m pytest api\tests\test_cors.py -q` (4 passed)
- `python -m py_compile api\main.py api\tests\test_cors.py`
- `git diff --check` (passes; repository reports only CRLF normalization warnings)

Payment: USDC | `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92` | Base
Alternative payment: USDT | `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi` | TRC20

No private prompt/session initialization text is included in source, comments, or metadata.