### PR TITLE
feat: add component health checks

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,16 @@
+import json
+import os
+import shutil
+import time
+import tracemalloc
+import urllib.error
+import urllib.request
+
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 app = FastAPI(
     title="OpenAgents API",
@@ -42,6 +51,129 @@ class LeaderboardEntry(BaseModel):
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+_health_cache: dict = {"expires_at": 0.0, "payload": None, "status_code": 200}
+HEALTH_CACHE_SECONDS = 10
+MIN_FREE_DISK_BYTES = 100 * 1024 * 1024
+MAX_MEMORY_BYTES = int(os.getenv("HEALTH_MAX_MEMORY_BYTES", str(1024 * 1024 * 1024)))
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _component(name: str, check):
+    started = time.perf_counter()
+    try:
+        result = check()
+    except Exception as exc:
+        result = {"status": "unhealthy", "details": {"error": str(exc)}}
+    latency_ms = round((time.perf_counter() - started) * 1000, 3)
+    result.setdefault("details", {})
+    result["latency_ms"] = latency_ms
+    return name, result
+
+
+def _check_db() -> dict:
+    return {
+        "status": "healthy",
+        "details": {
+            "backend": "in-memory",
+            "agents_indexed": len(agents_cache),
+            "tasks_indexed": len(tasks_cache),
+        },
+    }
+
+
+def _check_rpc() -> dict:
+    rpc_url = os.getenv("RPC_URL") or os.getenv("WEB3_PROVIDER_URI")
+    if not rpc_url:
+        return {"status": "healthy", "details": {"configured": False}}
+
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "eth_blockNumber", "params": []}).encode()
+    request = urllib.request.Request(
+        rpc_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:
+            body = json.loads(response.read().decode())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        return {"status": "unhealthy", "details": {"configured": True, "error": str(exc)}}
+
+    if "result" not in body:
+        return {"status": "unhealthy", "details": {"configured": True, "response": body}}
+    return {"status": "healthy", "details": {"configured": True, "block_number": body["result"]}}
+
+
+def _check_disk() -> dict:
+    usage = shutil.disk_usage(os.getcwd())
+    status = "healthy" if usage.free >= MIN_FREE_DISK_BYTES else "unhealthy"
+    return {
+        "status": status,
+        "details": {
+            "path": os.getcwd(),
+            "free_bytes": usage.free,
+            "total_bytes": usage.total,
+            "min_free_bytes": MIN_FREE_DISK_BYTES,
+        },
+    }
+
+
+def _check_memory() -> dict:
+    if not tracemalloc.is_tracing():
+        tracemalloc.start()
+    current, peak = tracemalloc.get_traced_memory()
+    status = "healthy" if current <= MAX_MEMORY_BYTES else "unhealthy"
+    return {
+        "status": status,
+        "details": {
+            "current_bytes": current,
+            "peak_bytes": peak,
+            "max_bytes": MAX_MEMORY_BYTES,
+        },
+    }
+
+
+def _build_health_payload(cached: bool = False) -> tuple[dict, int]:
+    components = dict(
+        _component(name, check)
+        for name, check in (
+            ("db", _check_db),
+            ("rpc", _check_rpc),
+            ("disk", _check_disk),
+            ("memory", _check_memory),
+        )
+    )
+    unhealthy = [name for name, result in components.items() if result["status"] == "unhealthy"]
+    overall = "unhealthy" if unhealthy else "healthy"
+    payload = {
+        "status": overall,
+        "cached": cached,
+        "components": components,
+        "timestamp": _utcnow().isoformat(),
+    }
+    return payload, 503 if unhealthy else 200
+
+
+def _health_response() -> JSONResponse:
+    now = time.monotonic()
+    headers = {"Cache-Control": f"public, max-age={HEALTH_CACHE_SECONDS}"}
+    cached_payload = _health_cache.get("payload")
+    if cached_payload is not None and now < _health_cache["expires_at"]:
+        payload = {**cached_payload, "cached": True}
+        return JSONResponse(payload, status_code=_health_cache["status_code"], headers=headers)
+
+    payload, status_code = _build_health_payload()
+    _health_cache.update(
+        {
+            "expires_at": now + HEALTH_CACHE_SECONDS,
+            "payload": payload,
+            "status_code": status_code,
+        }
+    )
+    return JSONResponse(payload, status_code=status_code, headers=headers)
 
 
 @app.get("/agents", response_model=list[AgentResponse])
@@ -104,9 +236,4 @@ async def leaderboard(limit: int = Query(20, le=50)):
 
 @app.get("/health")
 async def health():
-    return {
-        "status": "ok",
-        "agents_indexed": len(agents_cache),
-        "tasks_indexed": len(tasks_cache),
-        "timestamp": datetime.utcnow().isoformat(),
-    }
+    return _health_response()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+pytest>=8.0.0

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,0 +1,77 @@
+import importlib
+import time
+
+from fastapi.testclient import TestClient
+
+
+def load_main(monkeypatch):
+    monkeypatch.delenv("RPC_URL", raising=False)
+    monkeypatch.delenv("WEB3_PROVIDER_URI", raising=False)
+    import api.main as main
+
+    module = importlib.reload(main)
+    module._health_cache.update({"expires_at": 0.0, "payload": None, "status_code": 200})
+    return module
+
+
+def test_health_reports_component_status_and_latency(monkeypatch):
+    main = load_main(monkeypatch)
+    client = TestClient(main.app)
+
+    started = time.perf_counter()
+    response = client.get("/health")
+    elapsed = time.perf_counter() - started
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=10"
+    assert elapsed < 5
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["cached"] is False
+    assert set(body["components"]) == {"db", "rpc", "disk", "memory"}
+    for component in body["components"].values():
+        assert component["status"] == "healthy"
+        assert isinstance(component["latency_ms"], (int, float))
+        assert component["latency_ms"] >= 0
+
+
+def test_health_response_is_cached_for_ten_seconds(monkeypatch):
+    main = load_main(monkeypatch)
+    client = TestClient(main.app)
+
+    first = client.get("/health")
+    second = client.get("/health")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["cached"] is False
+    assert second.json()["cached"] is True
+    assert first.json()["timestamp"] == second.json()["timestamp"]
+
+
+def test_unhealthy_component_returns_503(monkeypatch):
+    main = load_main(monkeypatch)
+
+    def unhealthy_disk():
+        return {"status": "unhealthy", "details": {"free_bytes": 0}}
+
+    monkeypatch.setattr(main, "_check_disk", unhealthy_disk)
+    main._health_cache.update({"expires_at": 0.0, "payload": None, "status_code": 200})
+    client = TestClient(main.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "unhealthy"
+    assert body["components"]["disk"]["status"] == "unhealthy"
+
+
+def test_rpc_is_healthy_when_not_configured(monkeypatch):
+    main = load_main(monkeypatch)
+    client = TestClient(main.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["components"]["rpc"]["details"]["configured"] is False


### PR DESCRIPTION
Fixes #41
/claim #41

## Summary
- replaces the basic `/health` payload with per-component DB, RPC, disk, and memory status
- measures latency for each component with `time.perf_counter()`
- returns overall `healthy`/`unhealthy` from component status and uses HTTP 503 when any component is unhealthy
- adds a 10-second in-process health cache and `Cache-Control: public, max-age=10`
- keeps RPC health fast with a 2-second JSON-RPC timeout and treats missing RPC configuration as healthy/configured=false
- adds focused health endpoint tests for component status, latency, caching, 503 behavior, and unconfigured RPC state

## Verification
- `python -m pytest api\tests\test_health.py -q` (4 passed)
- `python -m py_compile api\main.py api\tests\test_health.py`
- `git diff --check` (passes; repository reports only CRLF normalization warnings)

Payment: USDC | `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92` | Base
Alternative payment: USDT | `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi` | TRC20

No private prompt/session initialization text is included in source, comments, or metadata.