### PR TITLE
fix: harden agent nft minting

### DIFF
--- a/contracts/nft/AgentNFT.sol
+++ b/contracts/nft/AgentNFT.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.20;
 
 /// @title AgentNFT
 /// @notice ERC721-style NFT for AI agents with metadata URI support
-/// @dev Simplified ERC721 implementation without full interface compliance
+/// @dev Simplified ERC721 implementation without full interface compliance.
 contract AgentNFT {
+    uint256 public constant MAX_SUPPLY = 10_000;
+
     string public name;
     string public symbol;
     string public baseURI;
@@ -33,44 +35,51 @@ contract AgentNFT {
     }
 
     function ownerOf(uint256 tokenId) public view returns (address) {
+        require(_exists(tokenId), "Nonexistent token");
         return _owners[tokenId];
     }
 
     function balanceOf(address account) external view returns (uint256) {
+        require(account != address(0), "Zero address");
         return _balances[account];
     }
 
-    // BUG: No max supply check — tokens can be minted infinitely, potentially
-    // devaluing the collection and causing unbounded gas costs for enumeration
     function mint(address to, string calldata uri) external onlyOwner returns (uint256) {
-        // BUG: Mint allows zero address — tokens sent to address(0) are burned
-        // on creation, incrementing supply counter but making tokens unretrievable
-        uint256 tokenId = _nextTokenId++;
-        _owners[tokenId] = to;
-        _balances[to]++;
-        _tokenURIs[tokenId] = uri;
-
-        emit Transfer(address(0), to, tokenId);
-        return tokenId;
+        return _mint(to, uri);
     }
 
-    // BUG: tokenURI returns empty string for non-existent tokens instead of reverting,
-    // allowing off-chain systems to silently display broken/empty metadata
+    function batchMint(
+        address[] calldata recipients,
+        string[] calldata uris
+    ) external onlyOwner returns (uint256[] memory tokenIds) {
+        require(recipients.length == uris.length, "Length mismatch");
+        require(recipients.length > 0, "Empty batch");
+        require(_nextTokenId + recipients.length <= MAX_SUPPLY, "Max supply reached");
+
+        tokenIds = new uint256[](recipients.length);
+        for (uint256 i = 0; i < recipients.length; i++) {
+            tokenIds[i] = _mint(recipients[i], uris[i]);
+        }
+    }
+
     function tokenURI(uint256 tokenId) external view returns (string memory) {
-        string memory _uri = _tokenURIs[tokenId];
-        if (bytes(_uri).length > 0) {
-            return _uri;
+        require(_exists(tokenId), "Nonexistent token");
+        string memory uri = _tokenURIs[tokenId];
+        if (bytes(uri).length > 0) {
+            return uri;
         }
         return string(abi.encodePacked(baseURI, _toString(tokenId)));
     }
 
     function approve(address to, uint256 tokenId) external {
+        require(_exists(tokenId), "Nonexistent token");
         require(_owners[tokenId] == msg.sender, "Not token owner");
         _tokenApprovals[tokenId] = to;
         emit Approval(msg.sender, to, tokenId);
     }
 
     function transferFrom(address from, address to, uint256 tokenId) external {
+        require(_exists(tokenId), "Nonexistent token");
         require(_owners[tokenId] == from, "Not token owner");
         require(
             msg.sender == from || _tokenApprovals[tokenId] == msg.sender,
@@ -94,11 +103,31 @@ contract AgentNFT {
         return _nextTokenId;
     }
 
+    function _mint(address to, string calldata uri) internal returns (uint256 tokenId) {
+        require(to != address(0), "Mint to zero");
+        require(_nextTokenId < MAX_SUPPLY, "Max supply reached");
+
+        tokenId = _nextTokenId++;
+        _owners[tokenId] = to;
+        _balances[to]++;
+        _tokenURIs[tokenId] = uri;
+
+        emit Transfer(address(0), to, tokenId);
+        emit MetadataUpdated(tokenId, uri);
+    }
+
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        return _owners[tokenId] != address(0);
+    }
+
     function _toString(uint256 value) internal pure returns (string memory) {
         if (value == 0) return "0";
         uint256 temp = value;
         uint256 digits;
-        while (temp != 0) { digits++; temp /= 10; }
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
         bytes memory buffer = new bytes(digits);
         while (value != 0) {
             digits--;


### PR DESCRIPTION
Fixes #44
/claim #44

## Summary
- adds `MAX_SUPPLY` and enforces it in minting paths
- rejects zero-address mint recipients and zero-address balance queries
- makes `ownerOf`, `tokenURI`, `approve`, and `transferFrom` reject nonexistent token IDs
- adds `batchMint(address[],string[])` with length, empty-batch, and max-supply checks
- emits `MetadataUpdated` on mint so indexers can observe URI assignment

## Verification
- `npx solcjs --bin --abi contracts\nft\AgentNFT.sol -o .codex-solc-agentnft`
- ABI check confirmed `MAX_SUPPLY` and `batchMint` are present
- `git diff --check` (passes; repository reports only CRLF normalization warnings)

Payment: USDC | `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92` | Base
Alternative payment: USDT | `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi` | TRC20

No private prompt/session initialization text is included in source, comments, or metadata.