### PR TITLE
fix: record received escrow amount

### DIFF
--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PaymentEscrow is Ownable {
+    using SafeERC20 for IERC20;
+
     struct Escrow {
         address payer;
         address payee;
@@ -31,22 +34,27 @@ contract PaymentEscrow is Ownable {
         uint256 lockDuration
     ) external returns (uint256) {
         require(payee != address(0), "Invalid payee");
+        require(token != address(0), "Invalid token");
         require(amount > 0, "Amount must be > 0");
 
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20 escrowToken = IERC20(token);
+        uint256 balanceBefore = escrowToken.balanceOf(address(this));
+        escrowToken.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = escrowToken.balanceOf(address(this)) - balanceBefore;
+        require(received > 0, "No tokens received");
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
             payer: msg.sender,
             payee: payee,
             token: token,
-            amount: amount,
+            amount: received,
             releaseTime: block.timestamp + lockDuration,
             released: false,
             refunded: false
         });
 
-        emit EscrowCreated(escrowId, msg.sender, amount);
+        emit EscrowCreated(escrowId, msg.sender, received);
         return escrowId;
     }
 
@@ -56,7 +64,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer || msg.sender == owner(), "Not authorized");
 
         escrow.released = true;
-        IERC20(escrow.token).transfer(escrow.payee, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payee, escrow.amount);
 
         emit EscrowReleased(escrowId, escrow.payee, escrow.amount);
     }
@@ -68,7 +76,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer, "Not payer");
 
         escrow.refunded = true;
-        IERC20(escrow.token).transfer(escrow.payer, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payer, escrow.amount);
 
         emit EscrowRefunded(escrowId, escrow.payer, escrow.amount);
     }


### PR DESCRIPTION
Fixes #104
/claim #104

## Summary
- keeps the existing zero-amount rejection and adds a zero-token-address guard
- measures escrow token balance before and after `safeTransferFrom`
- stores the actual received amount, so fee-on-transfer tokens cannot overstate escrow value
- rejects transfers that result in zero received tokens
- uses SafeERC20 for escrow creation, release, and refund transfers

## Verification
- `npx solcjs contracts\PaymentEscrow.sol --bin --abi --base-path . --include-path node_modules -o .codex-solc-escrow`
- `git diff --check` (passes; repository reports only CRLF normalization warnings)

Payment: USDC | `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92` | Base
Alternative payment: USDT | `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi` | TRC20

No private prompt/session initialization text is included in source, comments, or metadata.