### PR TITLE
fix: harden vesting wallet math

### DIFF
--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title VestingWallet
 /// @notice Linear vesting wallet with a cliff period for token distribution.
@@ -26,8 +27,6 @@ contract VestingWallet {
     event TokensReleased(address indexed beneficiary, uint256 amount);
     event VestingRevoked(address indexed token, uint256 refund);
 
-    // BUG: No zero-address validation on beneficiary — if beneficiary is set to
-    // address(0), all vested tokens are sent to the zero address (burned) on release.
     constructor(
         address _beneficiary,
         address _token,
@@ -37,6 +36,8 @@ contract VestingWallet {
         uint256 _totalAllocation,
         bool _revocable
     ) {
+        require(_beneficiary != address(0), "Vesting: zero beneficiary");
+        require(_token != address(0), "Vesting: zero token");
         require(_vestingDuration > _cliffDuration, "Vesting: cliff exceeds duration");
         require(_totalAllocation > 0, "Vesting: zero allocation");
 
@@ -65,17 +66,19 @@ contract VestingWallet {
     /// @notice Calculate the total vested amount at the current timestamp.
     /// @return The total amount of tokens that have vested.
     function vestedAmount() public view returns (uint256) {
-        if (block.timestamp < start + cliffDuration) {
+        if (block.timestamp < start) {
             return 0;
         }
-        if (block.timestamp >= start + vestingDuration) {
+
+        uint256 elapsed = block.timestamp - start;
+        if (elapsed < cliffDuration) {
+            return 0;
+        }
+        if (elapsed >= vestingDuration) {
             return totalAllocation;
         }
-        // BUG: Overflow risk — (totalAllocation * elapsed) can overflow for large
-        // allocations. E.g., if totalAllocation is 1e30 and elapsed is 1e8, the
-        // product exceeds uint256 max. Should use mulDiv or restructure the math.
-        uint256 elapsed = block.timestamp - start;
-        return (totalAllocation * elapsed) / vestingDuration;
+
+        return Math.mulDiv(totalAllocation, elapsed, vestingDuration);
     }
 
     /// @notice Revoke unvested tokens and return them to the owner.
@@ -84,15 +87,13 @@ contract VestingWallet {
         require(revocable, "Vesting: not revocable");
         require(!revoked, "Vesting: already revoked");
 
-        revoked = true;
         uint256 vested = vestedAmount();
-        // BUG: During the cliff period, vestedAmount() returns 0, so refund is
-        // calculated as totalAllocation - 0 = totalAllocation. But tokens may have
-        // already been partially transferred to the contract. The refund should use
-        // the actual token balance, not totalAllocation - vested, as the contract
-        // might not hold the full allocation yet, causing a revert or incorrect refund.
-        uint256 refund = totalAllocation - vested;
+        uint256 unvested = totalAllocation - vested;
+        uint256 balance = token.balanceOf(address(this));
+        uint256 refund = unvested < balance ? unvested : balance;
 
+        revoked = true;
+        totalAllocation = vested;
         token.safeTransfer(owner, refund);
         emit VestingRevoked(address(token), refund);
     }
@@ -104,6 +105,6 @@ contract VestingWallet {
 
     /// @notice Check if the cliff period has passed.
     function cliffReached() external view returns (bool) {
-        return block.timestamp >= start + cliffDuration;
+        return block.timestamp >= start && block.timestamp - start >= cliffDuration;
     }
 }


### PR DESCRIPTION
Fixes #12
/claim #12

Summary:
- Replace overflow-prone `totalAllocation * elapsed / vestingDuration` with OpenZeppelin `Math.mulDiv` for full-precision vesting math.
- Make vesting/cliff timestamp checks avoid `start + duration` overflow cases.
- Add zero-address validation for beneficiary/token and cap revoke refunds to the contract's actual balance while preserving vested allocation.

Verification:
- `npx solcjs contracts\token\VestingWallet.sol --bin --abi --base-path . --include-path node_modules -o .codex-solc-vesting`
- `git diff --check` (only Git LF-to-CRLF warning for the edited Solidity file)
- `npx hardhat compile` was also attempted, but the repo-wide compile is currently blocked by unrelated contracts importing OpenZeppelin `^0.8.24` files while `hardhat.config.js` only configures Solidity `0.8.20`.

Payment:
- Preferred: USDC on Base to `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 to `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.