### PR TITLE
fix: harden jwt auth middleware

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+from api.middleware.auth import refresh_access_token, revoke_token
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
@@ -37,6 +39,19 @@ class LeaderboardEntry(BaseModel):
     reputation: int
     tasks_completed: int
     success_rate: float
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenResponse(BaseModel):
+    token: str
+    expires_in: int
+
+
+class RevokeTokenRequest(BaseModel):
+    token: str
 
 
 # In-memory store (placeholder for DB)
@@ -100,6 +115,17 @@ async def leaderboard(limit: int = Query(20, le=50)):
         )
     entries.sort(key=lambda x: x["reputation"], reverse=True)
     return entries[:limit]
+
+
+@app.post("/auth/refresh", response_model=TokenResponse)
+async def refresh_token(request: RefreshTokenRequest):
+    return refresh_access_token(request.refresh_token)
+
+
+@app.post("/auth/revoke")
+async def revoke_auth_token(request: RevokeTokenRequest):
+    revoke_token(request.token)
+    return {"revoked": True}
 
 
 @app.get("/health")

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,46 +1,56 @@
 """JWT authentication middleware for the OpenAgents API."""
 
-import jwt
 import os
-from fastapi import Request, HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
+from uuid import uuid4
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+import jwt
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+JWT_SECRET = os.environ.get("JWT_SECRET", "openagents-development-secret-please-change")
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
+REVOKED_JTIS: set[str] = set()
+REVOKED_TOKENS: set[str] = set()
 
 security = HTTPBearer()
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
+    now = datetime.now(timezone.utc)
+    expire = now + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire, "iat": now, "type": "access", "jti": str(uuid4())})
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def create_refresh_token(data: dict) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
+    now = datetime.now(timezone.utc)
+    expire = now + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "iat": now, "type": "refresh", "jti": str(uuid4())})
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def is_token_revoked(token: str, payload: dict) -> bool:
+    jti = payload.get("jti")
+    return token in REVOKED_TOKENS or (jti is not None and jti in REVOKED_JTIS)
 
 
 def decode_token(token: str) -> dict:
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
-        return payload
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Invalid token")
+
+    if is_token_revoked(token, payload):
+        raise HTTPException(status_code=401, detail="Token has been revoked")
+    return payload
 
 
 async def get_current_user(
@@ -52,8 +62,6 @@ async def get_current_user(
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
 
-    # BUG: No token revocation check — logged-out or compromised tokens
-    # remain valid until they naturally expire
     user_data = {
         "id": payload.get("sub"),
         "address": payload.get("address"),
@@ -71,7 +79,36 @@ def require_role(role: str):
         if role not in user.get("roles", []):
             raise HTTPException(status_code=403, detail=f"Role '{role}' required")
         return user
+
     return role_checker
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    payload = decode_token(refresh_token)
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+
+    data = {
+        "sub": payload.get("sub"),
+        "address": payload.get("address"),
+        "roles": payload.get("roles", []),
+    }
+    if not data["sub"]:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+
+    return {
+        "token": create_access_token(data),
+        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    }
+
+
+def revoke_token(token: str) -> None:
+    payload = decode_token(token)
+    jti = payload.get("jti")
+    if jti:
+        REVOKED_JTIS.add(jti)
+    else:
+        REVOKED_TOKENS.add(token)
 
 
 def generate_login_tokens(user_id: str, address: str, roles: list = None) -> dict:

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,5 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+PyJWT>=2.10.0
+pytest>=8.0.0

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware import auth
+
+
+def setup_function():
+    auth.REVOKED_JTIS.clear()
+    auth.REVOKED_TOKENS.clear()
+
+
+def test_missing_secret_uses_fallback_without_import_crash():
+    assert auth.JWT_SECRET
+
+
+def test_decode_rejects_none_algorithm_token():
+    token = jwt.encode(
+        {
+            "sub": "user-1",
+            "address": "0xabc",
+            "roles": [],
+            "type": "access",
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        },
+        key="",
+        algorithm="none",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.decode_token(token)
+
+    assert exc_info.value.status_code == 401
+
+
+def test_revoked_access_token_is_rejected():
+    tokens = auth.generate_login_tokens("user-1", "0xabc", ["agent"])
+
+    auth.revoke_token(tokens["token"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.decode_token(tokens["token"])
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Token has been revoked"
+
+
+def test_refresh_endpoint_issues_new_access_token():
+    tokens = auth.generate_login_tokens("user-1", "0xabc", ["agent"])
+    client = TestClient(app)
+
+    response = client.post("/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+
+    assert response.status_code == 200
+    payload = auth.decode_token(response.json()["token"])
+    assert payload["type"] == "access"
+    assert payload["sub"] == "user-1"
+    assert response.json()["expires_in"] == auth.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+
+def test_refresh_endpoint_rejects_access_token():
+    tokens = auth.generate_login_tokens("user-1", "0xabc", ["agent"])
+    client = TestClient(app)
+
+    response = client.post("/auth/refresh", json={"refresh_token": tokens["token"]})
+
+    assert response.status_code == 401


### PR DESCRIPTION
Fixes #100
/claim #100

Summary:
- Pin JWT decoding to HS256 and reject unsigned `alg=none` tokens.
- Avoid startup crashes when `JWT_SECRET` is not set by providing a development fallback.
- Add JWT IDs plus in-memory revocation checks for revoked access/refresh tokens.
- Add `/auth/refresh` and `/auth/revoke` endpoints with focused coverage.

Verification:
- `python -m pytest api\tests\test_auth.py -q` (5 passed)
- `python -m py_compile api\middleware\auth.py api\main.py api\tests\test_auth.py`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base to `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 to `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.