### PR TITLE
feat: add sdk gas estimation

### DIFF
--- a/sdk/src/auth/session.ts
+++ b/sdk/src/auth/session.ts
@@ -53,7 +53,6 @@ export class SessionManager {
       to: "0x0000000000000000000000000000000000000000",
       value: 0n,
       data: "0x",
-      gasLimit: 0n,
     });
 
     const res = await fetch(`${this.apiBaseUrl}/auth/login`, {

--- a/sdk/src/auth/wallet.ts
+++ b/sdk/src/auth/wallet.ts
@@ -11,8 +11,11 @@ export interface Transaction {
   to: string;
   value: bigint;
   data: string;
-  gasLimit: bigint;
+  gasLimit?: bigint;
   gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  gasMarginBps?: number;
   nonce?: number;
   chainId?: number;
 }
@@ -21,6 +24,15 @@ export interface SignedTransaction {
   raw: string;
   hash: string;
 }
+
+interface ResolvedFeeData {
+  gasPrice: bigint;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+}
+
+const DEFAULT_GAS_MARGIN_BPS = 2_000;
+const BPS_DENOMINATOR = 10_000n;
 
 export class Wallet {
   // BUG: Private key stored as plaintext string in memory — should use
@@ -42,7 +54,7 @@ export class Wallet {
   }
 
   private deriveAddress(privateKey: string): string {
-    const { ec as EC } = require("elliptic");
+    const { ec: EC } = require("elliptic");
     const curve = new EC("secp256k1");
     const key = curve.keyFromPrivate(privateKey, "hex");
     const pubKey = key.getPublic(false, "hex").slice(2); // remove 04 prefix
@@ -54,12 +66,15 @@ export class Wallet {
     // BUG: No chain ID validation — transaction could be replayed on a different
     // chain if chainId is missing or mismatched with the provider
     const nonce = tx.nonce ?? await this.getNonce();
-    const gasPrice = tx.gasPrice ?? BigInt(await this.provider.call("eth_gasPrice") as string);
+    const gasLimit = tx.gasLimit ?? await this.estimateGasLimit(tx);
+    const feeData = await this.resolveFeeData(tx);
 
     const txData = encodeParams([
       { type: "uint256", value: nonce } as AbiParam,
-      { type: "uint256", value: gasPrice } as AbiParam,
-      { type: "uint256", value: tx.gasLimit } as AbiParam,
+      { type: "uint256", value: feeData.gasPrice } as AbiParam,
+      { type: "uint256", value: feeData.maxFeePerGas } as AbiParam,
+      { type: "uint256", value: feeData.maxPriorityFeePerGas } as AbiParam,
+      { type: "uint256", value: gasLimit } as AbiParam,
       { type: "address", value: tx.to } as AbiParam,
       { type: "uint256", value: tx.value } as AbiParam,
     ]);
@@ -70,6 +85,66 @@ export class Wallet {
     return {
       raw: "0x" + txData.slice(2) + signature,
       hash: "0x" + txHash,
+    };
+  }
+
+  async estimateGasLimit(tx: Transaction): Promise<bigint> {
+    const estimate = BigInt(await this.provider.call("eth_estimateGas", [
+      this.toRpcTransaction(tx),
+    ]) as string);
+    const marginBps = BigInt(Math.max(0, tx.gasMarginBps ?? DEFAULT_GAS_MARGIN_BPS));
+    const withMargin = (estimate * (BPS_DENOMINATOR + marginBps)) / BPS_DENOMINATOR;
+    const blockGasLimit = await this.getLatestBlockGasLimit();
+    return withMargin > blockGasLimit ? blockGasLimit : withMargin;
+  }
+
+  private async resolveFeeData(tx: Transaction): Promise<ResolvedFeeData> {
+    if (tx.gasPrice !== undefined) {
+      return {
+        gasPrice: tx.gasPrice,
+        maxFeePerGas: 0n,
+        maxPriorityFeePerGas: 0n,
+      };
+    }
+
+    const latestBlock = await this.getLatestBlock();
+    const baseFee = latestBlock?.baseFeePerGas ? BigInt(latestBlock.baseFeePerGas) : null;
+    if (baseFee !== null) {
+      const priorityFee = tx.maxPriorityFeePerGas ?? BigInt(
+        await this.provider.call("eth_maxPriorityFeePerGas") as string
+      );
+      return {
+        gasPrice: 0n,
+        maxFeePerGas: tx.maxFeePerGas ?? baseFee * 2n + priorityFee,
+        maxPriorityFeePerGas: priorityFee,
+      };
+    }
+
+    return {
+      gasPrice: BigInt(await this.provider.call("eth_gasPrice") as string),
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+    };
+  }
+
+  private async getLatestBlockGasLimit(): Promise<bigint> {
+    const latestBlock = await this.getLatestBlock();
+    return latestBlock?.gasLimit ? BigInt(latestBlock.gasLimit) : 30_000_000n;
+  }
+
+  private async getLatestBlock(): Promise<{ gasLimit?: string; baseFeePerGas?: string } | null> {
+    const block = await this.provider.call("eth_getBlockByNumber", ["latest", false]);
+    return typeof block === "object" && block !== null
+      ? block as { gasLimit?: string; baseFeePerGas?: string }
+      : null;
+  }
+
+  private toRpcTransaction(tx: Transaction): Record<string, string> {
+    return {
+      from: this.address,
+      to: tx.to,
+      value: "0x" + tx.value.toString(16),
+      data: tx.data || "0x",
     };
   }
 


### PR DESCRIPTION
Fixes #81
/claim #81

Summary:
- Make transaction `gasLimit` optional and estimate it with `eth_estimateGas` when not manually provided.
- Apply a default 20% gas margin and cap estimated gas at the latest block gas limit.
- Add EIP-1559 fee resolution from latest block `baseFeePerGas` plus `eth_maxPriorityFeePerGas`, with legacy `eth_gasPrice` fallback.
- Preserve manual overrides for `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, and `gasMarginBps`.
- Remove the session auth path's hardcoded `gasLimit: 0n`; also fix the existing invalid `elliptic` destructuring so the wallet bundles.

Verification:
- `npx esbuild sdk\src\auth\wallet.ts --bundle --platform=node --format=cjs --outfile=.codex-gas-wallet-bundle.js`
- Temporary runtime check confirmed `eth_estimateGas` is used by default, EIP-1559 priority fee is requested when base fee exists, legacy gas price is skipped for EIP-1559, and manual gas/price overrides bypass estimation.
- `git diff --check` (only Git LF-to-CRLF warnings for edited TypeScript files)

Payment:
- Preferred: USDC on Base to `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 to `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.