### PR TITLE
feat: add api key authentication

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,18 @@
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+from sqlalchemy.orm import Session
+
+from api.middleware.auth import create_api_key, get_current_user, revoke_api_key
+from api.models.database import get_db, init_db
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+init_db()
 
 
 class AgentResponse(BaseModel):
@@ -37,6 +42,17 @@ class LeaderboardEntry(BaseModel):
     reputation: int
     tasks_completed: int
     success_rate: float
+
+
+class APIKeyCreateRequest(BaseModel):
+    name: Optional[str] = None
+
+
+class APIKeyCreateResponse(BaseModel):
+    id: str
+    key: str
+    name: Optional[str] = None
+    created_at: datetime
 
 
 # In-memory store (placeholder for DB)
@@ -100,6 +116,30 @@ async def leaderboard(limit: int = Query(20, le=50)):
         )
     entries.sort(key=lambda x: x["reputation"], reverse=True)
     return entries[:limit]
+
+
+@app.get("/auth/me")
+async def auth_me(user: dict = Depends(get_current_user)):
+    return user
+
+
+@app.post("/auth/api-keys", response_model=APIKeyCreateResponse)
+async def create_auth_api_key(
+    request: APIKeyCreateRequest,
+    user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return create_api_key(db, user, request.name)
+
+
+@app.delete("/auth/api-keys/{key_id}")
+async def revoke_auth_api_key(
+    key_id: str,
+    user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    revoke_api_key(db, key_id, user)
+    return {"revoked": True}
 
 
 @app.get("/health")

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,63 +1,131 @@
-"""JWT authentication middleware for the OpenAgents API."""
+"""JWT and API key authentication middleware for the OpenAgents API."""
+
+import hashlib
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import uuid4
 
 import jwt
-import os
-from fastapi import Request, HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from datetime import datetime, timedelta
-from typing import Optional
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+from api.models.database import APIKey, get_db
+
+JWT_SECRET = os.environ.get("JWT_SECRET", "openagents-development-secret-please-change")
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
+API_KEY_PREFIX = "oa_"
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
+    now = datetime.now(timezone.utc)
+    expire = now + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire, "iat": now, "type": "access"})
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def create_refresh_token(data: dict) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
+    now = datetime.now(timezone.utc)
+    expire = now + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "iat": now, "type": "refresh"})
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def decode_token(token: str) -> dict:
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
-        return payload
+        return jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Invalid token")
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+def hash_api_key(api_key: str) -> str:
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+
+def create_api_key(
+    db: Session,
+    user: dict,
+    name: Optional[str] = None,
 ) -> dict:
-    token = credentials.credentials
-    payload = decode_token(token)
+    raw_key = API_KEY_PREFIX + secrets.token_urlsafe(32)
+    key = APIKey(
+        id=str(uuid4()),
+        user_id=str(user["id"]),
+        address=user.get("address"),
+        name=name,
+        key_hash=hash_api_key(raw_key),
+        roles=user.get("roles", []),
+        revoked=False,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return {
+        "id": key.id,
+        "key": raw_key,
+        "name": key.name,
+        "created_at": key.created_at,
+    }
+
+
+def revoke_api_key(db: Session, key_id: str, user: dict) -> bool:
+    key = db.query(APIKey).filter(APIKey.id == key_id).first()
+    if not key or key.user_id != str(user["id"]):
+        raise HTTPException(status_code=404, detail="API key not found")
+    key.revoked = True
+    key.revoked_at = datetime.now(timezone.utc)
+    db.commit()
+    return True
+
+
+def authenticate_api_key(db: Session, api_key: str) -> dict:
+    key_hash = hash_api_key(api_key)
+    key = db.query(APIKey).filter(APIKey.key_hash == key_hash).first()
+    if not key or key.revoked:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+    return {
+        "id": key.user_id,
+        "address": key.address,
+        "roles": key.roles or [],
+        "auth_type": "api_key",
+        "api_key_id": key.id,
+        "rate_limit_tier": "api_key",
+    }
+
+
+async def get_current_user(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: Session = Depends(get_db),
+) -> dict:
+    api_key = request.headers.get("X-API-Key")
+    if api_key:
+        return authenticate_api_key(db, api_key)
+
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Missing credentials")
+
+    payload = decode_token(credentials.credentials)
 
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
 
-    # BUG: No token revocation check — logged-out or compromised tokens
-    # remain valid until they naturally expire
     user_data = {
         "id": payload.get("sub"),
         "address": payload.get("address"),
         "roles": payload.get("roles", []),
+        "auth_type": "jwt",
+        "rate_limit_tier": "jwt",
     }
 
     if not user_data["id"]:
@@ -71,6 +139,7 @@ def require_role(role: str):
         if role not in user.get("roles", []):
             raise HTTPException(status_code=403, detail=f"Role '{role}' required")
         return user
+
     return role_checker
 
 

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,11 +2,10 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, Boolean,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
-from datetime import datetime
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+from datetime import datetime, timezone
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
@@ -14,6 +13,10 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
 engine = create_engine(DATABASE_URL, echo=False)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+
+def utc_now():
+    return datetime.now(timezone.utc)
 
 
 def get_db():
@@ -31,7 +34,7 @@ class User(Base):
     address = Column(String(42), unique=True, nullable=False)
     username = Column(String(64), unique=True, nullable=True)
     # BUG: No index on address — wallet lookups on every auth request do full table scans
-    created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
+    created_at = Column(DateTime, default=utc_now)
 
     agents = relationship("Agent", back_populates="owner")
 
@@ -45,7 +48,7 @@ class Agent(Base):
     model_type = Column(String(32), default="gpt-4")
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
 
     # BUG: No cascade delete — deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
@@ -62,7 +65,7 @@ class Task(Base):
     status = Column(String(32), default="open")
     creator_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     agent_id = Column(Integer, ForeignKey("agents.id"), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, nullable=True)
     deadline = Column(DateTime, nullable=True)
 
@@ -80,10 +83,24 @@ class Payment(Base):
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
     status = Column(String(32), default="pending")
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class APIKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(String(36), primary_key=True, index=True)
+    user_id = Column(String(128), nullable=False, index=True)
+    address = Column(String(42), nullable=True)
+    name = Column(String(128), nullable=True)
+    key_hash = Column(String(64), unique=True, nullable=False, index=True)
+    roles = Column(JSON, default=list)
+    revoked = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, default=utc_now)
+    revoked_at = Column(DateTime, nullable=True)
 
 
 def init_db():

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+PyJWT>=2.10.0
+SQLAlchemy>=2.0.0
+pytest>=8.0.0

--- a/api/tests/test_api_keys.py
+++ b/api/tests/test_api_keys.py
@@ -1,0 +1,83 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware.auth import generate_login_tokens, hash_api_key
+from api.models.database import APIKey, Base, get_db
+
+
+def build_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app), TestingSessionLocal
+
+
+def auth_header():
+    token = generate_login_tokens("user-1", "0x0000000000000000000000000000000000000001", ["agent"])["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_jwt_auth_still_works():
+    client, _ = build_client()
+
+    response = client.get("/auth/me", headers=auth_header())
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "user-1"
+    assert response.json()["auth_type"] == "jwt"
+    app.dependency_overrides.clear()
+
+
+def test_api_key_generation_stores_hash_and_authenticates():
+    client, SessionLocal = build_client()
+
+    created = client.post("/auth/api-keys", json={"name": "ci-key"}, headers=auth_header())
+    assert created.status_code == 200
+    api_key = created.json()["key"]
+    key_id = created.json()["id"]
+    assert api_key.startswith("oa_")
+
+    db = SessionLocal()
+    stored = db.query(APIKey).filter(APIKey.id == key_id).one()
+    assert stored.key_hash == hash_api_key(api_key)
+    assert stored.key_hash != api_key
+    db.close()
+
+    me = client.get("/auth/me", headers={"X-API-Key": api_key})
+    assert me.status_code == 200
+    assert me.json()["auth_type"] == "api_key"
+    assert me.json()["api_key_id"] == key_id
+    assert me.json()["rate_limit_tier"] == "api_key"
+    app.dependency_overrides.clear()
+
+
+def test_revoked_api_key_fails_immediately():
+    client, _ = build_client()
+
+    created = client.post("/auth/api-keys", json={"name": "revoke-me"}, headers=auth_header())
+    api_key = created.json()["key"]
+    key_id = created.json()["id"]
+
+    revoked = client.delete(f"/auth/api-keys/{key_id}", headers=auth_header())
+    assert revoked.status_code == 200
+    assert revoked.json()["revoked"] is True
+
+    response = client.get("/auth/me", headers={"X-API-Key": api_key})
+    assert response.status_code == 401
+    app.dependency_overrides.clear()


### PR DESCRIPTION
Fixes #138
/claim #138

Summary:
- Add `X-API-Key` authentication alongside existing JWT bearer auth.
- Store API keys as SHA-256 hashes in a persisted `api_keys` database table.
- Add `POST /auth/api-keys` to generate a key and return the raw key only once.
- Add `DELETE /auth/api-keys/{id}` to revoke keys, and revoked keys fail immediately.
- Add `/auth/me` for protected auth verification and expose auth/rate-limit tier metadata.
- Keep JWT auth working while pinning JWT decode to HS256 and avoiding missing-secret startup crashes.

Verification:
- `python -m pytest api\tests\test_api_keys.py -q` (3 passed)
- `python -m py_compile api\middleware\auth.py api\main.py api\models\database.py api\tests\test_api_keys.py`
- `git diff --check` (only Git LF-to-CRLF warnings for edited Python/requirements files)

Payment:
- Preferred: USDC on Base to `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 to `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.