### PR TITLE
fix: validate agent endpoint urls

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -4,8 +4,7 @@ from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
     ForeignKey, DateTime, Enum as SAEnum,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
 from datetime import datetime
 import os
 
@@ -42,6 +41,7 @@ class Agent(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(128), nullable=False)
     description = Column(Text, nullable=True)
+    endpoint = Column(String(2048), nullable=True)
     model_type = Column(String(32), default="gpt-4")
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+PyJWT>=2.10.0
+SQLAlchemy>=2.0.0
+pytest>=8.0.0

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,18 +1,25 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
+import ipaddress
+import socket
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlparse, urlunparse
+
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
 
-from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
+from ..models.database import Agent, get_db
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+ENDPOINT_TIMEOUT_SECONDS = 5.0
 
 
 class AgentCreate(BaseModel):
-    name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    name: str  # BUG: No validation - name can contain SQL injection, XSS, or be empty
+    endpoint: str
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
@@ -20,24 +27,80 @@ class AgentCreate(BaseModel):
 
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
+    endpoint: Optional[str] = None
     description: Optional[str] = None
     config: Optional[dict] = None
 
 
+def _is_private_address(host: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _host_resolves_private(host: str) -> bool:
+    try:
+        addresses = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        raise HTTPException(status_code=400, detail="Endpoint host cannot be resolved")
+
+    for entry in addresses:
+        resolved_ip = entry[4][0]
+        if _is_private_address(resolved_ip):
+            return True
+    return False
+
+
+async def validate_endpoint_url(endpoint: str) -> str:
+    parsed = urlparse(endpoint)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="Endpoint must be a valid http or https URL")
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="Endpoint URL must not contain credentials")
+
+    host = parsed.hostname
+    if _is_private_address(host) or _host_resolves_private(host):
+        raise HTTPException(status_code=400, detail="Endpoint must not resolve to a private or internal address")
+
+    normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path or "/", "", parsed.query, ""))
+    try:
+        async with httpx.AsyncClient(timeout=ENDPOINT_TIMEOUT_SECONDS, follow_redirects=False) as client:
+            response = await client.head(normalized)
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=400, detail="Endpoint validation timed out")
+    except httpx.HTTPError:
+        raise HTTPException(status_code=400, detail="Endpoint is not reachable")
+
+    if response.status_code >= 400:
+        raise HTTPException(status_code=400, detail="Endpoint is not reachable")
+    return normalized
+
+
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    endpoint = await validate_endpoint_url(agent.endpoint)
     new_agent = Agent(
         name=agent.name,
         description=agent.description,
+        endpoint=endpoint,
         model_type=agent.model_type,
         config=agent.config or {},
         owner_id=user["id"],
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {"id": new_agent.id, "name": new_agent.name, "endpoint": new_agent.endpoint, "owner": user["address"]}
 
 
 @router.get("/")
@@ -49,7 +112,7 @@ async def list_agents(
 ):
     query = db.query(Agent)
     if owner:
-        # BUG: String interpolation in query — vulnerable to SQL injection
+        # BUG: String interpolation in query - vulnerable to SQL injection
         query = query.filter(Agent.owner_id == owner)
     return query.offset(skip).limit(limit).all()
 
@@ -71,13 +134,17 @@ async def update_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.owner_id != user["id"]:
         raise HTTPException(status_code=403, detail="Not the owner")
-    for field, value in update.dict(exclude_unset=True).items():
+
+    update_data = update.dict(exclude_unset=True)
+    if "endpoint" in update_data and update_data["endpoint"] is not None:
+        update_data["endpoint"] = await validate_endpoint_url(update_data["endpoint"])
+    for field, value in update_data.items():
         setattr(agent, field, value)
     db.commit()
     return agent
 
 
-# BUG: No authentication — anyone can delete any agent
+# BUG: No authentication - anyone can delete any agent
 @router.delete("/{agent_id}")
 async def delete_agent(agent_id: int, db=Depends(get_db)):
     agent = db.query(Agent).filter(Agent.id == agent_id).first()

--- a/api/tests/test_agent_endpoint_validation.py
+++ b/api/tests/test_agent_endpoint_validation.py
@@ -1,0 +1,120 @@
+import asyncio
+import os
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import Agent, Base, get_db
+from api.routes import agents
+
+
+class FakeResponse:
+    status_code = 204
+
+
+class FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.timeout = kwargs.get("timeout")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def head(self, url):
+        assert self.timeout == agents.ENDPOINT_TIMEOUT_SECONDS
+        return FakeResponse()
+
+
+def public_dns(*args, **kwargs):
+    return [(None, None, None, "", ("93.184.216.34", 443))]
+
+
+def test_valid_url_is_normalized_after_head_check(monkeypatch):
+    monkeypatch.setattr(agents.socket, "getaddrinfo", public_dns)
+    monkeypatch.setattr(agents.httpx, "AsyncClient", FakeAsyncClient)
+
+    validated = asyncio.run(agents.validate_endpoint_url("https://agent.example/callback#fragment"))
+
+    assert validated == "https://agent.example/callback"
+
+
+def test_invalid_url_format_is_rejected():
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_endpoint_url("not-a-url"))
+
+    assert exc_info.value.status_code == 400
+    assert "valid http or https URL" in exc_info.value.detail
+
+
+def test_private_ip_is_rejected_before_head_request():
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_endpoint_url("http://127.0.0.1:8000/agent"))
+
+    assert exc_info.value.status_code == 400
+    assert "private or internal" in exc_info.value.detail
+
+
+def test_timeout_is_rejected(monkeypatch):
+    class TimeoutClient(FakeAsyncClient):
+        async def head(self, url):
+            raise httpx.TimeoutException("slow")
+
+    monkeypatch.setattr(agents.socket, "getaddrinfo", public_dns)
+    monkeypatch.setattr(agents.httpx, "AsyncClient", TimeoutClient)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_endpoint_url("https://agent.example/"))
+
+    assert exc_info.value.status_code == 400
+    assert "timed out" in exc_info.value.detail
+
+
+def test_create_agent_stores_validated_url(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    async def fake_validate_endpoint_url(endpoint):
+        assert endpoint == "https://agent.example/raw"
+        return "https://agent.example/raw/"
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    test_app = FastAPI()
+    test_app.include_router(agents.router)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[agents.get_current_user] = lambda: {
+        "id": 1,
+        "address": "0x0000000000000000000000000000000000000001",
+    }
+    monkeypatch.setattr(agents, "validate_endpoint_url", fake_validate_endpoint_url)
+
+    response = TestClient(test_app).post(
+        "/agents/",
+        json={"name": "agent", "endpoint": "https://agent.example/raw"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["endpoint"] == "https://agent.example/raw/"
+    db = TestingSessionLocal()
+    stored = db.query(Agent).one()
+    assert stored.endpoint == "https://agent.example/raw/"
+    db.close()


### PR DESCRIPTION
Fixes #139
/claim #139

Summary:
- Add an `endpoint` field to agent creation/update and persist the validated URL on the Agent model.
- Validate endpoint format as HTTP/HTTPS with host and no embedded credentials.
- Reject literal and DNS-resolved private/internal addresses for SSRF protection.
- Verify reachability using a HEAD request with a 5-second timeout and normalize the stored URL.
- Validate endpoint updates before persisting them.

Verification:
- `python -m pytest api\tests\test_agent_endpoint_validation.py -q` (5 passed)
- `python -m py_compile api\routes\agents.py api\models\database.py api\tests\test_agent_endpoint_validation.py`
- `git diff --check` (only Git LF-to-CRLF warnings for edited Python/requirements files)

Payment:
- Preferred: USDC on Base to `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 to `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.