### PR TITLE
fix: process expired escrow refunds

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -4,9 +4,8 @@ from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
     ForeignKey, DateTime, Enum as SAEnum,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
-from datetime import datetime
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+from datetime import datetime, timezone
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
@@ -14,6 +13,10 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
 engine = create_engine(DATABASE_URL, echo=False)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+
+def utc_now():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def get_db():
@@ -31,7 +34,7 @@ class User(Base):
     address = Column(String(42), unique=True, nullable=False)
     username = Column(String(64), unique=True, nullable=True)
     # BUG: No index on address — wallet lookups on every auth request do full table scans
-    created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
+    created_at = Column(DateTime, default=utc_now)
 
     agents = relationship("Agent", back_populates="owner")
 
@@ -45,7 +48,7 @@ class Agent(Base):
     model_type = Column(String(32), default="gpt-4")
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
 
     # BUG: No cascade delete — deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
@@ -62,7 +65,7 @@ class Task(Base):
     status = Column(String(32), default="open")
     creator_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     agent_id = Column(Integer, ForeignKey("agents.id"), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, nullable=True)
     deadline = Column(DateTime, nullable=True)
 
@@ -80,10 +83,25 @@ class Payment(Base):
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
     status = Column(String(32), default="pending")
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
+    release_time = Column(DateTime, nullable=True)
+    expired_at = Column(DateTime, nullable=True)
     claimed_at = Column(DateTime, nullable=True)
+    refunded_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class PaymentRefundLog(Base):
+    __tablename__ = "payment_refund_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    payment_id = Column(Integer, ForeignKey("payments.id"), nullable=False)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    amount = Column(Float, nullable=False)
+    refunded_to = Column(String(42), nullable=False)
+    reason = Column(String(64), nullable=False)
+    created_at = Column(DateTime, default=utc_now)
 
 
 def init_db():

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+PyJWT>=2.10.0
+SQLAlchemy>=2.0.0
+pytest>=8.0.0

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -3,12 +3,22 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
-from ..models.database import get_db, Payment, Task
+from ..models.database import get_db, Payment, PaymentRefundLog, Task
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/payments", tags=["payments"])
+AUTO_REFUND_GRACE_PERIOD = timedelta(days=30)
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def escrow_expired_at(payment: Payment, task: Optional[Task] = None) -> datetime:
+    release_time = payment.release_time or (task.deadline if task else None) or payment.created_at
+    return payment.expired_at or (release_time + AUTO_REFUND_GRACE_PERIOD)
 
 
 class EscrowDeposit(BaseModel):
@@ -36,13 +46,17 @@ async def deposit_escrow(
 
     # BUG: No idempotency key — retried requests create duplicate escrow entries,
     # locking more funds than intended
+    now = utc_now()
+    release_time = task.deadline or now
     payment = Payment(
         task_id=deposit.task_id,
         from_address=user["address"],
         amount=deposit.amount,
         token_address=deposit.token_address,
         status="escrowed",
-        created_at=datetime.utcnow(),
+        created_at=now,
+        release_time=release_time,
+        expired_at=release_time + AUTO_REFUND_GRACE_PERIOD,
     )
     db.add(payment)
     db.commit()
@@ -82,7 +96,7 @@ async def claim_payment(
     for payment in payments:
         payment.status = "claimed"
         payment.to_address = claim.recipient_address
-        payment.claimed_at = datetime.utcnow()
+        payment.claimed_at = utc_now()
         total_claimed += payment.amount
 
     db.commit()
@@ -91,6 +105,45 @@ async def claim_payment(
         "claimed_amount": total_claimed,
         "recipient": claim.recipient_address,
     }
+
+
+@router.post("/process-expired")
+async def process_expired_escrows(user=Depends(get_current_user), db=Depends(get_db)):
+    now = utc_now()
+    payments = db.query(Payment).filter(Payment.status == "escrowed").all()
+    refunded = []
+
+    for payment in payments:
+        task = db.query(Task).filter(Task.id == payment.task_id).first()
+        expired_at = escrow_expired_at(payment, task)
+        if expired_at > now:
+            continue
+
+        payment.status = "refunded"
+        payment.to_address = payment.from_address
+        payment.refunded_at = now
+        payment.expired_at = expired_at
+
+        log = PaymentRefundLog(
+            payment_id=payment.id,
+            task_id=payment.task_id,
+            amount=payment.amount,
+            refunded_to=payment.from_address,
+            reason="expired",
+            created_at=now,
+        )
+        db.add(log)
+        refunded.append({
+            "payment_id": payment.id,
+            "task_id": payment.task_id,
+            "amount": payment.amount,
+            "refunded_to": payment.from_address,
+            "refunded_at": now.isoformat(),
+            "expired_at": expired_at.isoformat(),
+        })
+
+    db.commit()
+    return {"processed": len(payments), "refunded": len(refunded), "refunds": refunded}
 
 
 @router.get("/history")

--- a/api/tests/test_expired_payments.py
+++ b/api/tests/test_expired_payments.py
@@ -1,0 +1,112 @@
+import os
+from datetime import timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import Base, Payment, PaymentRefundLog, Task, get_db
+from api.routes import payments
+
+
+def build_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app = FastAPI()
+    app.include_router(payments.router)
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[payments.get_current_user] = lambda: {
+        "id": 1,
+        "address": "0x0000000000000000000000000000000000000001",
+    }
+    return TestClient(app), TestingSessionLocal
+
+
+def seed_task_and_payment(SessionLocal, *, release_delta_days: int, status: str = "escrowed"):
+    now = payments.utc_now()
+    db = SessionLocal()
+    task = Task(
+        title="task",
+        reward_amount=10.0,
+        status="open",
+        creator_id=1,
+        created_at=now,
+        deadline=now + timedelta(days=release_delta_days),
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+
+    release_time = now + timedelta(days=release_delta_days)
+    payment = Payment(
+        task_id=task.id,
+        from_address="0xpayer",
+        amount=10.0,
+        token_address="0xtoken",
+        status=status,
+        created_at=now,
+        release_time=release_time,
+        expired_at=release_time + payments.AUTO_REFUND_GRACE_PERIOD,
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    payment_id = payment.id
+    db.close()
+    return payment_id
+
+
+def test_fresh_escrow_not_refunded():
+    client, SessionLocal = build_client()
+    payment_id = seed_task_and_payment(SessionLocal, release_delta_days=1)
+
+    response = client.post("/payments/process-expired")
+
+    assert response.status_code == 200
+    assert response.json()["refunded"] == 0
+    db = SessionLocal()
+    payment = db.query(Payment).filter(Payment.id == payment_id).one()
+    assert payment.status == "escrowed"
+    assert db.query(PaymentRefundLog).count() == 0
+    db.close()
+
+
+def test_expired_escrow_refunded_and_logged():
+    client, SessionLocal = build_client()
+    payment_id = seed_task_and_payment(SessionLocal, release_delta_days=-31)
+
+    response = client.post("/payments/process-expired")
+
+    assert response.status_code == 200
+    assert response.json()["processed"] == 1
+    assert response.json()["refunded"] == 1
+    assert response.json()["refunds"][0]["payment_id"] == payment_id
+
+    db = SessionLocal()
+    payment = db.query(Payment).filter(Payment.id == payment_id).one()
+    assert payment.status == "refunded"
+    assert payment.to_address == payment.from_address
+    assert payment.refunded_at is not None
+
+    log = db.query(PaymentRefundLog).one()
+    assert log.payment_id == payment_id
+    assert log.refunded_to == payment.from_address
+    assert log.reason == "expired"
+    db.close()


### PR DESCRIPTION
Fixes #120
/claim #120

Summary:
- Add escrow release/expiry metadata and a refund log table.
- Set `expired_at` to 30 days after release time when escrow deposits are created.
- Add `POST /payments/process-expired` to process all currently escrowed payments and refund only those past the 30-day grace period.
- Refund expired escrows to the payer address and log each refund with payment ID, task ID, amount, timestamp, recipient, and reason.

Verification:
- `python -m pytest api\tests\test_expired_payments.py -q` (2 passed)
- `python -m py_compile api\routes\payments.py api\models\database.py api\tests\test_expired_payments.py`
- `git diff --check` (only Git LF-to-CRLF warnings for edited Python/requirements files)

Payment:
- Preferred: USDC on Base to `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 to `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.