### PR TITLE
fix: add structured api errors

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,150 @@
+"""Structured API error responses.
+
+Error codes:
+- VALIDATION_ERROR: Invalid request input or malformed parameters.
+- NOT_FOUND: The requested resource or route does not exist.
+- AUTH_FAILED: Authentication failed or the caller lacks required access.
+- RATE_LIMITED: The caller exceeded the configured request limit.
+- INTERNAL_ERROR: An unexpected server-side failure occurred.
+"""
+
+from enum import Enum
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+class ErrorCode(str, Enum):
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_FOUND = "NOT_FOUND"
+    AUTH_FAILED = "AUTH_FAILED"
+    RATE_LIMITED = "RATE_LIMITED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+ERROR_CODE_DESCRIPTIONS = {
+    ErrorCode.VALIDATION_ERROR: "Invalid request input or malformed parameters.",
+    ErrorCode.NOT_FOUND: "The requested resource or route does not exist.",
+    ErrorCode.AUTH_FAILED: "Authentication failed or the caller lacks required access.",
+    ErrorCode.RATE_LIMITED: "The caller exceeded the configured request limit.",
+    ErrorCode.INTERNAL_ERROR: "An unexpected server-side failure occurred.",
+}
+
+
+class ErrorResponse(BaseModel):
+    code: ErrorCode
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+    request_id: str
+
+
+def get_request_id(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or request.headers.get(
+        "X-Request-ID", "unknown"
+    )
+
+
+def error_response(
+    request: Request,
+    code: ErrorCode,
+    message: str,
+    status_code: int,
+    details: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    request_id = get_request_id(request)
+    content = ErrorResponse(
+        code=code,
+        message=message,
+        details=details or {},
+        request_id=request_id,
+    ).model_dump(mode="json")
+    response_headers = {"X-Request-ID": request_id}
+    if headers:
+        response_headers.update(headers)
+    return JSONResponse(status_code=status_code, content=content, headers=response_headers)
+
+
+def status_to_error_code(status_code: int) -> ErrorCode:
+    if status_code in {401, 403}:
+        return ErrorCode.AUTH_FAILED
+    if status_code == 404:
+        return ErrorCode.NOT_FOUND
+    if status_code == 429:
+        return ErrorCode.RATE_LIMITED
+    if 400 <= status_code < 500:
+        return ErrorCode.VALIDATION_ERROR
+    return ErrorCode.INTERNAL_ERROR
+
+
+def normalize_http_detail(detail: Any, fallback_message: str) -> tuple[str, dict[str, Any]]:
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or detail.get("error") or fallback_message)
+        details = detail.get("details")
+        if isinstance(details, dict):
+            return message, details
+        return message, {k: v for k, v in detail.items() if k not in {"message", "error"}}
+    if detail:
+        return str(detail), {}
+    return fallback_message, {}
+
+
+def validation_error_details(exc: RequestValidationError) -> dict[str, Any]:
+    errors = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error.get("loc", []))
+        errors.append(
+            {
+                "field": loc,
+                "message": error.get("msg", "Invalid value"),
+                "type": error.get("type", "value_error"),
+            }
+        )
+    return {"errors": errors}
+
+
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return error_response(
+        request=request,
+        code=ErrorCode.VALIDATION_ERROR,
+        message="Request validation failed",
+        status_code=422,
+        details=validation_error_details(exc),
+    )
+
+
+async def http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    code = status_to_error_code(exc.status_code)
+    message, details = normalize_http_detail(exc.detail, exc.__class__.__name__)
+    return error_response(
+        request=request,
+        code=code,
+        message=message,
+        status_code=exc.status_code,
+        details=details,
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def internal_exception_handler(request: Request, _exc: Exception) -> JSONResponse:
+    return error_response(
+        request=request,
+        code=ErrorCode.INTERNAL_ERROR,
+        message="Internal server error",
+        status_code=500,
+        details={},
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, internal_exception_handler)

--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,31 @@
-from fastapi import FastAPI, HTTPException, Query
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, Query, Request
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+
+try:
+    from .errors import register_exception_handlers
+except ImportError:
+    from errors import register_exception_handlers
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+register_exception_handlers(app)
+
+
+@app.middleware("http")
+async def request_id_middleware(request: Request, call_next):
+    request_id = request.headers.get("X-Request-ID") or str(uuid4())
+    request.state.request_id = request_id
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    return response
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -2,10 +2,14 @@
 
 import time
 from collections import defaultdict
-from fastapi import Request, HTTPException
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
 from typing import Dict, Tuple
+
+try:
+    from ..errors import ErrorCode, error_response
+except ImportError:
+    from errors import ErrorCode, error_response
 
 
 class RateLimitConfig:
@@ -65,12 +69,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         is_limited, value = self._is_rate_limited(client_ip)
 
         if is_limited:
-            return JSONResponse(
+            return error_response(
+                request=request,
+                code=ErrorCode.RATE_LIMITED,
+                message="Rate limit exceeded",
                 status_code=429,
-                content={
-                    "error": "Rate limit exceeded",
-                    "retry_after": value,
-                },
+                details={"retry_after": value},
                 headers={"Retry-After": str(value)},
             )
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+pytest>=8.0.0

--- a/api/tests/test_structured_errors.py
+++ b/api/tests/test_structured_errors.py
@@ -1,0 +1,89 @@
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.testclient import TestClient
+
+try:
+    from api.errors import register_exception_handlers
+    from api.main import app as main_app
+except ImportError:
+    from errors import register_exception_handlers
+    from main import app as main_app
+
+
+def assert_error_schema(payload, expected_code, request_id):
+    assert payload["code"] == expected_code
+    assert isinstance(payload["message"], str)
+    assert isinstance(payload["details"], dict)
+    assert payload["request_id"] == request_id
+
+
+def test_validation_error_includes_field_details_and_request_id():
+    client = TestClient(main_app)
+
+    response = client.get(
+        "/agents",
+        params={"limit": "not-an-int"},
+        headers={"X-Request-ID": "req-validation"},
+    )
+
+    assert response.status_code == 422
+    assert response.headers["X-Request-ID"] == "req-validation"
+    payload = response.json()
+    assert_error_schema(payload, "VALIDATION_ERROR", "req-validation")
+    assert payload["details"]["errors"][0]["field"] == "query.limit"
+
+
+def test_not_found_error_uses_structured_schema():
+    client = TestClient(main_app)
+
+    response = client.get("/missing-route", headers={"X-Request-ID": "req-not-found"})
+
+    assert response.status_code == 404
+    assert_error_schema(response.json(), "NOT_FOUND", "req-not-found")
+
+
+def test_auth_failed_and_rate_limited_codes():
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/auth")
+    async def auth_failed():
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    @app.get("/limited")
+    async def limited():
+        raise HTTPException(
+            status_code=429,
+            detail={"message": "Rate limit exceeded", "details": {"retry_after": 30}},
+            headers={"Retry-After": "30"},
+        )
+
+    client = TestClient(app)
+
+    auth_response = client.get("/auth", headers={"X-Request-ID": "req-auth"})
+    limited_response = client.get("/limited", headers={"X-Request-ID": "req-rate"})
+
+    assert auth_response.status_code == 401
+    assert_error_schema(auth_response.json(), "AUTH_FAILED", "req-auth")
+    assert limited_response.status_code == 429
+    assert limited_response.headers["Retry-After"] == "30"
+    assert_error_schema(limited_response.json(), "RATE_LIMITED", "req-rate")
+    assert limited_response.json()["details"]["retry_after"] == 30
+
+
+def test_internal_error_uses_stable_response_without_exception_details():
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/boom")
+    async def boom(required: int = Query(1)):
+        raise RuntimeError("database password leaked here")
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/boom", headers={"X-Request-ID": "req-internal"})
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert_error_schema(payload, "INTERNAL_ERROR", "req-internal")
+    assert payload["message"] == "Internal server error"
+    assert "database password" not in response.text


### PR DESCRIPTION
Fixes #202
/claim #202

Summary:
- Adds a shared structured error module with documented codes: `VALIDATION_ERROR`, `NOT_FOUND`, `AUTH_FAILED`, `RATE_LIMITED`, and `INTERNAL_ERROR`.
- Registers FastAPI exception handlers for HTTP errors, validation errors, and internal errors.
- Adds request ID propagation via `X-Request-ID` and includes `request_id` in every normalized error body.
- Normalizes rate-limit middleware errors into the same `{code, message, details, request_id}` schema.
- Adds focused tests for validation details, 404, auth failure, rate limit, and internal error redaction.

Verification:
- `python -m pytest api\tests\test_structured_errors.py -q` (4 passed)
- `python -m pytest tests\test_structured_errors.py -q` from `api/` (4 passed)
- `python -m py_compile api\errors.py api\main.py api\middleware\ratelimit.py api\tests\test_structured_errors.py`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.