### PR TITLE
fix: add protected flash loan pool

### DIFF
--- a/contracts/lottery/FlashLoan.sol
+++ b/contracts/lottery/FlashLoan.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+interface IFlashLoanReceiver {
+    function executeOperation(
+        address token,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) external returns (bool);
+}
+
+/// @title FlashLoan
+/// @notice Single-token flash-loan pool with minimum fees and drainage protection.
+contract FlashLoan is Ownable, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint256 public constant FEE_BPS = 5;
+    uint256 public constant MAX_LOAN_BPS = 5_000;
+
+    IERC20 public immutable token;
+    uint256 public accountedLiquidity;
+
+    event Deposited(address indexed sender, uint256 amount);
+    event Withdrawn(address indexed recipient, uint256 amount);
+    event FlashLoanExecuted(address indexed receiver, uint256 amount, uint256 fee);
+    event AccountedLiquiditySynced(uint256 previousLiquidity, uint256 newLiquidity);
+
+    constructor(address token_) Ownable(msg.sender) {
+        require(token_ != address(0), "FlashLoan: zero token");
+        token = IERC20(token_);
+    }
+
+    function deposit(uint256 amount) external nonReentrant {
+        require(amount > 0, "FlashLoan: zero deposit");
+
+        uint256 beforeBalance = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = token.balanceOf(address(this)) - beforeBalance;
+        require(received > 0, "FlashLoan: no tokens received");
+
+        accountedLiquidity += received;
+        emit Deposited(msg.sender, received);
+    }
+
+    function withdraw(uint256 amount, address recipient) external onlyOwner nonReentrant {
+        require(recipient != address(0), "FlashLoan: zero recipient");
+        require(amount <= accountedLiquidity, "FlashLoan: insufficient liquidity");
+
+        accountedLiquidity -= amount;
+        token.safeTransfer(recipient, amount);
+        emit Withdrawn(recipient, amount);
+    }
+
+    function flashLoan(
+        IFlashLoanReceiver receiver,
+        uint256 amount,
+        bytes calldata data
+    ) external whenNotPaused nonReentrant {
+        require(address(receiver) != address(0), "FlashLoan: zero receiver");
+        require(amount > 0, "FlashLoan: zero amount");
+        require(amount <= maxFlashLoan(), "FlashLoan: exceeds max loan");
+
+        uint256 balanceBefore = token.balanceOf(address(this));
+        require(balanceBefore >= accountedLiquidity, "FlashLoan: liquidity mismatch");
+
+        uint256 fee = flashFee(amount);
+        token.safeTransfer(address(receiver), amount);
+        require(
+            receiver.executeOperation(address(token), amount, fee, data),
+            "FlashLoan: callback failed"
+        );
+
+        uint256 expectedBalance = balanceBefore + fee;
+        require(token.balanceOf(address(this)) >= expectedBalance, "FlashLoan: not repaid");
+
+        accountedLiquidity += fee;
+        emit FlashLoanExecuted(address(receiver), amount, fee);
+    }
+
+    function flashFee(uint256 amount) public pure returns (uint256) {
+        require(amount > 0, "FlashLoan: zero amount");
+        uint256 fee = (amount * FEE_BPS + BPS_DENOMINATOR - 1) / BPS_DENOMINATOR;
+        return fee == 0 ? 1 : fee;
+    }
+
+    function maxFlashLoan() public view returns (uint256) {
+        return (accountedLiquidity * MAX_LOAN_BPS) / BPS_DENOMINATOR;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function syncAccountedLiquidity() external onlyOwner {
+        uint256 previousLiquidity = accountedLiquidity;
+        accountedLiquidity = token.balanceOf(address(this));
+        emit AccountedLiquiditySynced(previousLiquidity, accountedLiquidity);
+    }
+}

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/FlashLoanReceiverMock.sol
+++ b/contracts/test/FlashLoanReceiverMock.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../lottery/FlashLoan.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract FlashLoanReceiverMock is IFlashLoanReceiver {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable repaymentToken;
+    bool public repay = true;
+    bool public called;
+    uint256 public lastFee;
+
+    constructor(address token_) {
+        repaymentToken = IERC20(token_);
+    }
+
+    function setRepay(bool repay_) external {
+        repay = repay_;
+    }
+
+    function executeOperation(
+        address,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata
+    ) external returns (bool) {
+        called = true;
+        lastFee = fee;
+        if (repay) {
+            repaymentToken.safeTransfer(msg.sender, amount + fee);
+        }
+        return true;
+    }
+}

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock Token", "MOCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/FlashLoan.test.js
+++ b/test/FlashLoan.test.js
@@ -1,0 +1,83 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("FlashLoan", function () {
+  let token;
+  let flashLoan;
+  let receiver;
+  let owner;
+  let user;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    token = await MockERC20.deploy();
+    await token.waitForDeployment();
+
+    const FlashLoan = await ethers.getContractFactory("FlashLoan");
+    flashLoan = await FlashLoan.deploy(await token.getAddress());
+    await flashLoan.waitForDeployment();
+
+    const FlashLoanReceiverMock = await ethers.getContractFactory("FlashLoanReceiverMock");
+    receiver = await FlashLoanReceiverMock.deploy(await token.getAddress());
+    await receiver.waitForDeployment();
+
+    await token.mint(owner.address, ethers.parseEther("1000"));
+    await token.mint(await receiver.getAddress(), ethers.parseEther("100"));
+    await token.approve(await flashLoan.getAddress(), ethers.parseEther("1000"));
+    await flashLoan.deposit(ethers.parseEther("1000"));
+  });
+
+  it("charges at least one token unit for tiny loans", async function () {
+    expect(await flashLoan.flashFee(1)).to.equal(1);
+
+    await flashLoan.flashLoan(await receiver.getAddress(), 1, "0x");
+
+    expect(await receiver.lastFee()).to.equal(1);
+    expect(await flashLoan.accountedLiquidity()).to.equal(ethers.parseEther("1000") + 1n);
+  });
+
+  it("rejects loans above half of accounted pool liquidity", async function () {
+    const maxLoan = await flashLoan.maxFlashLoan();
+
+    await expect(flashLoan.flashLoan(await receiver.getAddress(), maxLoan + 1n, "0x"))
+      .to.be.revertedWith("FlashLoan: exceeds max loan");
+  });
+
+  it("allows loans up to half of accounted pool liquidity", async function () {
+    const maxLoan = await flashLoan.maxFlashLoan();
+
+    await flashLoan.flashLoan(await receiver.getAddress(), maxLoan, "0x");
+
+    expect(await receiver.called()).to.equal(true);
+  });
+
+  it("reverts if the borrower does not repay amount plus fee", async function () {
+    await receiver.setRepay(false);
+
+    await expect(flashLoan.flashLoan(await receiver.getAddress(), ethers.parseEther("10"), "0x"))
+      .to.be.revertedWith("FlashLoan: not repaid");
+  });
+
+  it("pauses and unpauses flash loans", async function () {
+    await flashLoan.pause();
+    await expect(flashLoan.flashLoan(await receiver.getAddress(), 1, "0x"))
+      .to.be.revertedWithCustomError(flashLoan, "EnforcedPause");
+
+    await flashLoan.unpause();
+    await flashLoan.flashLoan(await receiver.getAddress(), 1, "0x");
+  });
+
+  it("tracks internal liquidity separately from unsolicited token transfers", async function () {
+    await token.connect(user).mint(user.address, ethers.parseEther("100"));
+    await token.connect(user).transfer(await flashLoan.getAddress(), ethers.parseEther("10"));
+
+    expect(await flashLoan.accountedLiquidity()).to.equal(ethers.parseEther("1000"));
+    expect(await flashLoan.maxFlashLoan()).to.equal(ethers.parseEther("500"));
+
+    await flashLoan.syncAccountedLiquidity();
+
+    expect(await flashLoan.accountedLiquidity()).to.equal(ethers.parseEther("1010"));
+  });
+});


### PR DESCRIPTION
Fixes #9
/claim #9

Summary:
- Adds `contracts/lottery/FlashLoan.sol`, a single-token flash-loan pool with a minimum nonzero fee, 50% max-loan cap, pause/unpause, repayment enforcement, non-reentrancy, and internal accounted liquidity.
- Adds owner deposit/withdraw and liquidity sync paths so unsolicited/rebased balances do not silently inflate loan capacity until explicitly synced.
- Adds mock ERC20 and receiver contracts plus focused FlashLoan tests covering minimum fee, >50% rejection, successful max-size loans, non-repayment reverts, pause/unpause, and accounting behavior.
- Updates Hardhat compiler settings for the repo's OpenZeppelin v5 imports and fixes the existing tuple destructuring syntax in `ChainlinkAdapter.sol` so the focused Solidity tests can compile.

Verification:
- `npx hardhat test test\FlashLoan.test.js` (6 passing)
- `npx hardhat compile` (Nothing to compile after successful test compile)
- `node --check test\FlashLoan.test.js`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Note:
- Full `npx hardhat test` reaches an unrelated pre-existing `StakingRewards` fixture failure: artifact `StakingToken` is missing. The new FlashLoan test file passes in isolation.

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.