### PR TITLE
fix: add multisig task payouts

### DIFF
--- a/contracts/TaskRouter.sol
+++ b/contracts/TaskRouter.sol
@@ -5,6 +5,10 @@ import "./AgentRegistry.sol";
 
 contract TaskRouter {
     AgentRegistry public registry;
+    address public owner;
+    uint256 public constant LARGE_PAYOUT_THRESHOLD = 1 ether;
+    uint256 public constant REQUIRED_APPROVALS = 2;
+    uint256 public constant MAX_SIGNERS = 3;
 
     enum TaskStatus { Open, Assigned, Completed, Disputed, Cancelled }
 
@@ -18,18 +22,44 @@ contract TaskRouter {
         bytes result;
     }
 
+    struct PaymentApproval {
+        address recipient;
+        uint256 amount;
+        uint256 approvalCount;
+        bool executed;
+    }
+
     mapping(uint256 => Task) public tasks;
+    mapping(uint256 => PaymentApproval) public paymentApprovals;
+    mapping(uint256 => mapping(address => bool)) public paymentApprovedBy;
+    mapping(address => bool) public paymentSigners;
     uint256 public taskCount;
     uint256 public platformFee; // basis points
+    uint256 public signerCount;
 
     event TaskCreated(uint256 indexed taskId, address indexed creator, uint256 reward);
     event TaskAssigned(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskCompleted(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskDisputed(uint256 indexed taskId);
+    event PaymentSignerUpdated(address indexed signer, bool active);
+    event LargePaymentPending(uint256 indexed taskId, address indexed recipient, uint256 amount);
+    event PaymentApproved(uint256 indexed taskId, address indexed signer, uint256 approvals);
+    event PaymentExecuted(uint256 indexed taskId, address indexed recipient, uint256 amount);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "TaskRouter: not owner");
+        _;
+    }
+
+    modifier onlyPaymentSigner() {
+        require(paymentSigners[msg.sender], "TaskRouter: not signer");
+        _;
+    }
 
     constructor(address _registry, uint256 _platformFee) {
         registry = AgentRegistry(_registry);
         platformFee = _platformFee;
+        owner = msg.sender;
     }
 
     function createTask(string calldata description, uint256 deadline) external payable returns (uint256) {
@@ -79,10 +109,62 @@ contract TaskRouter {
         uint256 fee = task.reward * platformFee / 10000;
         uint256 payout = task.reward - fee;
 
-        (bool success, ) = msg.sender.call{value: payout}("");
-        require(success, "Payout failed");
+        if (payout < LARGE_PAYOUT_THRESHOLD) {
+            _executePayment(taskId, msg.sender, payout);
+        } else {
+            PaymentApproval storage approval = paymentApprovals[taskId];
+            approval.recipient = msg.sender;
+            approval.amount = payout;
+            emit LargePaymentPending(taskId, msg.sender, payout);
+        }
 
         emit TaskCompleted(taskId, task.assignedAgent);
+    }
+
+    function approvePayment(uint256 taskId) external onlyPaymentSigner {
+        Task storage task = tasks[taskId];
+        require(task.status == TaskStatus.Completed, "TaskRouter: task not completed");
+
+        PaymentApproval storage approval = paymentApprovals[taskId];
+        require(approval.recipient != address(0), "TaskRouter: no pending payment");
+        require(!approval.executed, "TaskRouter: payment executed");
+        require(!paymentApprovedBy[taskId][msg.sender], "TaskRouter: already approved");
+
+        paymentApprovedBy[taskId][msg.sender] = true;
+        approval.approvalCount += 1;
+        emit PaymentApproved(taskId, msg.sender, approval.approvalCount);
+
+        if (approval.approvalCount >= REQUIRED_APPROVALS) {
+            _executePayment(taskId, approval.recipient, approval.amount);
+            approval.executed = true;
+        }
+    }
+
+    function setPaymentSigner(address signer, bool active) external onlyOwner {
+        require(signer != address(0), "TaskRouter: zero signer");
+        if (active) {
+            require(!paymentSigners[signer], "TaskRouter: signer exists");
+            require(signerCount < MAX_SIGNERS, "TaskRouter: signer limit");
+            paymentSigners[signer] = true;
+            signerCount += 1;
+        } else {
+            require(paymentSigners[signer], "TaskRouter: signer missing");
+            paymentSigners[signer] = false;
+            signerCount -= 1;
+        }
+
+        emit PaymentSignerUpdated(signer, active);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "TaskRouter: zero owner");
+        owner = newOwner;
+    }
+
+    function _executePayment(uint256 taskId, address recipient, uint256 amount) internal {
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Payout failed");
+        emit PaymentExecuted(taskId, recipient, amount);
     }
 
     function cancelTask(uint256 taskId) external {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/TaskRouterMultisig.test.js
+++ b/test/TaskRouterMultisig.test.js
@@ -1,0 +1,110 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("TaskRouter multisig payouts", function () {
+  let registry;
+  let router;
+  let owner;
+  let creator;
+  let agentOwner;
+  let signer1;
+  let signer2;
+  let signer3;
+  let outsider;
+  let agentId;
+
+  beforeEach(async function () {
+    [owner, creator, agentOwner, signer1, signer2, signer3, outsider] = await ethers.getSigners();
+
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    registry = await AgentRegistry.deploy(0);
+    await registry.waitForDeployment();
+
+    const TaskRouter = await ethers.getContractFactory("TaskRouter");
+    router = await TaskRouter.deploy(await registry.getAddress(), 0);
+    await router.waitForDeployment();
+
+    await router.setPaymentSigner(signer1.address, true);
+    await router.setPaymentSigner(signer2.address, true);
+    await router.setPaymentSigner(signer3.address, true);
+
+    const registerTx = await registry.connect(agentOwner).registerAgent("agent", "https://agent.local");
+    const receipt = await registerTx.wait();
+    const event = receipt.logs.find((log) => log.fragment && log.fragment.name === "AgentRegistered");
+    agentId = event.args.agentId;
+  });
+
+  async function createAndAssignTask(reward) {
+    const deadline = Math.floor(Date.now() / 1000) + 3600;
+    const createTx = await router.connect(creator).createTask("do work", deadline, { value: reward });
+    const receipt = await createTx.wait();
+    const event = receipt.logs.find((log) => log.fragment && log.fragment.name === "TaskCreated");
+    const taskId = event.args.taskId;
+    await router.connect(agentOwner).assignTask(taskId, agentId);
+    return taskId;
+  }
+
+  it("pays below-threshold tasks immediately", async function () {
+    const reward = ethers.parseEther("0.5");
+    const taskId = await createAndAssignTask(reward);
+
+    await expect(router.connect(agentOwner).completeTask(taskId, "0x1234"))
+      .to.emit(router, "PaymentExecuted")
+      .withArgs(taskId, agentOwner.address, reward);
+
+    expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(0);
+    const approval = await router.paymentApprovals(taskId);
+    expect(approval.recipient).to.equal(ethers.ZeroAddress);
+  });
+
+  it("holds above-threshold payouts until two signers approve", async function () {
+    const reward = ethers.parseEther("2");
+    const taskId = await createAndAssignTask(reward);
+
+    await expect(router.connect(agentOwner).completeTask(taskId, "0x1234"))
+      .to.emit(router, "LargePaymentPending")
+      .withArgs(taskId, agentOwner.address, reward);
+
+    expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(reward);
+
+    await router.connect(signer1).approvePayment(taskId);
+    let approval = await router.paymentApprovals(taskId);
+    expect(approval.approvalCount).to.equal(1);
+    expect(approval.executed).to.equal(false);
+    expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(reward);
+
+    await expect(router.connect(signer2).approvePayment(taskId))
+      .to.emit(router, "PaymentExecuted")
+      .withArgs(taskId, agentOwner.address, reward);
+
+    approval = await router.paymentApprovals(taskId);
+    expect(approval.approvalCount).to.equal(2);
+    expect(approval.executed).to.equal(true);
+    expect(await ethers.provider.getBalance(await router.getAddress())).to.equal(0);
+  });
+
+  it("rejects duplicate approvals and non-signers", async function () {
+    const taskId = await createAndAssignTask(ethers.parseEther("2"));
+    await router.connect(agentOwner).completeTask(taskId, "0x1234");
+
+    await router.connect(signer1).approvePayment(taskId);
+    await expect(router.connect(signer1).approvePayment(taskId))
+      .to.be.revertedWith("TaskRouter: already approved");
+    await expect(router.connect(outsider).approvePayment(taskId))
+      .to.be.revertedWith("TaskRouter: not signer");
+  });
+
+  it("manages the three-signer set", async function () {
+    expect(await router.signerCount()).to.equal(3);
+    await expect(router.setPaymentSigner(outsider.address, true))
+      .to.be.revertedWith("TaskRouter: signer limit");
+
+    await router.setPaymentSigner(signer3.address, false);
+    expect(await router.paymentSigners(signer3.address)).to.equal(false);
+    expect(await router.signerCount()).to.equal(2);
+
+    await router.setPaymentSigner(outsider.address, true);
+    expect(await router.paymentSigners(outsider.address)).to.equal(true);
+    expect(await router.signerCount()).to.equal(3);
+  });
+});


### PR DESCRIPTION
Fixes #31
/claim #31

Summary:
- Adds `LARGE_PAYOUT_THRESHOLD` at 1 ETH and routes payouts below the threshold through immediate execution.
- Adds 2-of-3 signer approval for large completed-task payouts with signer tracking, no double-approval, and auto-execution once the second approval lands.
- Adds owner-managed signer set updates and ownership transfer.
- Adds focused TaskRouter tests for immediate small payouts, held large payouts, two-approval auto-execution, duplicate/non-signer rejection, and signer management.
- Updates Hardhat compiler settings for the repo's OpenZeppelin v5 imports and fixes the existing tuple destructuring syntax in `ChainlinkAdapter.sol` so the focused Solidity tests can compile.

Verification:
- `npx hardhat test test\TaskRouterMultisig.test.js` (4 passing)
- `npx hardhat compile` (Nothing to compile after successful test compile)
- `node --check test\TaskRouterMultisig.test.js`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.