### PR TITLE
fix: harden nft marketplace listings

### DIFF
--- a/contracts/nft/NFTMarketplace.sol
+++ b/contracts/nft/NFTMarketplace.sol
@@ -7,15 +7,32 @@ interface IERC721 {
     function getApproved(uint256 tokenId) external view returns (address);
 }
 
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+interface IERC2981 {
+    function royaltyInfo(
+        uint256 tokenId,
+        uint256 salePrice
+    ) external view returns (address receiver, uint256 royaltyAmount);
+}
+
 /// @title NFTMarketplace
 /// @notice Decentralized marketplace for listing, buying, and canceling NFT sales
 /// @dev Supports any ERC721-compliant NFT contract
 contract NFTMarketplace {
+    bytes4 private constant ERC2981_INTERFACE_ID = 0x2a55205a;
+    uint256 public constant DEFAULT_LISTING_DURATION = 7 days;
+    uint256 public constant CANCEL_DELAY = 5 minutes;
+
     struct Listing {
         address seller;
         address nftContract;
         uint256 tokenId;
         uint256 price;
+        uint256 expiresAt;
+        uint256 cancelAvailableAt;
         bool active;
     }
 
@@ -25,18 +42,39 @@ contract NFTMarketplace {
 
     mapping(uint256 => Listing) public listings;
 
-    event Listed(uint256 indexed listingId, address indexed seller, address nftContract, uint256 tokenId, uint256 price);
+    event Listed(
+        uint256 indexed listingId,
+        address indexed seller,
+        address nftContract,
+        uint256 tokenId,
+        uint256 price,
+        uint256 expiresAt
+    );
     event Sold(uint256 indexed listingId, address indexed buyer, uint256 price);
+    event CancelRequested(uint256 indexed listingId, uint256 cancelAvailableAt);
     event Canceled(uint256 indexed listingId);
+    event RoyaltyPaid(uint256 indexed listingId, address indexed receiver, uint256 amount);
 
     constructor(uint256 _platformFee, address _feeRecipient) {
+        require(_platformFee <= 10000, "Fee too high");
+        require(_feeRecipient != address(0), "Zero fee recipient");
         platformFee = _platformFee;
         feeRecipient = _feeRecipient;
     }
 
-    // BUG: Price can be zero — allows listings with price 0, meaning NFTs can
-    // be "sold" for free and the platform earns no fee
     function listNFT(address nftContract, uint256 tokenId, uint256 price) external returns (uint256) {
+        return listNFTWithExpiry(nftContract, tokenId, price, block.timestamp + DEFAULT_LISTING_DURATION);
+    }
+
+    function listNFTWithExpiry(
+        address nftContract,
+        uint256 tokenId,
+        uint256 price,
+        uint256 expiresAt
+    ) public returns (uint256) {
+        require(price > 0, "Zero price");
+        require(expiresAt > block.timestamp, "Invalid expiry");
+
         IERC721 nft = IERC721(nftContract);
         require(nft.ownerOf(tokenId) == msg.sender, "Not NFT owner");
         require(
@@ -50,26 +88,36 @@ contract NFTMarketplace {
             nftContract: nftContract,
             tokenId: tokenId,
             price: price,
+            expiresAt: expiresAt,
+            cancelAvailableAt: 0,
             active: true
         });
 
-        emit Listed(listingId, msg.sender, nftContract, tokenId, price);
+        emit Listed(listingId, msg.sender, nftContract, tokenId, price, expiresAt);
         return listingId;
     }
 
-    // BUG: Seller can front-run cancel after buyer's tx is in mempool —
-    // seller sees buy tx, quickly cancels to re-list at higher price (no commit-reveal)
-    // BUG: No royalty payment — original creator receives nothing on secondary sales,
-    // violating ERC-2981 royalty standard expectations
     function buyNFT(uint256 listingId) external payable {
         Listing storage listing = listings[listingId];
         require(listing.active, "Not active");
+        require(block.timestamp <= listing.expiresAt, "Listing expired");
         require(msg.value == listing.price, "Wrong price");
 
         listing.active = false;
 
         uint256 fee = (msg.value * platformFee) / 10000;
         uint256 sellerProceeds = msg.value - fee;
+        (address royaltyReceiver, uint256 royaltyAmount) = _royaltyInfo(
+            listing.nftContract,
+            listing.tokenId,
+            msg.value
+        );
+        if (royaltyReceiver != address(0) && royaltyAmount > 0) {
+            require(royaltyAmount <= sellerProceeds, "Royalty exceeds proceeds");
+            sellerProceeds -= royaltyAmount;
+        } else {
+            royaltyAmount = 0;
+        }
 
         IERC721(listing.nftContract).transferFrom(
             listing.seller,
@@ -77,19 +125,31 @@ contract NFTMarketplace {
             listing.tokenId
         );
 
-        (bool feeSent, ) = feeRecipient.call{value: fee}("");
-        require(feeSent, "Fee transfer failed");
-
-        (bool sellerSent, ) = listing.seller.call{value: sellerProceeds}("");
-        require(sellerSent, "Seller transfer failed");
+        _sendValue(feeRecipient, fee, "Fee transfer failed");
+        if (royaltyAmount > 0) {
+            _sendValue(royaltyReceiver, royaltyAmount, "Royalty transfer failed");
+            emit RoyaltyPaid(listingId, royaltyReceiver, royaltyAmount);
+        }
+        _sendValue(listing.seller, sellerProceeds, "Seller transfer failed");
 
         emit Sold(listingId, msg.sender, msg.value);
+    }
+
+    function requestCancel(uint256 listingId) external {
+        Listing storage listing = listings[listingId];
+        require(listing.active, "Not active");
+        require(listing.seller == msg.sender, "Not seller");
+
+        listing.cancelAvailableAt = block.timestamp + CANCEL_DELAY;
+        emit CancelRequested(listingId, listing.cancelAvailableAt);
     }
 
     function cancelListing(uint256 listingId) external {
         Listing storage listing = listings[listingId];
         require(listing.active, "Not active");
         require(listing.seller == msg.sender, "Not seller");
+        require(listing.cancelAvailableAt != 0, "Cancel not requested");
+        require(block.timestamp >= listing.cancelAvailableAt, "Cancel delay active");
 
         listing.active = false;
         emit Canceled(listingId);
@@ -97,5 +157,36 @@ contract NFTMarketplace {
 
     function getListing(uint256 listingId) external view returns (Listing memory) {
         return listings[listingId];
+    }
+
+    function _royaltyInfo(
+        address nftContract,
+        uint256 tokenId,
+        uint256 salePrice
+    ) internal view returns (address receiver, uint256 amount) {
+        try IERC165(nftContract).supportsInterface(ERC2981_INTERFACE_ID) returns (bool supported) {
+            if (!supported) {
+                return (address(0), 0);
+            }
+        } catch {
+            return (address(0), 0);
+        }
+
+        try IERC2981(nftContract).royaltyInfo(tokenId, salePrice) returns (
+            address royaltyReceiver,
+            uint256 royaltyAmount
+        ) {
+            return (royaltyReceiver, royaltyAmount);
+        } catch {
+            return (address(0), 0);
+        }
+    }
+
+    function _sendValue(address recipient, uint256 amount, string memory errorMessage) internal {
+        if (amount == 0) {
+            return;
+        }
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, errorMessage);
     }
 }

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockRoyaltyNFT.sol
+++ b/contracts/test/MockRoyaltyNFT.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/common/ERC2981.sol";
+
+contract MockRoyaltyNFT is ERC721, ERC2981 {
+    constructor() ERC721("Royalty NFT", "RNFT") {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function setTokenRoyalty(address receiver, uint96 feeNumerator) external {
+        _setTokenRoyalty(1, receiver, feeNumerator);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC2981) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/NFTMarketplace.test.js
+++ b/test/NFTMarketplace.test.js
@@ -1,0 +1,89 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+describe("NFTMarketplace hardening", function () {
+  let market;
+  let nft;
+  let seller;
+  let buyer;
+  let feeRecipient;
+  let royaltyReceiver;
+
+  beforeEach(async function () {
+    [seller, buyer, feeRecipient, royaltyReceiver] = await ethers.getSigners();
+
+    const MockRoyaltyNFT = await ethers.getContractFactory("MockRoyaltyNFT");
+    nft = await MockRoyaltyNFT.deploy();
+    await nft.waitForDeployment();
+
+    const NFTMarketplace = await ethers.getContractFactory("NFTMarketplace");
+    market = await NFTMarketplace.deploy(250, feeRecipient.address);
+    await market.waitForDeployment();
+
+    await nft.mint(seller.address, 1);
+    await nft.connect(seller).approve(await market.getAddress(), 1);
+  });
+
+  async function list(price, expiresAt = undefined) {
+    if (expiresAt === undefined) {
+      const tx = await market.connect(seller).listNFT(await nft.getAddress(), 1, price);
+      const receipt = await tx.wait();
+      return receipt.logs.find((log) => log.fragment && log.fragment.name === "Listed").args.listingId;
+    }
+
+    const tx = await market.connect(seller).listNFTWithExpiry(await nft.getAddress(), 1, price, expiresAt);
+    const receipt = await tx.wait();
+    return receipt.logs.find((log) => log.fragment && log.fragment.name === "Listed").args.listingId;
+  }
+
+  it("rejects zero-price listings", async function () {
+    await expect(market.connect(seller).listNFT(await nft.getAddress(), 1, 0))
+      .to.be.revertedWith("Zero price");
+  });
+
+  it("requires delayed cancellation before canceling a listing", async function () {
+    const listingId = await list(ethers.parseEther("1"));
+
+    await expect(market.connect(seller).cancelListing(listingId))
+      .to.be.revertedWith("Cancel not requested");
+
+    await market.connect(seller).requestCancel(listingId);
+    await expect(market.connect(seller).cancelListing(listingId))
+      .to.be.revertedWith("Cancel delay active");
+
+    await network.provider.send("evm_increaseTime", [301]);
+    await network.provider.send("evm_mine");
+
+    await expect(market.connect(seller).cancelListing(listingId))
+      .to.emit(market, "Canceled")
+      .withArgs(listingId);
+  });
+
+  it("pays ERC-2981 royalties before seller proceeds", async function () {
+    await nft.setTokenRoyalty(royaltyReceiver.address, 1000);
+    const price = ethers.parseEther("1");
+    const fee = price * 250n / 10000n;
+    const royalty = price * 1000n / 10000n;
+    const sellerProceeds = price - fee - royalty;
+    const listingId = await list(price);
+
+    await expect(() => market.connect(buyer).buyNFT(listingId, { value: price }))
+      .to.changeEtherBalances(
+        [feeRecipient, royaltyReceiver, seller],
+        [fee, royalty, sellerProceeds]
+      );
+
+    expect(await nft.ownerOf(1)).to.equal(buyer.address);
+  });
+
+  it("blocks expired listing purchases", async function () {
+    const latest = await ethers.provider.getBlock("latest");
+    const listingId = await list(ethers.parseEther("1"), latest.timestamp + 60);
+
+    await network.provider.send("evm_setNextBlockTimestamp", [latest.timestamp + 61]);
+    await network.provider.send("evm_mine");
+
+    await expect(market.connect(buyer).buyNFT(listingId, { value: ethers.parseEther("1") }))
+      .to.be.revertedWith("Listing expired");
+  });
+});


### PR DESCRIPTION
Fixes #18
/claim #18

Summary:
- Rejects zero-price listings and gives each listing an explicit expiry.
- Replaces immediate seller cancellation with two-step delayed cancellation (`requestCancel` then `cancelListing`) to prevent same-block/mempool cancel front-running.
- Adds ERC-2981 royalty detection and payout before seller proceeds, with malformed/unsupported royalty contracts gracefully ignored.
- Adds focused tests for zero-price rejection, delayed cancellation, royalty payout, and expired-listing purchase rejection.
- Updates Hardhat compiler settings for the repo's OpenZeppelin v5 imports and fixes the existing tuple destructuring syntax in `ChainlinkAdapter.sol` so the focused Solidity tests can compile.

Verification:
- `npx hardhat test test\NFTMarketplace.test.js` (4 passing)
- `npx hardhat compile` (Nothing to compile after successful test compile)
- `node --check test\NFTMarketplace.test.js`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.