### PR TITLE
fix: snapshot governance voting power

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -18,6 +18,7 @@ contract GovernorAlpha is ReentrancyGuard {
         bytes[] calldatas;
         uint256 startBlock;
         uint256 endBlock;
+        uint256 snapshotBlock;
         uint256 forVotes;
         uint256 againstVotes;
         bool executed;
@@ -62,6 +63,7 @@ contract GovernorAlpha is ReentrancyGuard {
         p.targets = targets;
         p.values = values;
         p.calldatas = calldatas;
+        p.snapshotBlock = block.number;
         p.startBlock = block.number + VOTING_DELAY;
         p.endBlock = block.number + VOTING_DELAY + VOTING_PERIOD;
 
@@ -79,7 +81,7 @@ contract GovernorAlpha is ReentrancyGuard {
         require(!p.hasVoted[tx.origin], "Governor: already voted");
         p.hasVoted[tx.origin] = true;
 
-        uint256 weight = token.getPastVotes(tx.origin, p.startBlock);
+        uint256 weight = getVotingPower(tx.origin, proposalId);
         if (support) {
             p.forVotes += weight;
         } else {
@@ -118,6 +120,18 @@ contract GovernorAlpha is ReentrancyGuard {
         require(!p.executed, "Governor: already executed");
         p.canceled = true;
         emit ProposalCanceled(proposalId);
+    }
+
+    function getVotingPower(address account, uint256 proposalId) public view returns (uint256) {
+        Proposal storage p = proposals[proposalId];
+        require(p.id != 0, "Governor: unknown proposal");
+        return token.getPastVotes(account, p.snapshotBlock);
+    }
+
+    function proposalSnapshotBlock(uint256 proposalId) external view returns (uint256) {
+        Proposal storage p = proposals[proposalId];
+        require(p.id != 0, "Governor: unknown proposal");
+        return p.snapshotBlock;
     }
 
     receive() external payable {}

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockCheckpointVotes.sol
+++ b/contracts/test/MockCheckpointVotes.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockCheckpointVotes {
+    mapping(address => uint256) public votes;
+    mapping(address => mapping(uint256 => uint256)) public checkpoints;
+
+    function setVotes(address account, uint256 amount) external {
+        votes[account] = amount;
+        checkpoints[account][block.number] = amount;
+    }
+
+    function getVotes(address account) external view returns (uint256) {
+        return votes[account];
+    }
+
+    function getPastVotes(address account, uint256 blockNumber) external view returns (uint256) {
+        for (uint256 i = blockNumber + 1; i > 0; i--) {
+            uint256 checkpointBlock = i - 1;
+            uint256 checkpointVotes = checkpoints[account][checkpointBlock];
+            if (checkpointVotes != 0 || checkpointBlock == 0) {
+                return checkpointVotes;
+            }
+        }
+        return 0;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/GovernorAlphaSnapshot.test.js
+++ b/test/GovernorAlphaSnapshot.test.js
@@ -1,0 +1,65 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+describe("GovernorAlpha proposal snapshots", function () {
+  let token;
+  let governor;
+  let proposer;
+  let lateBuyer;
+  let target;
+
+  beforeEach(async function () {
+    [proposer, lateBuyer, target] = await ethers.getSigners();
+
+    const MockCheckpointVotes = await ethers.getContractFactory("MockCheckpointVotes");
+    token = await MockCheckpointVotes.deploy();
+    await token.waitForDeployment();
+
+    const GovernorAlpha = await ethers.getContractFactory("GovernorAlpha");
+    governor = await GovernorAlpha.deploy(await token.getAddress());
+    await governor.waitForDeployment();
+
+    await token.setVotes(proposer.address, ethers.parseEther("500000"));
+  });
+
+  async function createProposal() {
+    const tx = await governor.connect(proposer).propose([target.address], [0], ["0x"]);
+    const receipt = await tx.wait();
+    const event = receipt.logs.find((log) => log.fragment && log.fragment.name === "ProposalCreated");
+    return event.args.id;
+  }
+
+  it("stores the proposal creation block as the snapshot", async function () {
+    const proposalId = await createProposal();
+    const receiptBlock = await ethers.provider.getBlock("latest");
+
+    expect(await governor.proposalSnapshotBlock(proposalId)).to.equal(receiptBlock.number);
+    expect(await governor.getVotingPower(proposer.address, proposalId))
+      .to.equal(ethers.parseEther("500000"));
+  });
+
+  it("ignores tokens acquired after proposal creation", async function () {
+    const proposalId = await createProposal();
+
+    await token.setVotes(lateBuyer.address, ethers.parseEther("500000"));
+    await network.provider.send("hardhat_mine", ["0x2"]);
+    await governor.connect(lateBuyer).vote(proposalId, true);
+
+    expect(await governor.getVotingPower(lateBuyer.address, proposalId)).to.equal(0);
+    const proposal = await governor.proposals(proposalId);
+    expect(proposal.forVotes).to.equal(0);
+  });
+
+  it("keeps original voting power after later balance loss", async function () {
+    const proposalId = await createProposal();
+
+    await token.setVotes(proposer.address, 0);
+    await network.provider.send("hardhat_mine", ["0x2"]);
+    await governor.connect(proposer).vote(proposalId, true);
+
+    expect(await governor.getVotingPower(proposer.address, proposalId))
+      .to.equal(ethers.parseEther("500000"));
+    const proposal = await governor.proposals(proposalId);
+    expect(proposal.forVotes).to.equal(ethers.parseEther("500000"));
+  });
+});


### PR DESCRIPTION
Fixes #149
/claim #149

Summary:
- Stores `snapshotBlock` on each proposal at proposal creation time.
- Adds `getVotingPower(account, proposalId)` and `proposalSnapshotBlock(proposalId)` helpers.
- Changes vote weight lookup to use the proposal creation snapshot block rather than the later voting start block.
- Adds focused tests proving post-creation token acquisition has no effect, later balance loss does not reduce snapshot voting power, and the snapshot block is stored correctly.
- Updates Hardhat compiler settings for the repo's OpenZeppelin v5 imports and fixes the existing tuple destructuring syntax in `ChainlinkAdapter.sol` so the focused Solidity tests can compile.

Verification:
- `npx hardhat test test\GovernorAlphaSnapshot.test.js` (3 passing)
- `npx hardhat compile` (Nothing to compile after successful test compile)
- `node --check test\GovernorAlphaSnapshot.test.js`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.