### PR TITLE
fix: store received escrow amount

### DIFF
--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PaymentEscrow is Ownable {
+    using SafeERC20 for IERC20;
+
     struct Escrow {
         address payer;
         address payee;
@@ -33,20 +36,24 @@ contract PaymentEscrow is Ownable {
         require(payee != address(0), "Invalid payee");
         require(amount > 0, "Amount must be > 0");
 
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20 escrowToken = IERC20(token);
+        uint256 balanceBefore = escrowToken.balanceOf(address(this));
+        escrowToken.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = escrowToken.balanceOf(address(this)) - balanceBefore;
+        require(received > 0, "No tokens received");
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
             payer: msg.sender,
             payee: payee,
             token: token,
-            amount: amount,
+            amount: received,
             releaseTime: block.timestamp + lockDuration,
             released: false,
             refunded: false
         });
 
-        emit EscrowCreated(escrowId, msg.sender, amount);
+        emit EscrowCreated(escrowId, msg.sender, received);
         return escrowId;
     }
 
@@ -56,7 +63,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer || msg.sender == owner(), "Not authorized");
 
         escrow.released = true;
-        IERC20(escrow.token).transfer(escrow.payee, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payee, escrow.amount);
 
         emit EscrowReleased(escrowId, escrow.payee, escrow.amount);
     }
@@ -68,7 +75,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer, "Not payer");
 
         escrow.refunded = true;
-        IERC20(escrow.token).transfer(escrow.payer, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payer, escrow.amount);
 
         emit EscrowRefunded(escrowId, escrow.payer, escrow.amount);
     }

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockFeeOnTransferToken.sol
+++ b/contracts/test/MockFeeOnTransferToken.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferToken is ERC20 {
+    uint256 public feeBps;
+
+    constructor(uint256 feeBps_) ERC20("Fee Token", "FEE") {
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 fee = (value * feeBps) / 10_000;
+        uint256 net = value - fee;
+        super._update(from, address(0), fee);
+        super._update(from, to, net);
+    }
+}

--- a/contracts/test/MockPlainERC20.sol
+++ b/contracts/test/MockPlainERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockPlainERC20 is ERC20 {
+    constructor() ERC20("Plain Token", "PLN") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/PaymentEscrowReceivedAmount.test.js
+++ b/test/PaymentEscrowReceivedAmount.test.js
@@ -1,0 +1,87 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+describe("PaymentEscrow received amount accounting", function () {
+  let escrow;
+  let plainToken;
+  let feeToken;
+  let payer;
+  let payee;
+
+  beforeEach(async function () {
+    [payer, payee] = await ethers.getSigners();
+
+    const PaymentEscrow = await ethers.getContractFactory("PaymentEscrow");
+    escrow = await PaymentEscrow.deploy();
+    await escrow.waitForDeployment();
+
+    const MockPlainERC20 = await ethers.getContractFactory("MockPlainERC20");
+    plainToken = await MockPlainERC20.deploy();
+    await plainToken.waitForDeployment();
+
+    const MockFeeOnTransferToken = await ethers.getContractFactory("MockFeeOnTransferToken");
+    feeToken = await MockFeeOnTransferToken.deploy(1000);
+    await feeToken.waitForDeployment();
+
+    await plainToken.mint(payer.address, ethers.parseEther("100"));
+    await feeToken.mint(payer.address, ethers.parseEther("100"));
+  });
+
+  it("rejects zero amount escrows", async function () {
+    await expect(escrow.createEscrow(payee.address, await plainToken.getAddress(), 0, 0))
+      .to.be.revertedWith("Amount must be > 0");
+  });
+
+  it("stores the full amount for normal ERC20 deposits", async function () {
+    const amount = ethers.parseEther("10");
+    await plainToken.approve(await escrow.getAddress(), amount);
+
+    await expect(escrow.createEscrow(payee.address, await plainToken.getAddress(), amount, 0))
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0, payer.address, amount);
+
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(amount);
+  });
+
+  it("stores actual received balance delta for fee-on-transfer tokens", async function () {
+    const amount = ethers.parseEther("10");
+    const expectedReceived = ethers.parseEther("9");
+    await feeToken.approve(await escrow.getAddress(), amount);
+
+    await expect(escrow.createEscrow(payee.address, await feeToken.getAddress(), amount, 0))
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0, payer.address, expectedReceived);
+
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(expectedReceived);
+    expect(await feeToken.balanceOf(await escrow.getAddress())).to.equal(expectedReceived);
+  });
+
+  it("releases only the received amount", async function () {
+    const amount = ethers.parseEther("10");
+    const expectedReceived = ethers.parseEther("9");
+    await feeToken.approve(await escrow.getAddress(), amount);
+    await escrow.createEscrow(payee.address, await feeToken.getAddress(), amount, 0);
+
+    await escrow.releaseEscrow(0);
+
+    expect(await feeToken.balanceOf(payee.address)).to.equal(ethers.parseEther("8.1"));
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(expectedReceived);
+  });
+
+  it("refunds only the received amount after lock expiry", async function () {
+    const amount = ethers.parseEther("10");
+    const expectedReceived = ethers.parseEther("9");
+    await feeToken.approve(await escrow.getAddress(), amount);
+    await escrow.createEscrow(payee.address, await feeToken.getAddress(), amount, 60);
+
+    await network.provider.send("evm_increaseTime", [61]);
+    await network.provider.send("evm_mine");
+
+    await expect(escrow.refundEscrow(0))
+      .to.emit(escrow, "EscrowRefunded")
+      .withArgs(0, payer.address, expectedReceived);
+  });
+});


### PR DESCRIPTION
Fixes #179
/claim #179

Summary:
- Keeps the zero-amount guard and changes escrow accounting to store the actual token balance delta received by the contract.
- Uses `SafeERC20` for deposits, releases, and refunds so non-standard/failed token transfers are handled safely.
- Emits/stores the received amount for fee-on-transfer tokens instead of the requested input amount.
- Adds focused tests for zero amount rejection, normal ERC20 deposits, fee-on-transfer received amount accounting, release behavior, and refund behavior.
- Updates Hardhat compiler settings for the repo's OpenZeppelin v5 imports and fixes the existing tuple destructuring syntax in `ChainlinkAdapter.sol` so the focused Solidity tests can compile.

Verification:
- `npx hardhat test test\PaymentEscrowReceivedAmount.test.js` (5 passing)
- `npx hardhat compile` (Nothing to compile after successful test compile)
- `node --check test\PaymentEscrowReceivedAmount.test.js`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.