### PR TITLE
fix: add emergency staking withdrawal

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -37,6 +37,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
+    event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
 
     // BUG: Missing zero-address validation — rewardToken can be set to address(0),
     // causing all reward transfers to silently burn tokens or revert unpredictably.
@@ -130,6 +131,22 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
         user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
         emit Withdraw(msg.sender, pid, amount);
+    }
+
+    /// @notice Withdraw all staked tokens from a pool without claiming rewards.
+    /// @param pid Pool ID.
+    function emergencyWithdraw(uint256 pid) external nonReentrant {
+        PoolInfo storage pool = poolInfo[pid];
+        UserInfo storage user = userInfo[pid][msg.sender];
+        uint256 amount = user.amount;
+        require(amount > 0, "MultiStaking: nothing to withdraw");
+
+        user.amount = 0;
+        user.rewardDebt = 0;
+        pool.totalStaked -= amount;
+
+        pool.stakeToken.safeTransfer(msg.sender, amount);
+        emit EmergencyWithdraw(msg.sender, pid, amount);
     }
 
     /// @notice View pending rewards for a user in a pool.

--- a/contracts/test/MockPlainERC20.sol
+++ b/contracts/test/MockPlainERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockPlainERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/MultiTokenStakingEmergencyWithdraw.test.js
+++ b/test/MultiTokenStakingEmergencyWithdraw.test.js
@@ -1,0 +1,56 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+describe("MultiTokenStaking emergencyWithdraw", function () {
+  let staking;
+  let stakeToken;
+  let rewardToken;
+  let owner;
+  let staker;
+
+  beforeEach(async function () {
+    [owner, staker] = await ethers.getSigners();
+
+    const MockPlainERC20 = await ethers.getContractFactory("MockPlainERC20");
+    stakeToken = await MockPlainERC20.deploy("Stake Token", "STK");
+    await stakeToken.waitForDeployment();
+    rewardToken = await MockPlainERC20.deploy("Reward Token", "RWD");
+    await rewardToken.waitForDeployment();
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    staking = await MultiTokenStaking.deploy(await rewardToken.getAddress(), ethers.parseEther("1"));
+    await staking.waitForDeployment();
+
+    await staking.addPool(100, await stakeToken.getAddress());
+    await stakeToken.mint(staker.address, ethers.parseEther("100"));
+    await rewardToken.mint(await staking.getAddress(), ethers.parseEther("1000"));
+  });
+
+  it("returns principal without rewards and updates accounting", async function () {
+    const amount = ethers.parseEther("10");
+    await stakeToken.connect(staker).approve(await staking.getAddress(), amount);
+    await staking.connect(staker).deposit(0, amount);
+
+    await network.provider.send("evm_increaseTime", [3600]);
+    await network.provider.send("evm_mine");
+
+    expect(await staking.pendingReward(0, staker.address)).to.be.gt(0);
+
+    await expect(staking.connect(staker).emergencyWithdraw(0))
+      .to.emit(staking, "EmergencyWithdraw")
+      .withArgs(staker.address, 0, amount);
+
+    const user = await staking.userInfo(0, staker.address);
+    const pool = await staking.poolInfo(0);
+    expect(user.amount).to.equal(0);
+    expect(user.rewardDebt).to.equal(0);
+    expect(pool.totalStaked).to.equal(0);
+    expect(await stakeToken.balanceOf(staker.address)).to.equal(ethers.parseEther("100"));
+    expect(await rewardToken.balanceOf(staker.address)).to.equal(0);
+  });
+
+  it("reverts when the user has no stake", async function () {
+    await expect(staking.connect(staker).emergencyWithdraw(0))
+      .to.be.revertedWith("MultiStaking: nothing to withdraw");
+  });
+});


### PR DESCRIPTION
Fixes #195
/claim #195

Summary:
- Adds `emergencyWithdraw(uint256 pid)` to return a user's staked tokens without harvesting rewards.
- Resets the user's `amount` and `rewardDebt` to zero and decrements the pool `totalStaked` accounting before transfer.
- Emits `EmergencyWithdraw(user, pid, amount)` and reverts when there is no stake to recover.
- Adds focused tests for normal stake then emergency withdraw, no reward distribution, accounting reset, pool total update, event emission, and empty-withdraw rejection.
- Updates Hardhat compiler settings for the repo's OpenZeppelin v5 imports and fixes the existing tuple destructuring syntax in `ChainlinkAdapter.sol` so the focused Solidity tests can compile.

Verification:
- `npx hardhat test test\MultiTokenStakingEmergencyWithdraw.test.js` (2 passing)
- `npx hardhat compile` (Nothing to compile after successful test compile)
- `node --check test\MultiTokenStakingEmergencyWithdraw.test.js`
- `git diff --check` (only Git LF-to-CRLF warnings for edited files)

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

No private prompt/session initialization text is included in source, comments, or metadata.