### PR TITLE
Fix AMMPool indexed indexer events

### DIFF
--- a/contracts/dex/AMMPool.sol
+++ b/contracts/dex/AMMPool.sol
@@ -23,7 +23,10 @@ contract AMMPool {
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB);
-    event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event Swap(address indexed user, address indexed tokenIn, uint256 amountIn, uint256 amountOut);
+    event Sync(uint256 reserveA, uint256 reserveB);
+    event Mint(address indexed sender, uint256 amountA, uint256 amountB);
+    event Burn(address indexed sender, uint256 amountA, uint256 amountB, address indexed to);
 
     constructor(address _tokenA, address _tokenB) {
         tokenA = IERC20(_tokenA);
@@ -53,6 +56,8 @@ contract AMMPool {
         totalLiquidity += lpTokens;
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
+        emit Mint(msg.sender, amountA, amountB);
+        emit Sync(reserveA, reserveB);
     }
 
     function removeLiquidity(uint256 lpTokens) external {
@@ -70,6 +75,8 @@ contract AMMPool {
         require(tokenB.transfer(msg.sender, amountB), "Transfer B failed");
 
         emit LiquidityRemoved(msg.sender, amountA, amountB);
+        emit Burn(msg.sender, amountA, amountB, msg.sender);
+        emit Sync(reserveA, reserveB);
     }
 
     // BUG: Swap has no deadline parameter — transaction can sit in mempool and execute
@@ -103,6 +110,7 @@ contract AMMPool {
         }
 
         emit Swap(msg.sender, tokenIn, amountIn, amountOut);
+        emit Sync(reserveA, reserveB);
     }
 
     function _sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/AMMPoolEvents.test.js
+++ b/test/AMMPoolEvents.test.js
@@ -1,0 +1,75 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AMMPool indexer events", function () {
+  async function deployPool() {
+    const [lp, trader] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const tokenA = await Token.deploy("Token A", "TKNA");
+    const tokenB = await Token.deploy("Token B", "TKNB");
+    await tokenA.waitForDeployment();
+    await tokenB.waitForDeployment();
+
+    const Pool = await ethers.getContractFactory("AMMPool");
+    const pool = await Pool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    await pool.waitForDeployment();
+
+    for (const token of [tokenA, tokenB]) {
+      await token.mint(lp.address, ethers.parseEther("2000"));
+      await token.mint(trader.address, ethers.parseEther("100"));
+      await token.connect(lp).approve(await pool.getAddress(), ethers.MaxUint256);
+      await token.connect(trader).approve(await pool.getAddress(), ethers.MaxUint256);
+    }
+
+    return { pool, tokenA, tokenB, lp, trader };
+  }
+
+  async function seedLiquidity(pool, tokenA, tokenB, lp) {
+    const amountA = ethers.parseEther("1000");
+    const amountB = ethers.parseEther("1000");
+    await pool.connect(lp).addLiquidity(amountA, amountB);
+    return { amountA, amountB };
+  }
+
+  it("marks Swap user and tokenIn as indexed and emits Sync after swaps", async function () {
+    const { pool, tokenA, tokenB, lp, trader } = await deployPool();
+    const swapEvent = pool.interface.getEvent("Swap");
+    expect(swapEvent.inputs[0].indexed).to.equal(true);
+    expect(swapEvent.inputs[1].indexed).to.equal(true);
+
+    const { amountA, amountB } = await seedLiquidity(pool, tokenA, tokenB, lp);
+    const amountIn = ethers.parseEther("10");
+    const tokenAAddress = await tokenA.getAddress();
+    const amountOut = await pool.connect(trader).swap.staticCall(tokenAAddress, amountIn, 0);
+
+    await expect(pool.connect(trader).swap(tokenAAddress, amountIn, 0))
+      .to.emit(pool, "Swap")
+      .withArgs(trader.address, tokenAAddress, amountIn, amountOut)
+      .and.to.emit(pool, "Sync")
+      .withArgs(amountA + amountIn, amountB - amountOut);
+  });
+
+  it("emits Mint, Burn, and Sync for liquidity changes", async function () {
+    const { pool, tokenA, tokenB, lp } = await deployPool();
+    const amountA = ethers.parseEther("1000");
+    const amountB = ethers.parseEther("1000");
+
+    await expect(pool.connect(lp).addLiquidity(amountA, amountB))
+      .to.emit(pool, "Mint")
+      .withArgs(lp.address, amountA, amountB)
+      .and.to.emit(pool, "Sync")
+      .withArgs(amountA, amountB);
+
+    const lpTokens = await pool.liquidity(lp.address);
+    const burnTokens = lpTokens / 2n;
+    const expectedAmountA = amountA / 2n;
+    const expectedAmountB = amountB / 2n;
+
+    await expect(pool.connect(lp).removeLiquidity(burnTokens))
+      .to.emit(pool, "Burn")
+      .withArgs(lp.address, expectedAmountA, expectedAmountB, lp.address)
+      .and.to.emit(pool, "Sync")
+      .withArgs(amountA - expectedAmountA, amountB - expectedAmountB);
+  });
+});


### PR DESCRIPTION
## Summary
- Indexes both `user` and `tokenIn` on the AMMPool `Swap` event for efficient filtering.
- Emits `Sync` after reserve changes and adds `Mint`/`Burn` liquidity events while preserving the existing liquidity events.
- Adds focused Hardhat coverage for event ABI indexing and emitted swap/liquidity events.

/claim #165

Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Verification:
- `npx hardhat test test\AMMPoolEvents.test.js`
- `npx hardhat compile`
- `node --check test\AMMPoolEvents.test.js`
- `git diff --check` (only existing LF-to-CRLF warnings)
- Prompt/session leak scan over modified files: no private instruction text found

Security note: no private prompt/session initialization text is included in source, comments, CONTRIBUTORS, or metadata. The requested contributor/platform-instructions records were omitted because they would expose private session instructions.