### PR TITLE
Fix PrizeSplit pull claim expiry and reclaim

### DIFF
--- a/contracts/lottery/PrizeSplit.sol
+++ b/contracts/lottery/PrizeSplit.sol
@@ -5,14 +5,20 @@ pragma solidity ^0.8.20;
 /// @notice Distributes prize pool among multiple winners with configurable shares
 /// @dev Winners claim their share after the admin finalizes the round
 contract PrizeSplit {
+    uint256 public constant CLAIM_DEADLINE = 90 days;
+
     address public admin;
+    address public treasury;
     uint256 public totalPrize;
     uint256 public roundId;
 
     struct Round {
         address[] winners;
         uint256 prizePool;
+        uint256 finalizedAt;
+        uint256 claimedTotal;
         bool finalized;
+        bool reclaimed;
         mapping(address => uint256) shares;
         mapping(address => bool) claimed;
     }
@@ -22,6 +28,7 @@ contract PrizeSplit {
     event RoundFunded(uint256 indexed roundId, uint256 amount);
     event RoundFinalized(uint256 indexed roundId, uint256 winnerCount);
     event PrizeClaimed(address indexed winner, uint256 amount, uint256 indexed roundId);
+    event UnclaimedPrizesReclaimed(uint256 indexed roundId, address indexed treasury, uint256 amount);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -30,6 +37,7 @@ contract PrizeSplit {
 
     constructor() {
         admin = msg.sender;
+        treasury = msg.sender;
     }
 
     function fundRound() external payable onlyAdmin {
@@ -39,15 +47,11 @@ contract PrizeSplit {
         emit RoundFunded(roundId, msg.value);
     }
 
-    // BUG: No zero-winner check — if winners array is empty, the function
-    // succeeds silently and the prize pool becomes permanently locked
     function finalizeRound(uint256 _roundId, address[] calldata winners) external onlyAdmin {
         Round storage round = rounds[_roundId];
         require(!round.finalized, "Already finalized");
         require(round.prizePool > 0, "No prize pool");
 
-        // BUG: Rounding error loses dust — integer division truncates remainder,
-        // so (prizePool % winners.length) wei is permanently locked in the contract
         uint256 sharePerWinner = round.prizePool / winners.length;
 
         for (uint256 i = 0; i < winners.length; i++) {
@@ -56,26 +60,42 @@ contract PrizeSplit {
         }
 
         round.finalized = true;
+        round.finalizedAt = block.timestamp;
         emit RoundFinalized(_roundId, winners.length);
     }
 
-    // BUG: Reentrancy — state (claimed flag) is set after the external call,
-    // allowing a malicious contract to re-enter claimPrize and drain funds
     function claimPrize(uint256 _roundId) external {
         Round storage round = rounds[_roundId];
         require(round.finalized, "Not finalized");
+        require(block.timestamp <= round.finalizedAt + CLAIM_DEADLINE, "Claim expired");
         require(round.shares[msg.sender] > 0, "No share");
         require(!round.claimed[msg.sender], "Already claimed");
 
         uint256 amount = round.shares[msg.sender];
+        round.claimed[msg.sender] = true;
+        round.claimedTotal += amount;
+        totalPrize -= amount;
 
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "Transfer failed");
 
-        // State updated after external call — reentrancy window
-        round.claimed[msg.sender] = true;
-
         emit PrizeClaimed(msg.sender, amount, _roundId);
+    }
+
+    function reclaimUnclaimedPrizes(uint256 _roundId) external onlyAdmin {
+        Round storage round = rounds[_roundId];
+        require(round.finalized, "Not finalized");
+        require(block.timestamp > round.finalizedAt + CLAIM_DEADLINE, "Claim active");
+        require(!round.reclaimed, "Already reclaimed");
+
+        uint256 amount = round.prizePool - round.claimedTotal;
+        round.reclaimed = true;
+        totalPrize -= amount;
+
+        (bool sent, ) = treasury.call{value: amount}("");
+        require(sent, "Treasury transfer failed");
+
+        emit UnclaimedPrizesReclaimed(_roundId, treasury, amount);
     }
 
     function getShare(uint256 _roundId, address winner) external view returns (uint256) {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/RejectEthWinner.sol
+++ b/contracts/test/RejectEthWinner.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IPrizeSplit {
+    function claimPrize(uint256 roundId) external;
+}
+
+contract RejectEthWinner {
+    function claimPrize(IPrizeSplit prizeSplit, uint256 roundId) external {
+        prizeSplit.claimPrize(roundId);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/PrizeSplitPullClaims.test.js
+++ b/test/PrizeSplitPullClaims.test.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PrizeSplit pull claims", function () {
+  const deadlineSeconds = 90 * 24 * 60 * 60;
+
+  async function deployPrizeSplit() {
+    const [admin, winner, otherWinner] = await ethers.getSigners();
+    const PrizeSplit = await ethers.getContractFactory("PrizeSplit");
+    const prizeSplit = await PrizeSplit.deploy();
+    await prizeSplit.waitForDeployment();
+
+    const RejectEthWinner = await ethers.getContractFactory("RejectEthWinner");
+    const rejectWinner = await RejectEthWinner.deploy();
+    await rejectWinner.waitForDeployment();
+
+    return { prizeSplit, rejectWinner, admin, winner, otherWinner };
+  }
+
+  async function fundAndFinalize(prizeSplit, winners, prize = ethers.parseEther("2")) {
+    await prizeSplit.fundRound({ value: prize });
+    const roundId = await prizeSplit.roundId();
+    await prizeSplit.finalizeRound(roundId, winners);
+    return roundId;
+  }
+
+  it("lets other winners claim when a contract winner rejects ETH", async function () {
+    const { prizeSplit, rejectWinner, winner } = await deployPrizeSplit();
+    const roundId = await fundAndFinalize(prizeSplit, [await rejectWinner.getAddress(), winner.address]);
+
+    await expect(rejectWinner.claimPrize(prizeSplit, roundId)).to.be.revertedWith("Transfer failed");
+    await expect(prizeSplit.connect(winner).claimPrize(roundId))
+      .to.emit(prizeSplit, "PrizeClaimed")
+      .withArgs(winner.address, ethers.parseEther("1"), roundId);
+
+    expect(await prizeSplit.isClaimed(roundId, winner.address)).to.equal(true);
+    expect(await prizeSplit.isClaimed(roundId, await rejectWinner.getAddress())).to.equal(false);
+  });
+
+  it("reclaims unclaimed prizes to treasury after the 90 day deadline", async function () {
+    const { prizeSplit, admin, winner, otherWinner } = await deployPrizeSplit();
+    const roundId = await fundAndFinalize(prizeSplit, [winner.address, otherWinner.address]);
+
+    await ethers.provider.send("evm_increaseTime", [deadlineSeconds + 1]);
+    await ethers.provider.send("evm_mine");
+
+    await expect(prizeSplit.connect(winner).claimPrize(roundId)).to.be.revertedWith("Claim expired");
+    await expect(prizeSplit.reclaimUnclaimedPrizes(roundId))
+      .to.emit(prizeSplit, "UnclaimedPrizesReclaimed")
+      .withArgs(roundId, admin.address, ethers.parseEther("2"));
+
+    expect(await ethers.provider.getBalance(await prizeSplit.getAddress())).to.equal(0n);
+    expect(await prizeSplit.totalPrize()).to.equal(0n);
+  });
+
+  it("reclaims only the remaining balance after partial claims", async function () {
+    const { prizeSplit, winner, otherWinner } = await deployPrizeSplit();
+    const roundId = await fundAndFinalize(prizeSplit, [winner.address, otherWinner.address]);
+
+    await prizeSplit.connect(winner).claimPrize(roundId);
+    await ethers.provider.send("evm_increaseTime", [deadlineSeconds + 1]);
+    await ethers.provider.send("evm_mine");
+
+    await expect(prizeSplit.reclaimUnclaimedPrizes(roundId))
+      .to.emit(prizeSplit, "UnclaimedPrizesReclaimed")
+      .withArgs(roundId, await prizeSplit.treasury(), ethers.parseEther("1"));
+
+    expect(await prizeSplit.totalPrize()).to.equal(0n);
+  });
+});


### PR DESCRIPTION
## Summary
- Moves PrizeSplit claim accounting before the external ETH transfer so a rejecting contract winner cannot affect other winners or reopen state.
- Adds a 90-day claim deadline and admin treasury reclaim for unclaimed prize balances.
- Adds focused Hardhat coverage for rejecting contract winners, deadline expiry, full reclaim, and partial-claim reclaim.

/claim #189

Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Verification:
- `npx hardhat test test\PrizeSplitPullClaims.test.js`
- `npx hardhat compile`
- `node --check test\PrizeSplitPullClaims.test.js`
- `git diff --check` (only existing LF-to-CRLF warnings)
- Prompt/session leak scan over modified files: no private instruction text found

Security note: no private prompt/session initialization text is included in source, comments, CONTRIBUTORS, or metadata. The requested contributor/platform-instructions records were omitted because they would expose private session instructions.