### PR TITLE
Add SDK contract deployment helper

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,19 @@ export interface AgentConfig {
   routerAddress: string;
 }
 
+export interface DeployContractOptions {
+  confirmations?: number;
+  overrides?: Record<string, unknown>;
+}
+
+export interface DeploymentResult<TContract = ethers.Contract> {
+  contract: TContract;
+  address: string;
+  transactionHash: string;
+  gasUsed: bigint;
+  receipt: ethers.TransactionReceipt;
+}
+
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
@@ -58,6 +71,36 @@ export class OpenAgentsSDK {
       ethers.toUtf8Bytes(result)
     );
     await tx.wait();
+  }
+
+  async deployContract<TContract = ethers.Contract>(
+    abi: ethers.InterfaceAbi,
+    bytecode: ethers.BytesLike | string,
+    args: unknown[] = [],
+    options: DeployContractOptions = {}
+  ): Promise<DeploymentResult<TContract>> {
+    const factory = new ethers.ContractFactory(abi, bytecode, this.signer);
+    const deployArgs = options.overrides ? [...args, options.overrides] : args;
+    const contract = await factory.deploy(...deployArgs);
+    await contract.waitForDeployment();
+
+    const deploymentTx = contract.deploymentTransaction();
+    if (!deploymentTx) {
+      throw new Error("Deployment transaction is unavailable");
+    }
+
+    const receipt = await deploymentTx.wait(options.confirmations ?? 1);
+    if (!receipt) {
+      throw new Error("Deployment receipt is unavailable");
+    }
+
+    return {
+      contract: contract as TContract,
+      address: await contract.getAddress(),
+      transactionHash: deploymentTx.hash,
+      gasUsed: receipt.gasUsed,
+      receipt,
+    };
   }
 
   async getOpenTasks(): Promise<any[]> {

--- a/test/SDKDeployHelpers.test.js
+++ b/test/SDKDeployHelpers.test.js
@@ -1,0 +1,113 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const vm = require("vm");
+
+function loadSdk(fakeEthers) {
+  const sourcePath = path.join(__dirname, "..", "sdk", "src", "index.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  }).outputText;
+
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require(name) {
+      if (name === "ethers") {
+        return { ethers: fakeEthers };
+      }
+      return require(name);
+    },
+  };
+  vm.runInNewContext(output, sandbox);
+  return sandbox.module.exports;
+}
+
+async function testDeployContractWithArgsAndConfirmations() {
+  const calls = {};
+  const fakeReceipt = { hash: "0xreceipt", gasUsed: 12345n };
+  const fakeContract = {
+    async waitForDeployment() {
+      calls.waitForDeployment = true;
+    },
+    deploymentTransaction() {
+      return {
+        hash: "0xdeploy",
+        async wait(confirmations) {
+          calls.confirmations = confirmations;
+          return fakeReceipt;
+        },
+      };
+    },
+    async getAddress() {
+      return "0x000000000000000000000000000000000000dEaD";
+    },
+  };
+
+  class FakeContractFactory {
+    constructor(abi, bytecode, signer) {
+      calls.abi = abi;
+      calls.bytecode = bytecode;
+      calls.signer = signer;
+    }
+
+    async deploy(...args) {
+      calls.deployArgs = args;
+      return fakeContract;
+    }
+  }
+
+  const fakeEthers = {
+    JsonRpcProvider: class FakeProvider {},
+    Wallet: class FakeWallet {
+      constructor(privateKey, provider) {
+        this.privateKey = privateKey;
+        this.provider = provider;
+      }
+    },
+    Contract: class FakeContract {},
+    ContractFactory: FakeContractFactory,
+  };
+
+  const { OpenAgentsSDK } = loadSdk(fakeEthers);
+  const sdk = new OpenAgentsSDK({
+    name: "agent",
+    endpoint: "https://agent.example",
+    privateKey: "0xabc",
+    rpcUrl: "http://127.0.0.1:8545",
+    registryAddress: "0x0000000000000000000000000000000000000001",
+    routerAddress: "0x0000000000000000000000000000000000000002",
+  });
+
+  const result = await sdk.deployContract(
+    ["constructor(uint256,string)"],
+    "0x60006000",
+    [42n, "hello"],
+    { confirmations: 3, overrides: { value: 10n } }
+  );
+
+  assert.deepStrictEqual(calls.abi, ["constructor(uint256,string)"]);
+  assert.strictEqual(calls.bytecode, "0x60006000");
+  assert.deepStrictEqual(calls.deployArgs, [42n, "hello", { value: 10n }]);
+  assert.strictEqual(calls.waitForDeployment, true);
+  assert.strictEqual(calls.confirmations, 3);
+  assert.strictEqual(result.contract, fakeContract);
+  assert.strictEqual(result.address, "0x000000000000000000000000000000000000dEaD");
+  assert.strictEqual(result.transactionHash, "0xdeploy");
+  assert.strictEqual(result.gasUsed, 12345n);
+  assert.strictEqual(result.receipt, fakeReceipt);
+}
+
+testDeployContractWithArgsAndConfirmations()
+  .then(() => console.log("SDK deploy helper tests passed"))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- Adds `deployContract(abi, bytecode, args, options)` to `OpenAgentsSDK` using `ethers.ContractFactory`.
- Waits for deployment and configurable confirmation count before returning metadata.
- Returns the deployed contract instance plus address, deployment transaction hash, gas used, and receipt.
- Adds a focused Node unit test with a mocked ethers factory covering constructor args, overrides, confirmations, and metadata.

/claim #199

Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Verification:
- `node test\SDKDeployHelpers.test.js`
- `node --check test\SDKDeployHelpers.test.js`
- TypeScript transpile check for `sdk/src/index.ts`
- `git diff --check` (only existing LF-to-CRLF warning)
- Prompt/session leak scan over modified files: no private instruction text found

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested contributor-info block was omitted because it would expose private session instructions.