### PR TITLE
Add SDK event subscription helper

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,24 @@ export interface AgentConfig {
   routerAddress: string;
 }
 
+export interface EventSubscriptionOptions {
+  indexedFilters?: Record<string, unknown>;
+  autoReconnect?: boolean;
+  reconnectDelayMs?: number;
+}
+
+export interface DecodedContractEvent {
+  name: string;
+  args: Record<string, unknown>;
+  values: unknown[];
+  log?: unknown;
+}
+
+export interface EventSubscription {
+  unsubscribe(): void;
+  resubscribe(): Promise<void>;
+}
+
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
@@ -58,6 +76,73 @@ export class OpenAgentsSDK {
       ethers.toUtf8Bytes(result)
     );
     await tx.wait();
+  }
+
+  subscribeToEvents(
+    contract: ethers.Contract,
+    eventName: string,
+    callback: (event: DecodedContractEvent) => void | Promise<void>,
+    options: EventSubscriptionOptions = {}
+  ): EventSubscription {
+    const eventFragment = contract.interface.getEvent(eventName);
+    if (!eventFragment) {
+      throw new Error(`Unknown event: ${eventName}`);
+    }
+
+    const indexedInputs = eventFragment.inputs.filter((input) => input.indexed);
+    const filterValues = indexedInputs.map((input) => (
+      options.indexedFilters && input.name in options.indexedFilters
+        ? options.indexedFilters[input.name]
+        : null
+    ));
+
+    const filterFactory = (contract as any).filters?.[eventName];
+    const filter = filterFactory ? filterFactory(...filterValues) : eventName;
+
+    const listener = async (...listenerArgs: unknown[]) => {
+      const eventPayload = listenerArgs[listenerArgs.length - 1];
+      const values = listenerArgs.slice(0, eventFragment.inputs.length);
+      const args: Record<string, unknown> = {};
+
+      eventFragment.inputs.forEach((input, index) => {
+        args[input.name || String(index)] = values[index];
+      });
+
+      await callback({
+        name: eventName,
+        args,
+        values,
+        log: (eventPayload as any)?.log ?? eventPayload,
+      });
+    };
+
+    const subscribe = async () => {
+      await (contract as any).on(filter, listener);
+    };
+    const unsubscribe = () => {
+      (contract as any).off(filter, listener);
+    };
+    const resubscribe = async () => {
+      unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, options.reconnectDelayMs ?? 1000));
+      await subscribe();
+    };
+
+    subscribe();
+
+    if (options.autoReconnect !== false) {
+      const provider = (contract.runner as any)?.provider ?? (contract as any).provider;
+      const websocket = provider?.websocket ?? provider?._websocket;
+      if (websocket?.addEventListener) {
+        websocket.addEventListener("close", resubscribe);
+      } else if (websocket?.on) {
+        websocket.on("close", resubscribe);
+      } else if (provider?.on) {
+        provider.on("disconnect", resubscribe);
+      }
+    }
+
+    return { unsubscribe, resubscribe };
   }
 
   async getOpenTasks(): Promise<any[]> {

--- a/test/SDKEventSubscriptions.test.js
+++ b/test/SDKEventSubscriptions.test.js
@@ -1,0 +1,143 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const vm = require("vm");
+
+function loadSdk(fakeEthers) {
+  const sourcePath = path.join(__dirname, "..", "sdk", "src", "index.ts");
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  }).outputText;
+
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require(name) {
+      if (name === "ethers") {
+        return { ethers: fakeEthers };
+      }
+      return require(name);
+    },
+    setTimeout,
+  };
+  vm.runInNewContext(output, sandbox);
+  return sandbox.module.exports;
+}
+
+function createFakeContract() {
+  const calls = { on: [], off: [], filters: [] };
+  const websocketHandlers = {};
+  const eventFragment = {
+    inputs: [
+      { name: "user", indexed: true },
+      { name: "taskId", indexed: true },
+      { name: "status", indexed: false },
+    ],
+  };
+  const filter = { eventName: "TaskUpdated" };
+  const contract = {
+    interface: {
+      getEvent(name) {
+        assert.strictEqual(name, "TaskUpdated");
+        return eventFragment;
+      },
+    },
+    filters: {
+      TaskUpdated(...args) {
+        calls.filters.push(args);
+        return filter;
+      },
+    },
+    runner: {
+      provider: {
+        websocket: {
+          on(eventName, handler) {
+            websocketHandlers[eventName] = handler;
+          },
+        },
+      },
+    },
+    async on(usedFilter, listener) {
+      calls.on.push({ filter: usedFilter, listener });
+      contract.listener = listener;
+    },
+    off(usedFilter, listener) {
+      calls.off.push({ filter: usedFilter, listener });
+    },
+    emitClose() {
+      return websocketHandlers.close();
+    },
+  };
+  return { contract, calls, filter };
+}
+
+async function testSubscribeDecodeFilterAndReconnect() {
+  const fakeEthers = {
+    JsonRpcProvider: class FakeProvider {},
+    Wallet: class FakeWallet {},
+    Contract: class FakeContract {},
+  };
+  const { OpenAgentsSDK } = loadSdk(fakeEthers);
+  const sdk = new OpenAgentsSDK({
+    name: "agent",
+    endpoint: "https://agent.example",
+    privateKey: "0xabc",
+    rpcUrl: "ws://127.0.0.1:8545",
+    registryAddress: "0x0000000000000000000000000000000000000001",
+    routerAddress: "0x0000000000000000000000000000000000000002",
+  });
+  const { contract, calls, filter } = createFakeContract();
+  const received = [];
+
+  const subscription = sdk.subscribeToEvents(
+    contract,
+    "TaskUpdated",
+    (event) => received.push(event),
+    {
+      indexedFilters: {
+        user: "0x0000000000000000000000000000000000000003",
+        taskId: 7n,
+      },
+      reconnectDelayMs: 0,
+    }
+  );
+
+  assert.deepStrictEqual(calls.filters, [["0x0000000000000000000000000000000000000003", 7n]]);
+  assert.strictEqual(calls.on.length, 1);
+  assert.strictEqual(calls.on[0].filter, filter);
+
+  await contract.listener(
+    "0x0000000000000000000000000000000000000003",
+    7n,
+    "completed",
+    { log: { transactionHash: "0xabc" } }
+  );
+
+  assert.strictEqual(received.length, 1);
+  assert.strictEqual(received[0].name, "TaskUpdated");
+  assert.strictEqual(received[0].args.user, "0x0000000000000000000000000000000000000003");
+  assert.strictEqual(received[0].args.taskId, 7n);
+  assert.strictEqual(received[0].args.status, "completed");
+  assert.strictEqual(received[0].log.transactionHash, "0xabc");
+
+  await contract.emitClose();
+  assert.strictEqual(calls.off.length, 1);
+  assert.strictEqual(calls.on.length, 2);
+
+  subscription.unsubscribe();
+  assert.strictEqual(calls.off.length, 2);
+}
+
+testSubscribeDecodeFilterAndReconnect()
+  .then(() => console.log("SDK event subscription tests passed"))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- Adds `subscribeToEvents(contract, eventName, callback, options)` to `OpenAgentsSDK`.
- Decodes event arguments by ABI input names, supports indexed parameter filters, and returns unsubscribe/resubscribe controls.
- Adds best-effort websocket/provider reconnect handling that resubscribes automatically after disconnect.
- Adds a focused Node unit test with a mocked ethers contract covering subscribe, receive/decode, filter, reconnect, and unsubscribe.

/claim #196

Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Verification:
- `node test\SDKEventSubscriptions.test.js`
- `node --check test\SDKEventSubscriptions.test.js`
- TypeScript transpile check for `sdk/src/index.ts`
- `git diff --check` (only existing LF-to-CRLF warning)
- Prompt/session leak scan over modified files: no private instruction text found

Security note: no private prompt/session initialization text is included in source, comments, CONTRIBUTORS, or metadata. The requested contributor/platform-config records were omitted because they would expose private session instructions.