### PR TITLE
Add ChainlinkAdapter derived prices

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -29,6 +29,7 @@ contract ChainlinkAdapter {
 
     event FeedRegistered(address indexed token, address feed, uint256 heartbeat);
     event FeedDeactivated(address indexed token);
+    event DerivedPriceRead(address indexed base, address indexed quote, uint256 price);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -69,21 +70,40 @@ contract ChainlinkAdapter {
     // BUG: Negative price not rejected — Chainlink can return negative prices for
     // certain feeds; casting a negative int256 to uint256 produces a huge incorrect value
     function getPrice(address token) external view returns (uint256) {
+        return _getNormalizedPrice(token);
+    }
+
+    function derivedPrice(address base, address quote) external view returns (uint256) {
+        if (base == quote) {
+            return 10 ** TARGET_DECIMALS;
+        }
+
+        uint256 basePrice = _getNormalizedPrice(base);
+        uint256 quotePrice = _getNormalizedPrice(quote);
+        require(quotePrice > 0, "Invalid quote price");
+
+        return (basePrice * (10 ** TARGET_DECIMALS)) / quotePrice;
+    }
+
+    function _getNormalizedPrice(address token) internal view returns (uint256) {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        startedAt;
 
-        // No validation of roundId, staleness, or negative price
+        require(answer > 0, "Invalid price");
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(updatedAt + config.heartbeat >= block.timestamp, "Stale price");
+
         uint256 price = uint256(answer);
 
-        // Normalize to 18 decimals
         uint8 feedDecimals = config.feed.decimals();
         if (feedDecimals < TARGET_DECIMALS) {
             price = price * (10 ** (TARGET_DECIMALS - feedDecimals));

--- a/contracts/test/MockAggregatorV3.sol
+++ b/contracts/test/MockAggregatorV3.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockAggregatorV3 {
+    uint8 private immutable feedDecimals;
+    uint80 private roundId = 1;
+    int256 private answer;
+    uint256 private updatedAt;
+    uint80 private answeredInRound = 1;
+
+    constructor(uint8 decimals_, int256 answer_, uint256 updatedAt_) {
+        feedDecimals = decimals_;
+        answer = answer_;
+        updatedAt = updatedAt_;
+    }
+
+    function setRoundData(
+        uint80 roundId_,
+        int256 answer_,
+        uint256 updatedAt_,
+        uint80 answeredInRound_
+    ) external {
+        roundId = roundId_;
+        answer = answer_;
+        updatedAt = updatedAt_;
+        answeredInRound = answeredInRound_;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, updatedAt, updatedAt, answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/ChainlinkAdapterDerivedPrice.test.js
+++ b/test/ChainlinkAdapterDerivedPrice.test.js
@@ -1,0 +1,68 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ChainlinkAdapter derived prices", function () {
+  async function deployFeed(decimals, answer, updatedAt) {
+    const Feed = await ethers.getContractFactory("MockAggregatorV3");
+    const feed = await Feed.deploy(decimals, answer, updatedAt);
+    await feed.waitForDeployment();
+    return feed;
+  }
+
+  async function deployAdapter() {
+    const Adapter = await ethers.getContractFactory("ChainlinkAdapter");
+    const adapter = await Adapter.deploy();
+    await adapter.waitForDeployment();
+    return adapter;
+  }
+
+  it("uses direct feed prices through getPrice", async function () {
+    const [token] = await ethers.getSigners();
+    const latest = await ethers.provider.getBlock("latest");
+    const adapter = await deployAdapter();
+    const feed = await deployFeed(8, 2000_00000000n, latest.timestamp);
+
+    await adapter.registerFeed(token.address, await feed.getAddress(), 3600);
+
+    expect(await adapter.getPrice(token.address)).to.equal(ethers.parseEther("2000"));
+  });
+
+  it("derives base over quote price from two normalized feeds", async function () {
+    const [base, quote] = await ethers.getSigners();
+    const latest = await ethers.provider.getBlock("latest");
+    const adapter = await deployAdapter();
+    const baseFeed = await deployFeed(8, 2000_00000000n, latest.timestamp);
+    const quoteFeed = await deployFeed(8, 1000_00000000n, latest.timestamp);
+
+    await adapter.registerFeed(base.address, await baseFeed.getAddress(), 3600);
+    await adapter.registerFeed(quote.address, await quoteFeed.getAddress(), 3600);
+
+    expect(await adapter.derivedPrice(base.address, quote.address)).to.equal(ethers.parseEther("2"));
+  });
+
+  it("handles decimal mismatches between component feeds", async function () {
+    const [base, quote] = await ethers.getSigners();
+    const latest = await ethers.provider.getBlock("latest");
+    const adapter = await deployAdapter();
+    const baseFeed = await deployFeed(18, ethers.parseEther("1.5"), latest.timestamp);
+    const quoteFeed = await deployFeed(8, 50_000000n, latest.timestamp);
+
+    await adapter.registerFeed(base.address, await baseFeed.getAddress(), 3600);
+    await adapter.registerFeed(quote.address, await quoteFeed.getAddress(), 3600);
+
+    expect(await adapter.derivedPrice(base.address, quote.address)).to.equal(ethers.parseEther("3"));
+  });
+
+  it("rejects stale component feeds", async function () {
+    const [base, quote] = await ethers.getSigners();
+    const latest = await ethers.provider.getBlock("latest");
+    const adapter = await deployAdapter();
+    const staleFeed = await deployFeed(8, 2000_00000000n, latest.timestamp - 7200);
+    const freshFeed = await deployFeed(8, 1000_00000000n, latest.timestamp);
+
+    await adapter.registerFeed(base.address, await staleFeed.getAddress(), 3600);
+    await adapter.registerFeed(quote.address, await freshFeed.getAddress(), 3600);
+
+    await expect(adapter.derivedPrice(base.address, quote.address)).to.be.revertedWith("Stale price");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `derivedPrice(base, quote)` using normalized component feeds at 18-decimal precision.
- Validates positive, complete, non-stale feed rounds for both direct and derived reads.
- Adds focused Hardhat tests for direct feed reads, derived price calculation, decimal mismatch handling, and stale component rejection.

/claim #133

Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Verification:
- `npx hardhat test test\ChainlinkAdapterDerivedPrice.test.js`
- `npx hardhat compile`
- `node --check test\ChainlinkAdapterDerivedPrice.test.js`
- `git diff --check` (only existing LF-to-CRLF warnings)
- Prompt/session leak scan over modified files: no private instruction text found

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.