### PR TITLE
Add timelocked ownership transfers

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "./access/TimelockedOwnable.sol";
 
-contract AgentRegistry is Ownable {
+contract AgentRegistry is TimelockedOwnable {
     struct Agent {
         address owner;
         string name;
@@ -25,7 +25,7 @@ contract AgentRegistry is Ownable {
     event AgentDeactivated(bytes32 indexed agentId);
     event ReputationUpdated(bytes32 indexed agentId, uint256 newReputation);
 
-    constructor(uint256 _registrationFee) Ownable(msg.sender) {
+    constructor(uint256 _registrationFee) TimelockedOwnable(msg.sender) {
         registrationFee = _registrationFee;
         minReputation = 0;
     }

--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "./access/TimelockedOwnable.sol";
 
-contract PaymentEscrow is Ownable {
+contract PaymentEscrow is TimelockedOwnable {
     struct Escrow {
         address payer;
         address payee;
@@ -22,7 +22,7 @@ contract PaymentEscrow is Ownable {
     event EscrowReleased(uint256 indexed escrowId, address indexed payee, uint256 amount);
     event EscrowRefunded(uint256 indexed escrowId, address indexed payer, uint256 amount);
 
-    constructor() Ownable(msg.sender) {}
+    constructor() TimelockedOwnable(msg.sender) {}
 
     function createEscrow(
         address payee,

--- a/contracts/access/TimelockedOwnable.sol
+++ b/contracts/access/TimelockedOwnable.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+abstract contract TimelockedOwnable is Ownable {
+    uint256 public constant OWNERSHIP_TRANSFER_DELAY = 2 days;
+
+    address public pendingOwner;
+    uint256 public ownershipTransferReadyAt;
+
+    event OwnershipTransferQueued(address indexed currentOwner, address indexed pendingOwner, uint256 readyAt);
+    event OwnershipTransferCanceled(address indexed currentOwner, address indexed pendingOwner);
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
+        require(newOwner != address(0), "TimelockedOwnable: zero address");
+        pendingOwner = newOwner;
+        ownershipTransferReadyAt = block.timestamp + OWNERSHIP_TRANSFER_DELAY;
+        emit OwnershipTransferQueued(owner(), newOwner, ownershipTransferReadyAt);
+    }
+
+    function acceptOwnership() external {
+        require(msg.sender == pendingOwner, "TimelockedOwnable: not pending owner");
+        require(block.timestamp >= ownershipTransferReadyAt, "TimelockedOwnable: transfer locked");
+
+        address newOwner = pendingOwner;
+        pendingOwner = address(0);
+        ownershipTransferReadyAt = 0;
+        _transferOwnership(newOwner);
+    }
+
+    function cancelTransfer() external onlyOwner {
+        address canceledOwner = pendingOwner;
+        require(canceledOwner != address(0), "TimelockedOwnable: no pending transfer");
+        pendingOwner = address(0);
+        ownershipTransferReadyAt = 0;
+        emit OwnershipTransferCanceled(owner(), canceledOwner);
+    }
+}

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../access/TimelockedOwnable.sol";
 
 /// @title MultiTokenStaking
 /// @notice Allows users to stake multiple ERC20 tokens across different pools,
 ///         each earning a share of a global reward token emission.
 /// @dev Each pool has an allocation weight. Rewards are distributed proportionally.
-contract MultiTokenStaking is Ownable, ReentrancyGuard {
+contract MultiTokenStaking is TimelockedOwnable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     struct PoolInfo {
@@ -40,7 +40,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
 
     // BUG: Missing zero-address validation — rewardToken can be set to address(0),
     // causing all reward transfers to silently burn tokens or revert unpredictably.
-    constructor(address _rewardToken, uint256 _rewardPerSecond) Ownable(msg.sender) {
+    constructor(address _rewardToken, uint256 _rewardPerSecond) TimelockedOwnable(msg.sender) {
         rewardToken = IERC20(_rewardToken);
         rewardPerSecond = _rewardPerSecond;
     }

--- a/contracts/test/MockPlainERC20.sol
+++ b/contracts/test/MockPlainERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockPlainERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/token/AgentToken.sol
+++ b/contracts/token/AgentToken.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "../access/TimelockedOwnable.sol";
 
 /// @title AgentToken
 /// @notice ERC20 token with minting, burning, and EIP-2612 permit functionality.
 /// @dev Used as the native token for the OpenAgents platform.
-contract AgentToken is ERC20, ERC20Burnable {
-    address public owner;
+contract AgentToken is ERC20, ERC20Burnable, TimelockedOwnable {
     // BUG: No max supply cap — tokens can be minted infinitely, leading to
     // unbounded inflation and devaluation of existing holders' tokens.
 
@@ -18,14 +18,11 @@ contract AgentToken is ERC20, ERC20Burnable {
     bytes32 public immutable DOMAIN_SEPARATOR;
     mapping(address => uint256) public nonces;
 
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
     constructor(
         string memory name_,
         string memory symbol_,
         uint256 initialSupply
-    ) ERC20(name_, symbol_) {
-        owner = msg.sender;
+    ) ERC20(name_, symbol_) TimelockedOwnable(msg.sender) {
         _mint(msg.sender, initialSupply);
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
@@ -43,15 +40,6 @@ contract AgentToken is ERC20, ERC20Burnable {
     // Should be restricted to owner or a minter role.
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
-    }
-
-    /// @notice Transfer ownership of the contract.
-    /// @param newOwner The new owner address.
-    function transferOwnership(address newOwner) external {
-        require(msg.sender == owner, "AgentToken: not owner");
-        require(newOwner != address(0), "AgentToken: zero address");
-        emit OwnershipTransferred(owner, newOwner);
-        owner = newOwner;
     }
 
     /// @notice EIP-2612 permit: approve via signature.

--- a/contracts/vault/CompoundVault.sol
+++ b/contracts/vault/CompoundVault.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../access/TimelockedOwnable.sol";
 
 /// @title CompoundVault
 /// @notice Auto-compounding vault that periodically harvests yield and reinvests.
 /// @dev Deposits into an underlying strategy, harvests rewards, sells for the base
 ///      asset, and re-deposits to compound returns. Charges a performance fee.
-contract CompoundVault is Ownable, ReentrancyGuard {
+contract CompoundVault is TimelockedOwnable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable baseToken;
@@ -37,7 +37,7 @@ contract CompoundVault is Ownable, ReentrancyGuard {
         address _strategy,
         address _feeRecipient,
         uint256 _feeBps
-    ) Ownable(msg.sender) {
+    ) TimelockedOwnable(msg.sender) {
         require(_feeBps <= 3000, "Vault: fee too high");
         baseToken = IERC20(_baseToken);
         rewardToken = IERC20(_rewardToken);

--- a/contracts/vault/YieldAggregator.sol
+++ b/contracts/vault/YieldAggregator.sol
@@ -4,14 +4,14 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../access/TimelockedOwnable.sol";
 
 /// @title YieldAggregator
 /// @notice Vault that accepts deposits and allocates capital across yield strategies.
 /// @dev Implements a simplified vault pattern. Users deposit a base token and receive
 ///      shares proportional to their ownership of the vault's total assets.
-contract YieldAggregator is Ownable, ReentrancyGuard {
+contract YieldAggregator is TimelockedOwnable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     struct Strategy {
@@ -32,7 +32,7 @@ contract YieldAggregator is Ownable, ReentrancyGuard {
     event StrategyAdded(uint256 indexed strategyId, address target);
     event StrategyAllocated(uint256 indexed strategyId, uint256 amount);
 
-    constructor(address _asset) Ownable(msg.sender) {
+    constructor(address _asset) TimelockedOwnable(msg.sender) {
         asset = IERC20(_asset);
     }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/TimelockedOwnership.test.js
+++ b/test/TimelockedOwnership.test.js
@@ -1,0 +1,112 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Timelocked ownership transfers", function () {
+  const delay = 2 * 24 * 60 * 60;
+
+  async function deployContracts() {
+    const [owner, pendingOwner, feeRecipient] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockPlainERC20");
+    const token = await Token.deploy("Mock", "MOCK");
+    await token.waitForDeployment();
+
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    const registry = await AgentRegistry.deploy(0);
+    await registry.waitForDeployment();
+
+    const PaymentEscrow = await ethers.getContractFactory("PaymentEscrow");
+    const escrow = await PaymentEscrow.deploy();
+    await escrow.waitForDeployment();
+
+    const CompoundVault = await ethers.getContractFactory("CompoundVault");
+    const compoundVault = await CompoundVault.deploy(
+      await token.getAddress(),
+      await token.getAddress(),
+      ethers.ZeroAddress,
+      feeRecipient.address,
+      0
+    );
+    await compoundVault.waitForDeployment();
+
+    const YieldAggregator = await ethers.getContractFactory("YieldAggregator");
+    const yieldAggregator = await YieldAggregator.deploy(await token.getAddress());
+    await yieldAggregator.waitForDeployment();
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    const staking = await MultiTokenStaking.deploy(await token.getAddress(), 1);
+    await staking.waitForDeployment();
+
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const agentToken = await AgentToken.deploy("Agent", "AGENT", 0);
+    await agentToken.waitForDeployment();
+
+    return {
+      owner,
+      pendingOwner,
+      contracts: [registry, escrow, compoundVault, yieldAggregator, staking, agentToken],
+    };
+  }
+
+  it("queues and accepts ownership transfers across owner-controlled contracts", async function () {
+    const { owner, pendingOwner, contracts } = await deployContracts();
+
+    for (const contract of contracts) {
+      await expect(contract.transferOwnership(pendingOwner.address))
+        .to.emit(contract, "OwnershipTransferQueued");
+      expect(await contract.owner()).to.equal(owner.address);
+      expect(await contract.pendingOwner()).to.equal(pendingOwner.address);
+      expect(await contract.ownershipTransferReadyAt()).to.be.gt(0n);
+    }
+
+    await ethers.provider.send("evm_increaseTime", [delay]);
+    await ethers.provider.send("evm_mine");
+
+    for (const contract of contracts) {
+      await expect(contract.connect(pendingOwner).acceptOwnership())
+        .to.emit(contract, "OwnershipTransferred")
+        .withArgs(owner.address, pendingOwner.address);
+      expect(await contract.owner()).to.equal(pendingOwner.address);
+      expect(await contract.pendingOwner()).to.equal(ethers.ZeroAddress);
+      expect(await contract.ownershipTransferReadyAt()).to.equal(0n);
+    }
+  });
+
+  it("blocks early acceptance and lets the pending owner accept after the delay", async function () {
+    const { owner, pendingOwner, contracts } = await deployContracts();
+    const registry = contracts[0];
+
+    await registry.transferOwnership(pendingOwner.address);
+    await expect(registry.connect(pendingOwner).acceptOwnership()).to.be.revertedWith(
+      "TimelockedOwnable: transfer locked"
+    );
+
+    await ethers.provider.send("evm_increaseTime", [delay]);
+    await ethers.provider.send("evm_mine");
+
+    await expect(registry.connect(pendingOwner).acceptOwnership())
+      .to.emit(registry, "OwnershipTransferred")
+      .withArgs(owner.address, pendingOwner.address);
+
+    expect(await registry.owner()).to.equal(pendingOwner.address);
+    expect(await registry.pendingOwner()).to.equal(ethers.ZeroAddress);
+    expect(await registry.ownershipTransferReadyAt()).to.equal(0n);
+  });
+
+  it("lets the current owner cancel a pending transfer", async function () {
+    const { pendingOwner, contracts } = await deployContracts();
+    const registry = contracts[0];
+
+    await registry.transferOwnership(pendingOwner.address);
+    await expect(registry.cancelTransfer())
+      .to.emit(registry, "OwnershipTransferCanceled");
+
+    expect(await registry.pendingOwner()).to.equal(ethers.ZeroAddress);
+    expect(await registry.ownershipTransferReadyAt()).to.equal(0n);
+
+    await ethers.provider.send("evm_increaseTime", [delay]);
+    await ethers.provider.send("evm_mine");
+    await expect(registry.connect(pendingOwner).acceptOwnership()).to.be.revertedWith(
+      "TimelockedOwnable: not pending owner"
+    );
+  });
+});


### PR DESCRIPTION
/claim #146

## Summary
- Added TimelockedOwnable with pendingOwner, a two-day transfer delay, delayed acceptOwnership, and owner cancelTransfer.
- Migrated AgentRegistry, PaymentEscrow, CompoundVault, YieldAggregator, MultiTokenStaking, and AgentToken to the timelocked ownership flow.
- Added focused Hardhat coverage for queueing, early-accept rejection, delayed acceptance across all updated contracts, and cancellation.
- Kept the requested contributor traceability header out of source because it would expose private session/startup initialization text.

## Verification
- npx hardhat test test\\TimelockedOwnership.test.js
- npx hardhat compile --force
- node --check test\\TimelockedOwnership.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92