### PR TITLE
Harden VestingWallet accounting

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockPlainERC20.sol
+++ b/contracts/test/MockPlainERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockPlainERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title VestingWallet
 /// @notice Linear vesting wallet with a cliff period for token distribution.
@@ -26,8 +27,6 @@ contract VestingWallet {
     event TokensReleased(address indexed beneficiary, uint256 amount);
     event VestingRevoked(address indexed token, uint256 refund);
 
-    // BUG: No zero-address validation on beneficiary — if beneficiary is set to
-    // address(0), all vested tokens are sent to the zero address (burned) on release.
     constructor(
         address _beneficiary,
         address _token,
@@ -37,6 +36,7 @@ contract VestingWallet {
         uint256 _totalAllocation,
         bool _revocable
     ) {
+        require(_beneficiary != address(0), "Vesting: zero beneficiary");
         require(_vestingDuration > _cliffDuration, "Vesting: cliff exceeds duration");
         require(_totalAllocation > 0, "Vesting: zero allocation");
 
@@ -53,6 +53,7 @@ contract VestingWallet {
     /// @notice Release vested tokens to the beneficiary.
     function release() external {
         require(msg.sender == beneficiary, "Vesting: not beneficiary");
+        require(!revoked, "Vesting: revoked");
         uint256 vested = vestedAmount();
         uint256 unreleased = vested - released;
         require(unreleased > 0, "Vesting: nothing to release");
@@ -71,11 +72,10 @@ contract VestingWallet {
         if (block.timestamp >= start + vestingDuration) {
             return totalAllocation;
         }
-        // BUG: Overflow risk — (totalAllocation * elapsed) can overflow for large
-        // allocations. E.g., if totalAllocation is 1e30 and elapsed is 1e8, the
-        // product exceeds uint256 max. Should use mulDiv or restructure the math.
         uint256 elapsed = block.timestamp - start;
-        return (totalAllocation * elapsed) / vestingDuration;
+        uint256 baseRate = totalAllocation / vestingDuration;
+        uint256 remainder = totalAllocation % vestingDuration;
+        return (baseRate * elapsed) + Math.mulDiv(remainder, elapsed, vestingDuration);
     }
 
     /// @notice Revoke unvested tokens and return them to the owner.
@@ -85,13 +85,7 @@ contract VestingWallet {
         require(!revoked, "Vesting: already revoked");
 
         revoked = true;
-        uint256 vested = vestedAmount();
-        // BUG: During the cliff period, vestedAmount() returns 0, so refund is
-        // calculated as totalAllocation - 0 = totalAllocation. But tokens may have
-        // already been partially transferred to the contract. The refund should use
-        // the actual token balance, not totalAllocation - vested, as the contract
-        // might not hold the full allocation yet, causing a revert or incorrect refund.
-        uint256 refund = totalAllocation - vested;
+        uint256 refund = totalAllocation - released;
 
         token.safeTransfer(owner, refund);
         emit VestingRevoked(address(token), refund);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/VestingWalletSafety.test.js
+++ b/test/VestingWalletSafety.test.js
@@ -1,0 +1,112 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("VestingWallet safety fixes", function () {
+  async function latestTimestamp() {
+    return (await ethers.provider.getBlock("latest")).timestamp;
+  }
+
+  async function deployFixture(overrides = {}) {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockPlainERC20");
+    const token = await Token.deploy("Mock", "MOCK");
+    await token.waitForDeployment();
+
+    const start = overrides.start ?? ((await latestTimestamp()) + 100);
+    const cliffDuration = overrides.cliffDuration ?? 0;
+    const vestingDuration = overrides.vestingDuration ?? 1000;
+    const totalAllocation = overrides.totalAllocation ?? ethers.parseEther("1000");
+    const revocable = overrides.revocable ?? true;
+
+    const VestingWallet = await ethers.getContractFactory("VestingWallet");
+    const wallet = await VestingWallet.deploy(
+      overrides.beneficiary ?? beneficiary.address,
+      await token.getAddress(),
+      start,
+      cliffDuration,
+      vestingDuration,
+      totalAllocation,
+      revocable
+    );
+    await wallet.waitForDeployment();
+
+    return { owner, beneficiary, token, wallet, start, vestingDuration, totalAllocation };
+  }
+
+  it("rejects a zero-address beneficiary", async function () {
+    const [owner] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockPlainERC20");
+    const token = await Token.deploy("Mock", "MOCK");
+    await token.waitForDeployment();
+
+    const VestingWallet = await ethers.getContractFactory("VestingWallet");
+    await expect(
+      VestingWallet.deploy(
+        ethers.ZeroAddress,
+        await token.getAddress(),
+        (await latestTimestamp()) + 100,
+        0,
+        1000,
+        ethers.parseEther("1"),
+        true
+      )
+    ).to.be.revertedWith("Vesting: zero beneficiary");
+  });
+
+  it("calculates large 18-decimal allocations without overflowing", async function () {
+    const oneYear = 365 * 24 * 60 * 60;
+    const totalAllocation = ethers.parseEther("1000000000");
+    const { wallet, start } = await deployFixture({
+      vestingDuration: oneYear,
+      totalAllocation,
+    });
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [start + oneYear / 2]);
+    await ethers.provider.send("evm_mine");
+
+    expect(await wallet.vestedAmount()).to.equal(totalAllocation / 2n);
+  });
+
+  it("refunds the full unclaimed allocation when revoked during the cliff", async function () {
+    const oneDay = 24 * 60 * 60;
+    const oneYear = 365 * oneDay;
+    const totalAllocation = ethers.parseEther("1000");
+    const { owner, token, wallet } = await deployFixture({
+      cliffDuration: oneDay,
+      vestingDuration: oneYear,
+      totalAllocation,
+    });
+    const walletAddress = await wallet.getAddress();
+    await token.mint(walletAddress, totalAllocation);
+
+    await expect(wallet.revoke())
+      .to.emit(wallet, "VestingRevoked")
+      .withArgs(await token.getAddress(), totalAllocation);
+
+    expect(await token.balanceOf(owner.address)).to.equal(totalAllocation);
+    expect(await token.balanceOf(walletAddress)).to.equal(0n);
+  });
+
+  it("refunds total allocation minus already released tokens on revoke", async function () {
+    const totalAllocation = ethers.parseEther("1000");
+    const { owner, beneficiary, token, wallet, start } = await deployFixture({
+      vestingDuration: 1000,
+      totalAllocation,
+    });
+    const walletAddress = await wallet.getAddress();
+    await token.mint(walletAddress, totalAllocation);
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [start + 250]);
+    await wallet.connect(beneficiary).release();
+
+    const released = ethers.parseEther("250");
+    const refund = totalAllocation - released;
+    expect(await token.balanceOf(beneficiary.address)).to.equal(released);
+
+    await expect(wallet.revoke())
+      .to.emit(wallet, "VestingRevoked")
+      .withArgs(await token.getAddress(), refund);
+    expect(await token.balanceOf(owner.address)).to.equal(refund);
+    expect(await token.balanceOf(walletAddress)).to.equal(0n);
+  });
+});


### PR DESCRIPTION
/claim #12

## Summary
- Reworked VestingWallet vestedAmount math to divide before multiplying and use Math.mulDiv for the remainder path.
- Added zero-address beneficiary validation.
- Changed revoke accounting to refund totalAllocation minus already released tokens and blocked releases after revoke.
- Added focused Hardhat tests for large 18-decimal allocations, cliff revocation, post-release revoke accounting, and zero-address rejection.
- Omitted the requested raw startup/contributor traceability payload because it would expose private session initialization text.

## Verification
- npx hardhat test test\\VestingWalletSafety.test.js
- npx hardhat compile --force
- node --check test\\VestingWalletSafety.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92