### PR TITLE
Enforce Router multi-hop slippage controls

### DIFF
--- a/contracts/dex/Router.sol
+++ b/contracts/dex/Router.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 interface IAMMPool {
     function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut) external returns (uint256);
     function getReserves() external view returns (uint256, uint256);
@@ -16,8 +18,8 @@ interface IERC20 {
 }
 
 /// @title Router
-/// @notice Multi-hop swap router that routes trades through multiple AMM pools
-/// @dev Each hop uses a registered pool; tokens flow through the router
+/// @notice Multi-hop swap router that routes trades through multiple AMM pools.
+/// @dev Each hop uses a registered pool; tokens flow through the router.
 contract Router {
     address public admin;
 
@@ -38,40 +40,66 @@ contract Router {
         emit PoolRegistered(_tokenA, _tokenB, _pool);
     }
 
-    // BUG: No slippage protection — minAmountOut is passed as 0 to every intermediate hop,
-    // so a sandwich attacker can extract maximum value from multi-hop trades
-    // BUG: Path validation missing — no check that path[0] != path[path.length-1],
-    // allowing circular swaps (A->B->A) that waste gas and may be used in attacks
-    // BUG: Intermediate amounts not validated — if a pool returns 0 from swap,
-    // subsequent hops proceed with 0 input, silently producing a 0-output trade
+    function swapExactTokensForTokens(
+        address[] calldata path,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        return _swapMultiHop(path, amountIn, minAmountOut, deadline);
+    }
+
     function swapMultiHop(
         address[] calldata path,
         uint256 amountIn,
-        uint256 /* minAmountOut */
+        uint256 minAmountOut,
+        uint256 deadline
     ) external returns (uint256 amountOut) {
-        require(path.length >= 2, "Path too short");
+        return _swapMultiHop(path, amountIn, minAmountOut, deadline);
+    }
 
-        IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+    function _swapMultiHop(
+        address[] calldata path,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) internal returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Deadline expired");
+        require(path.length >= 2, "Path too short");
+        require(amountIn > 0, "Zero input");
+        require(minAmountOut > 0, "Zero min output");
+        _validatePath(path);
+
+        uint256 quotedFinalOut = _quotePath(path, amountIn);
+        require(quotedFinalOut >= minAmountOut, "Slippage exceeded");
+        require(IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn), "Transfer in failed");
 
         uint256 currentAmount = amountIn;
 
         for (uint256 i = 0; i < path.length - 1; i++) {
             address tokenIn = path[i];
             address tokenOut = path[i + 1];
-
             address pool = pools[tokenIn][tokenOut];
             require(pool != address(0), "No pool for pair");
 
-            IERC20(tokenIn).approve(pool, currentAmount);
+            uint256 expectedHopOut = _quoteHop(tokenIn, tokenOut, currentAmount);
+            uint256 hopMinAmountOut = Math.mulDiv(
+                expectedHopOut,
+                minAmountOut,
+                quotedFinalOut,
+                Math.Rounding.Ceil
+            );
+            require(hopMinAmountOut > 0, "Zero output");
 
-            // Passes 0 as minAmountOut — no slippage protection on intermediate hops
-            currentAmount = IAMMPool(pool).swap(tokenIn, currentAmount, 0);
+            require(IERC20(tokenIn).approve(pool, currentAmount), "Approve failed");
+            currentAmount = IAMMPool(pool).swap(tokenIn, currentAmount, hopMinAmountOut);
+            require(currentAmount >= hopMinAmountOut, "Slippage exceeded");
+            require(currentAmount > 0, "Zero output");
         }
 
         amountOut = currentAmount;
-
-        // Transfer final tokens to user
-        IERC20(path[path.length - 1]).transfer(msg.sender, amountOut);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+        require(IERC20(path[path.length - 1]).transfer(msg.sender, amountOut), "Transfer out failed");
 
         emit MultiHopSwap(msg.sender, path, amountIn, amountOut);
     }
@@ -80,21 +108,55 @@ contract Router {
         address[] calldata path,
         uint256 amountIn
     ) external view returns (uint256 estimatedOut) {
+        return _quotePath(path, amountIn);
+    }
+
+    function _quotePath(
+        address[] calldata path,
+        uint256 amountIn
+    ) internal view returns (uint256 estimatedOut) {
+        require(path.length >= 2, "Path too short");
+        require(amountIn > 0, "Zero input");
+        _validatePath(path);
+
         uint256 currentAmount = amountIn;
-
         for (uint256 i = 0; i < path.length - 1; i++) {
-            address pool = pools[path[i]][path[i + 1]];
-            require(pool != address(0), "No pool");
-
-            (uint256 resA, uint256 resB) = IAMMPool(pool).getReserves();
-            address tA = IAMMPool(pool).tokenA();
-
-            (uint256 resIn, uint256 resOut) = (path[i] == tA) ? (resA, resB) : (resB, resA);
-            uint256 amountInWithFee = currentAmount * 9970;
-            currentAmount = (amountInWithFee * resOut) / (resIn * 10000 + amountInWithFee);
+            currentAmount = _quoteHop(path[i], path[i + 1], currentAmount);
         }
-
         return currentAmount;
+    }
+
+    function _quoteHop(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) internal view returns (uint256 amountOut) {
+        address pool = pools[tokenIn][tokenOut];
+        require(pool != address(0), "No pool");
+
+        (uint256 resA, uint256 resB) = IAMMPool(pool).getReserves();
+        address tA = IAMMPool(pool).tokenA();
+        address tB = IAMMPool(pool).tokenB();
+        require(
+            (tokenIn == tA && tokenOut == tB) || (tokenIn == tB && tokenOut == tA),
+            "Pool mismatch"
+        );
+
+        (uint256 resIn, uint256 resOut) = (tokenIn == tA) ? (resA, resB) : (resB, resA);
+        require(resIn > 0 && resOut > 0, "Empty pool");
+
+        uint256 amountInWithFee = amountIn * 9970;
+        amountOut = (amountInWithFee * resOut) / (resIn * 10000 + amountInWithFee);
+        require(amountOut > 0, "Zero output");
+    }
+
+    function _validatePath(address[] calldata path) internal pure {
+        for (uint256 i = 0; i < path.length; i++) {
+            require(path[i] != address(0), "Invalid path");
+            for (uint256 j = i + 1; j < path.length; j++) {
+                require(path[i] != path[j], "Circular path");
+            }
+        }
     }
 
     function getPool(address tokenA, address tokenB) external view returns (address) {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockPlainERC20.sol
+++ b/contracts/test/MockPlainERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockPlainERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/test/MockRouterPool.sol
+++ b/contracts/test/MockRouterPool.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IMockRouterToken {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+contract MockRouterPool {
+    address public tokenA;
+    address public tokenB;
+    uint256 public reserveA;
+    uint256 public reserveB;
+    uint256 public lastMinAmountOut;
+
+    constructor(address _tokenA, address _tokenB, uint256 _reserveA, uint256 _reserveB) {
+        tokenA = _tokenA;
+        tokenB = _tokenB;
+        reserveA = _reserveA;
+        reserveB = _reserveB;
+    }
+
+    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut) external returns (uint256 amountOut) {
+        require(tokenIn == tokenA || tokenIn == tokenB, "Invalid token");
+        require(amountIn > 0, "Zero input");
+
+        bool isA = tokenIn == tokenA;
+        (uint256 resIn, uint256 resOut) = isA ? (reserveA, reserveB) : (reserveB, reserveA);
+        uint256 amountInWithFee = amountIn * 9970;
+        amountOut = (amountInWithFee * resOut) / (resIn * 10000 + amountInWithFee);
+
+        lastMinAmountOut = minAmountOut;
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+        require(amountOut > 0, "Zero output");
+
+        address tokenOut = isA ? tokenB : tokenA;
+        require(IMockRouterToken(tokenIn).transferFrom(msg.sender, address(this), amountIn), "Transfer in failed");
+        require(IMockRouterToken(tokenOut).transfer(msg.sender, amountOut), "Transfer out failed");
+
+        if (isA) {
+            reserveA += amountIn;
+            reserveB -= amountOut;
+        } else {
+            reserveB += amountIn;
+            reserveA -= amountOut;
+        }
+    }
+
+    function getReserves() external view returns (uint256, uint256) {
+        return (reserveA, reserveB);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/RouterSlippage.test.js
+++ b/test/RouterSlippage.test.js
@@ -1,0 +1,91 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Router multi-hop slippage controls", function () {
+  async function latestTimestamp() {
+    return (await ethers.provider.getBlock("latest")).timestamp;
+  }
+
+  async function deployFixture() {
+    const [admin, trader] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockPlainERC20");
+    const tokenA = await Token.deploy("Token A", "TKA");
+    const tokenB = await Token.deploy("Token B", "TKB");
+    const tokenC = await Token.deploy("Token C", "TKC");
+    await Promise.all([
+      tokenA.waitForDeployment(),
+      tokenB.waitForDeployment(),
+      tokenC.waitForDeployment(),
+    ]);
+
+    const reserve = ethers.parseEther("10000");
+    const Pool = await ethers.getContractFactory("MockRouterPool");
+    const poolAB = await Pool.deploy(await tokenA.getAddress(), await tokenB.getAddress(), reserve, reserve);
+    const poolBC = await Pool.deploy(await tokenB.getAddress(), await tokenC.getAddress(), reserve, reserve);
+    await Promise.all([poolAB.waitForDeployment(), poolBC.waitForDeployment()]);
+
+    for (const [token, pool] of [
+      [tokenA, poolAB],
+      [tokenB, poolAB],
+      [tokenB, poolBC],
+      [tokenC, poolBC],
+    ]) {
+      await token.mint(await pool.getAddress(), reserve);
+    }
+
+    const Router = await ethers.getContractFactory("Router");
+    const router = await Router.deploy();
+    await router.waitForDeployment();
+    await router.registerPool(await tokenA.getAddress(), await tokenB.getAddress(), await poolAB.getAddress());
+    await router.registerPool(await tokenB.getAddress(), await tokenC.getAddress(), await poolBC.getAddress());
+
+    return { admin, trader, tokenA, tokenB, tokenC, poolAB, poolBC, router };
+  }
+
+  it("applies non-zero proportional minimums to each hop", async function () {
+    const { trader, tokenA, tokenB, tokenC, poolAB, poolBC, router } = await deployFixture();
+    const path = [await tokenA.getAddress(), await tokenB.getAddress(), await tokenC.getAddress()];
+    const amountIn = ethers.parseEther("100");
+    const quotedOut = await router.getQuote(path, amountIn);
+    const minAmountOut = (quotedOut * 95n) / 100n;
+    const deadline = (await latestTimestamp()) + 100;
+
+    await tokenA.mint(trader.address, amountIn);
+    await tokenA.connect(trader).approve(await router.getAddress(), amountIn);
+
+    await expect(router.connect(trader).swapMultiHop(path, amountIn, minAmountOut, deadline))
+      .to.emit(router, "MultiHopSwap");
+
+    expect(await poolAB.lastMinAmountOut()).to.be.gt(0n);
+    expect(await poolBC.lastMinAmountOut()).to.equal(minAmountOut);
+    expect(await tokenC.balanceOf(trader.address)).to.be.gte(minAmountOut);
+  });
+
+  it("rejects circular paths", async function () {
+    const { tokenA, tokenB, router } = await deployFixture();
+    const path = [await tokenA.getAddress(), await tokenB.getAddress(), await tokenA.getAddress()];
+    const deadline = (await latestTimestamp()) + 100;
+
+    await expect(router.swapMultiHop(path, 1, 1, deadline)).to.be.revertedWith("Circular path");
+  });
+
+  it("rejects expired deadlines", async function () {
+    const { tokenA, tokenB, router } = await deployFixture();
+    const path = [await tokenA.getAddress(), await tokenB.getAddress()];
+    const expired = (await latestTimestamp()) - 1;
+
+    await expect(router.swapMultiHop(path, 1, 1, expired)).to.be.revertedWith("Deadline expired");
+  });
+
+  it("rejects zero input and zero-output hops", async function () {
+    const { trader, tokenA, tokenB, router } = await deployFixture();
+    const path = [await tokenA.getAddress(), await tokenB.getAddress()];
+    const deadline = (await latestTimestamp()) + 100;
+
+    await expect(router.swapMultiHop(path, 0, 1, deadline)).to.be.revertedWith("Zero input");
+
+    await tokenA.mint(trader.address, 1);
+    await tokenA.connect(trader).approve(await router.getAddress(), 1);
+    await expect(router.connect(trader).swapMultiHop(path, 1, 1, deadline)).to.be.revertedWith("Zero output");
+  });
+});


### PR DESCRIPTION
/claim #35

## Summary
- Added deadline-enforced multi-hop swaps and a swapExactTokensForTokens alias for the issue-named API.
- Rejects repeated/circular paths, zero input, zero minimum output, and zero-output hops.
- Computes a quoted final output and passes non-zero proportional minAmountOut values into every hop.
- Added focused Hardhat tests for per-hop minimums, circular paths, expired deadlines, and zero-output handling.
- Omitted the requested raw contributor traceability header because it would expose private session/startup initialization text.

## Verification
- npx hardhat test test\\RouterSlippage.test.js
- npx hardhat compile --force
- node --check test\\RouterSlippage.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92