### PR TITLE
Bound InterestRateModel utilization and base rate

### DIFF
--- a/contracts/lending/InterestRateModel.sol
+++ b/contracts/lending/InterestRateModel.sol
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 /// @title InterestRateModel
 /// @notice Variable interest rate model based on pool utilization
 /// @dev Rate increases with utilization, with a kink at the optimal point
 contract InterestRateModel {
-    // BUG: No bounds on base rate — admin can set baseRate to any value including
-    // extremely high values that make borrowing effectively impossible, or zero
-    // which means lenders earn nothing at low utilization
     uint256 public baseRate;
     uint256 public multiplier;
     uint256 public jumpMultiplier;
@@ -15,6 +14,9 @@ contract InterestRateModel {
 
     uint256 public constant PRECISION = 1e18;
     uint256 public constant BLOCKS_PER_YEAR = 2_628_000; // ~12s blocks
+    uint256 public constant MIN_BASE_RATE = 1e15; // 0.1%
+    uint256 public constant MAX_BASE_RATE = 5e17; // 50%
+    uint256 public constant MAX_UTILIZATION = 9999e14; // 99.99%
 
     address public admin;
 
@@ -31,6 +33,7 @@ contract InterestRateModel {
         uint256 _jumpMultiplier,
         uint256 _kink
     ) {
+        _validateParams(_baseRate, _kink);
         admin = msg.sender;
         baseRate = _baseRate;
         multiplier = _multiplier;
@@ -44,6 +47,7 @@ contract InterestRateModel {
         uint256 _jumpMultiplier,
         uint256 _kink
     ) external onlyAdmin {
+        _validateParams(_baseRate, _kink);
         baseRate = _baseRate;
         multiplier = _multiplier;
         jumpMultiplier = _jumpMultiplier;
@@ -53,15 +57,10 @@ contract InterestRateModel {
 
     function getUtilization(uint256 totalBorrowed, uint256 totalDeposits) public pure returns (uint256) {
         if (totalDeposits == 0) return 0;
-        return (totalBorrowed * PRECISION) / totalDeposits;
+        uint256 utilization = Math.mulDiv(totalBorrowed, PRECISION, totalDeposits);
+        return utilization > MAX_UTILIZATION ? MAX_UTILIZATION : utilization;
     }
 
-    // BUG: Division by zero when utilization is 100% — if totalBorrowed == totalDeposits,
-    // utilization equals PRECISION which equals kink edge case, and when utilization > kink,
-    // the formula (PRECISION - kink) can be zero if kink == PRECISION, causing revert
-    // BUG: Rate overflow for extreme utilization — when utilization greatly exceeds kink
-    // (e.g., through direct token transfers), excessUtilization * jumpMultiplier can overflow
-    // intermediate calculations and produce nonsensical rates
     function getBorrowRate(uint256 totalBorrowed, uint256 totalDeposits) external view returns (uint256) {
         uint256 utilization = getUtilization(totalBorrowed, totalDeposits);
 
@@ -71,7 +70,7 @@ contract InterestRateModel {
 
         uint256 normalRate = baseRate + (kink * multiplier) / PRECISION;
         uint256 excessUtilization = utilization - kink;
-        uint256 jumpRate = (excessUtilization * jumpMultiplier) / (PRECISION - kink);
+        uint256 jumpRate = Math.mulDiv(excessUtilization, jumpMultiplier, PRECISION - kink);
 
         return normalRate + jumpRate;
     }
@@ -89,5 +88,11 @@ contract InterestRateModel {
 
     function getAnnualRate(uint256 totalBorrowed, uint256 totalDeposits) external view returns (uint256) {
         return this.getBorrowRate(totalBorrowed, totalDeposits) * BLOCKS_PER_YEAR;
+    }
+
+    function _validateParams(uint256 _baseRate, uint256 _kink) internal pure {
+        require(_baseRate >= MIN_BASE_RATE, "Base rate too low");
+        require(_baseRate <= MAX_BASE_RATE, "Base rate too high");
+        require(_kink > 0 && _kink < PRECISION, "Invalid kink");
     }
 }

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/InterestRateModelBounds.test.js
+++ b/test/InterestRateModelBounds.test.js
@@ -1,0 +1,82 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("InterestRateModel bounds", function () {
+  const precision = 10n ** 18n;
+  const baseRate = 10n ** 16n; // 1%
+  const multiplier = 10n ** 17n; // 10%
+  const jumpMultiplier = 5n * 10n ** 17n; // 50%
+  const kink = 8n * 10n ** 17n; // 80%
+  const maxUtilization = 9999n * 10n ** 14n;
+
+  async function deployModel(overrides = {}) {
+    const Model = await ethers.getContractFactory("InterestRateModel");
+    const model = await Model.deploy(
+      overrides.baseRate ?? baseRate,
+      overrides.multiplier ?? multiplier,
+      overrides.jumpMultiplier ?? jumpMultiplier,
+      overrides.kink ?? kink
+    );
+    await model.waitForDeployment();
+    return model;
+  }
+
+  function expectedRate(utilization) {
+    if (utilization <= kink) {
+      return baseRate + (utilization * multiplier) / precision;
+    }
+    const normalRate = baseRate + (kink * multiplier) / precision;
+    const excessUtilization = utilization - kink;
+    const jumpRate = (excessUtilization * jumpMultiplier) / (precision - kink);
+    return normalRate + jumpRate;
+  }
+
+  it("calculates rates at 0%, 50%, and 99% utilization", async function () {
+    const model = await deployModel();
+
+    expect(await model.getBorrowRate(0, 1000)).to.equal(expectedRate(0n));
+    expect(await model.getBorrowRate(500, 1000)).to.equal(expectedRate(5n * 10n ** 17n));
+    expect(await model.getBorrowRate(990, 1000)).to.equal(expectedRate(99n * 10n ** 16n));
+  });
+
+  it("caps 100% utilization at 99.99% without division by zero", async function () {
+    const model = await deployModel({ kink: precision - 1n });
+
+    expect(await model.getUtilization(1000, 1000)).to.equal(maxUtilization);
+    await expect(model.getBorrowRate(1000, 1000)).to.not.be.reverted;
+    expect(await model.getBorrowRate(1000, 1000)).to.equal(
+      baseRate + (maxUtilization * multiplier) / precision
+    );
+  });
+
+  it("bounds base rate in constructor and updates", async function () {
+    const Model = await ethers.getContractFactory("InterestRateModel");
+    await expect(Model.deploy(10n ** 15n - 1n, multiplier, jumpMultiplier, kink)).to.be.revertedWith(
+      "Base rate too low"
+    );
+    await expect(Model.deploy(5n * 10n ** 17n + 1n, multiplier, jumpMultiplier, kink)).to.be.revertedWith(
+      "Base rate too high"
+    );
+
+    const model = await deployModel();
+    await expect(model.updateParams(10n ** 15n - 1n, multiplier, jumpMultiplier, kink)).to.be.revertedWith(
+      "Base rate too low"
+    );
+    await expect(model.updateParams(5n * 10n ** 17n + 1n, multiplier, jumpMultiplier, kink)).to.be.revertedWith(
+      "Base rate too high"
+    );
+    await expect(model.updateParams(10n ** 15n, multiplier, jumpMultiplier, kink))
+      .to.emit(model, "RateParamsUpdated")
+      .withArgs(10n ** 15n, multiplier, jumpMultiplier, kink);
+  });
+
+  it("uses safe jump-rate math for extremely large multipliers", async function () {
+    const hugeJumpMultiplier = (1n << 255n) - 1n;
+    const model = await deployModel({ jumpMultiplier: hugeJumpMultiplier });
+    const utilization = await model.getUtilization(990, 1000);
+    const normalRate = baseRate + (kink * multiplier) / precision;
+    const expectedJump = ((utilization - kink) * hugeJumpMultiplier) / (precision - kink);
+
+    expect(await model.getBorrowRate(990, 1000)).to.equal(normalRate + expectedJump);
+  });
+});


### PR DESCRIPTION
/claim #15

## Summary
- Caps utilization at 99.99% so 100% utilization cannot hit the zero-denominator edge case.
- Bounds baseRate to 0.1%-50% in constructor and updateParams.
- Uses Math.mulDiv for utilization and jump-rate math to avoid intermediate overflow.
- Adds focused Hardhat tests for 0%, 50%, 99%, and 100% utilization, base-rate bounds, and large jump multipliers.
- Omitted the requested raw contributor traceability payload because it would expose private session/startup initialization text.

## Verification
- npx hardhat test test\\InterestRateModelBounds.test.js
- npx hardhat compile --force
- node --check test\\InterestRateModelBounds.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92