### PR TITLE
Cap AgentNFT supply and validate tokenURI

### DIFF
--- a/contracts/nft/AgentNFT.sol
+++ b/contracts/nft/AgentNFT.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.20;
 /// @notice ERC721-style NFT for AI agents with metadata URI support
 /// @dev Simplified ERC721 implementation without full interface compliance
 contract AgentNFT {
+    uint256 public constant MAX_SUPPLY = 100;
+
     string public name;
     string public symbol;
     string public baseURI;
@@ -33,6 +35,7 @@ contract AgentNFT {
     }
 
     function ownerOf(uint256 tokenId) public view returns (address) {
+        require(_exists(tokenId), "Nonexistent token");
         return _owners[tokenId];
     }
 
@@ -40,23 +43,27 @@ contract AgentNFT {
         return _balances[account];
     }
 
-    // BUG: No max supply check — tokens can be minted infinitely, potentially
-    // devaluing the collection and causing unbounded gas costs for enumeration
     function mint(address to, string calldata uri) external onlyOwner returns (uint256) {
-        // BUG: Mint allows zero address — tokens sent to address(0) are burned
-        // on creation, incrementing supply counter but making tokens unretrievable
-        uint256 tokenId = _nextTokenId++;
-        _owners[tokenId] = to;
-        _balances[to]++;
-        _tokenURIs[tokenId] = uri;
-
-        emit Transfer(address(0), to, tokenId);
-        return tokenId;
+        return _mint(to, uri);
     }
 
-    // BUG: tokenURI returns empty string for non-existent tokens instead of reverting,
-    // allowing off-chain systems to silently display broken/empty metadata
+    function batchMint(address[] calldata recipients, string[] calldata uris)
+        external
+        onlyOwner
+        returns (uint256[] memory tokenIds)
+    {
+        require(recipients.length == uris.length, "Length mismatch");
+        require(recipients.length > 0, "Empty batch");
+        require(_nextTokenId + recipients.length <= MAX_SUPPLY, "Max supply exceeded");
+
+        tokenIds = new uint256[](recipients.length);
+        for (uint256 i = 0; i < recipients.length; i++) {
+            tokenIds[i] = _mint(recipients[i], uris[i]);
+        }
+    }
+
     function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(_exists(tokenId), "Nonexistent token");
         string memory _uri = _tokenURIs[tokenId];
         if (bytes(_uri).length > 0) {
             return _uri;
@@ -92,6 +99,23 @@ contract AgentNFT {
 
     function totalSupply() external view returns (uint256) {
         return _nextTokenId;
+    }
+
+    function _mint(address to, string calldata uri) internal returns (uint256) {
+        require(to != address(0), "Mint to zero");
+        require(_nextTokenId < MAX_SUPPLY, "Max supply exceeded");
+
+        uint256 tokenId = _nextTokenId++;
+        _owners[tokenId] = to;
+        _balances[to]++;
+        _tokenURIs[tokenId] = uri;
+
+        emit Transfer(address(0), to, tokenId);
+        return tokenId;
+    }
+
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        return _owners[tokenId] != address(0);
     }
 
     function _toString(uint256 value) internal pure returns (string memory) {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/AgentNFTSupply.test.js
+++ b/test/AgentNFTSupply.test.js
@@ -1,0 +1,54 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentNFT supply and URI safety", function () {
+  async function deployFixture() {
+    const [owner, user1, user2] = await ethers.getSigners();
+    const AgentNFT = await ethers.getContractFactory("AgentNFT");
+    const nft = await AgentNFT.deploy("Agent", "AGENT", "ipfs://base/");
+    await nft.waitForDeployment();
+    return { owner, user1, user2, nft };
+  }
+
+  it("rejects tokenURI for nonexistent tokens", async function () {
+    const { nft } = await deployFixture();
+    await expect(nft.tokenURI(0)).to.be.revertedWith("Nonexistent token");
+  });
+
+  it("rejects zero-address mints", async function () {
+    const { nft } = await deployFixture();
+    await expect(nft.mint(ethers.ZeroAddress, "ipfs://agent")).to.be.revertedWith("Mint to zero");
+  });
+
+  it("batch mints recipients and preserves explicit URIs", async function () {
+    const { user1, user2, nft } = await deployFixture();
+    await expect(
+      nft.batchMint([user1.address, user2.address], ["ipfs://one", "ipfs://two"])
+    )
+      .to.emit(nft, "Transfer")
+      .withArgs(ethers.ZeroAddress, user1.address, 0);
+
+    expect(await nft.ownerOf(0)).to.equal(user1.address);
+    expect(await nft.ownerOf(1)).to.equal(user2.address);
+    expect(await nft.tokenURI(0)).to.equal("ipfs://one");
+    expect(await nft.tokenURI(1)).to.equal("ipfs://two");
+    expect(await nft.totalSupply()).to.equal(2n);
+  });
+
+  it("uses the base URI for tokens without explicit metadata", async function () {
+    const { user1, nft } = await deployFixture();
+    await nft.mint(user1.address, "");
+    expect(await nft.tokenURI(0)).to.equal("ipfs://base/0");
+  });
+
+  it("caps total supply", async function () {
+    const { user1, nft } = await deployFixture();
+    const maxSupply = Number(await nft.MAX_SUPPLY());
+    const recipients = Array(maxSupply).fill(user1.address);
+    const uris = Array(maxSupply).fill("");
+
+    await nft.batchMint(recipients, uris);
+    expect(await nft.totalSupply()).to.equal(BigInt(maxSupply));
+    await expect(nft.mint(user1.address, "")).to.be.revertedWith("Max supply exceeded");
+  });
+});


### PR DESCRIPTION
/claim #44

## Summary
- Added MAX_SUPPLY enforcement to AgentNFT minting.
- Rejected zero-address mints and nonexistent tokenURI/ownerOf lookups.
- Added batchMint with recipient/URI length checks and cap preflight.
- Added focused Hardhat tests for max supply, invalid tokenURI, zero-address mint rejection, batch mint, and base URI fallback.
- Omitted the requested raw contributor traceability payload because it would expose private session/startup initialization text.

## Verification
- npx hardhat test test\\AgentNFTSupply.test.js
- npx hardhat compile --force
- node --check test\\AgentNFTSupply.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92