### PR TITLE
Track active AgentRegistry count

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -20,6 +20,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public activeCount;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -50,6 +51,7 @@ contract AgentRegistry is Ownable {
 
         ownerAgents[msg.sender].push(agentId);
         agentIds.push(agentId);
+        activeCount++;
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
@@ -57,7 +59,9 @@ contract AgentRegistry is Ownable {
 
     function deactivateAgent(bytes32 agentId) external {
         require(agents[agentId].owner == msg.sender, "Not agent owner");
+        require(agents[agentId].active, "Agent inactive");
         agents[agentId].active = false;
+        activeCount--;
         emit AgentDeactivated(agentId);
     }
 
@@ -80,9 +84,15 @@ contract AgentRegistry is Ownable {
     }
 
     function getActiveAgentCount() external view returns (uint256 count) {
-        for (uint256 i = 0; i < agentIds.length; i++) {
-            if (agents[agentIds[i]].active) count++;
-        }
+        return activeCount;
+    }
+
+    function getAgents(uint256 offset, uint256 limit) external view returns (bytes32[] memory) {
+        return _page(agentIds, offset, limit);
+    }
+
+    function getAgentsByOwner(address agentOwner, uint256 offset, uint256 limit) external view returns (bytes32[] memory) {
+        return _page(ownerAgents[agentOwner], offset, limit);
     }
 
     function setRegistrationFee(uint256 _fee) external onlyOwner {
@@ -92,5 +102,22 @@ contract AgentRegistry is Ownable {
     function withdrawFees() external onlyOwner {
         (bool success, ) = owner().call{value: address(this).balance}("");
         require(success, "Withdraw failed");
+    }
+
+    function _page(bytes32[] storage ids, uint256 offset, uint256 limit) internal view returns (bytes32[] memory) {
+        if (offset >= ids.length || limit == 0) {
+            return new bytes32[](0);
+        }
+
+        uint256 end = offset + limit;
+        if (end > ids.length) {
+            end = ids.length;
+        }
+
+        bytes32[] memory page = new bytes32[](end - offset);
+        for (uint256 i = offset; i < end; i++) {
+            page[i - offset] = ids[i];
+        }
+        return page;
     }
 }

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/AgentRegistryPagination.test.js
+++ b/test/AgentRegistryPagination.test.js
@@ -1,0 +1,67 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry active count and pagination", function () {
+  async function deployFixture() {
+    const [owner, alice, bob] = await ethers.getSigners();
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    const registry = await AgentRegistry.deploy(0);
+    await registry.waitForDeployment();
+    return { owner, alice, bob, registry };
+  }
+
+  async function register(registry, signer, name) {
+    const tx = await registry.connect(signer).registerAgent(name, `${name}.example`);
+    const receipt = await tx.wait();
+    const event = receipt.logs
+      .map((log) => registry.interface.parseLog(log))
+      .find((parsed) => parsed.name === "AgentRegistered");
+    return event.args.agentId;
+  }
+
+  it("maintains an O(1) active counter through registration and deactivation", async function () {
+    const { alice, bob, registry } = await deployFixture();
+
+    const aliceOne = await register(registry, alice, "alice-one");
+    await register(registry, alice, "alice-two");
+    await register(registry, bob, "bob-one");
+
+    expect(await registry.activeCount()).to.equal(3n);
+    expect(await registry.getActiveAgentCount()).to.equal(3n);
+
+    await expect(registry.connect(alice).deactivateAgent(aliceOne))
+      .to.emit(registry, "AgentDeactivated")
+      .withArgs(aliceOne);
+
+    expect(await registry.activeCount()).to.equal(2n);
+    expect(await registry.getActiveAgentCount()).to.equal(2n);
+    await expect(registry.connect(alice).deactivateAgent(aliceOne)).to.be.revertedWith("Agent inactive");
+  });
+
+  it("returns paginated global agent ids", async function () {
+    const { alice, bob, registry } = await deployFixture();
+    const ids = [
+      await register(registry, alice, "alice-one"),
+      await register(registry, bob, "bob-one"),
+      await register(registry, alice, "alice-two"),
+    ];
+
+    expect(await registry.getAgents(0, 2)).to.deep.equal(ids.slice(0, 2));
+    expect(await registry.getAgents(2, 2)).to.deep.equal(ids.slice(2, 3));
+    expect(await registry.getAgents(10, 2)).to.deep.equal([]);
+    expect(await registry.getAgents(0, 0)).to.deep.equal([]);
+  });
+
+  it("returns paginated owner-filtered agent ids", async function () {
+    const { alice, bob, registry } = await deployFixture();
+    const aliceIds = [
+      await register(registry, alice, "alice-one"),
+      await register(registry, alice, "alice-two"),
+      await register(registry, alice, "alice-three"),
+    ];
+    await register(registry, bob, "bob-one");
+
+    expect(await registry.getAgentsByOwner(alice.address, 1, 2)).to.deep.equal(aliceIds.slice(1, 3));
+    expect(await registry.getAgentsByOwner(bob.address, 0, 10)).to.have.length(1);
+  });
+});


### PR DESCRIPTION
/claim #45

## Summary
- Added an O(1) activeCount counter for AgentRegistry.
- Updates activeCount on registration and single deactivation, and rejects double-deactivation.
- Added paginated getAgents and getAgentsByOwner views.
- Added focused Hardhat tests for counter accuracy, pagination, and owner filtering.
- Omitted the requested raw contributor traceability payload because it would expose private session/startup initialization text.

## Verification
- npx hardhat test test\\AgentRegistryPagination.test.js
- npx hardhat compile --force
- node --check test\\AgentRegistryPagination.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92