### PR TITLE
Harden TWAP oracle window handling

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/oracle/TWAPOracle.sol
+++ b/contracts/oracle/TWAPOracle.sol
@@ -16,11 +16,10 @@ contract TWAPOracle {
 
     Observation[] public observations;
     uint256 public constant PRECISION = 1e18;
+    uint256 public constant MIN_WINDOW_SIZE = 30 minutes;
 
-    // BUG: Observation window too short (1 block / 12 seconds) — TWAP computed over
-    // a single block provides no meaningful time-weighting and is trivially manipulable
-    // via flash loans within the same block
-    uint256 public windowSize = 12; // seconds — effectively 1 block
+    uint256 public windowSize = MIN_WINDOW_SIZE;
+    uint256 public lastObservationBlock;
 
     event ObservationRecorded(uint256 timestamp, uint256 spotPrice, uint256 priceCumulative);
     event WindowUpdated(uint256 newWindow);
@@ -38,36 +37,30 @@ contract TWAPOracle {
     function recordObservation(uint256 spotPrice) external {
         require(spotPrice > 0, "Zero price");
 
-        uint256 lastCumulative = 0;
-        uint256 lastTimestamp = block.timestamp;
-
+        uint256 nextCumulative = 0;
         if (observations.length > 0) {
+            require(block.number > lastObservationBlock, "Observation already recorded");
             Observation storage last = observations[observations.length - 1];
             uint256 elapsed = block.timestamp - last.timestamp;
-            lastCumulative = last.priceCumulative + (last.spotPrice * elapsed);
-            lastTimestamp = block.timestamp;
+            nextCumulative = last.priceCumulative + (last.spotPrice * elapsed);
         }
 
-        // BUG: Price can be manipulated in same block — no check that block.timestamp
-        // has advanced since last observation, so multiple observations per block are
-        // allowed, letting an attacker overwrite the price within a single transaction
         observations.push(Observation({
-            timestamp: lastTimestamp,
-            priceCumulative: lastCumulative,
+            timestamp: block.timestamp,
+            priceCumulative: nextCumulative,
             spotPrice: spotPrice
         }));
+        lastObservationBlock = block.number;
 
-        emit ObservationRecorded(lastTimestamp, spotPrice, lastCumulative);
+        emit ObservationRecorded(block.timestamp, spotPrice, nextCumulative);
     }
 
-    // BUG: No staleness check — if no observation has been recorded for hours/days,
-    // the TWAP still returns an outdated price without warning, misleading consumers
     function getTWAP() external view returns (uint256) {
         require(observations.length >= 2, "Not enough observations");
 
         Observation storage latest = observations[observations.length - 1];
+        require(block.timestamp <= latest.timestamp + windowSize, "Price stale");
 
-        // Find the oldest observation within the window
         uint256 targetTime = latest.timestamp - windowSize;
         uint256 oldIndex = 0;
 
@@ -79,21 +72,23 @@ contract TWAPOracle {
         }
 
         Observation storage old = observations[oldIndex];
-        uint256 timeElapsed = latest.timestamp - old.timestamp;
+        require(old.timestamp <= targetTime, "Window not covered");
 
-        if (timeElapsed == 0) {
-            return latest.spotPrice;
-        }
+        uint256 timeElapsed = latest.timestamp - old.timestamp;
+        require(timeElapsed > 0, "Invalid window");
 
         return (latest.priceCumulative - old.priceCumulative) / timeElapsed;
     }
 
     function getLatestPrice() external view returns (uint256) {
         require(observations.length > 0, "No observations");
-        return observations[observations.length - 1].spotPrice;
+        Observation storage latest = observations[observations.length - 1];
+        require(block.timestamp <= latest.timestamp + windowSize, "Price stale");
+        return latest.spotPrice;
     }
 
     function setWindowSize(uint256 _windowSize) external onlyAdmin {
+        require(_windowSize >= MIN_WINDOW_SIZE, "Window too short");
         windowSize = _windowSize;
         emit WindowUpdated(_windowSize);
     }

--- a/contracts/test/DoubleTWAPRecorder.sol
+++ b/contracts/test/DoubleTWAPRecorder.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ITWAPOracle {
+    function recordObservation(uint256 spotPrice) external;
+}
+
+contract DoubleTWAPRecorder {
+    function recordTwice(address oracle, uint256 firstPrice, uint256 secondPrice) external {
+        ITWAPOracle(oracle).recordObservation(firstPrice);
+        ITWAPOracle(oracle).recordObservation(secondPrice);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/TWAPOracleWindow.test.js
+++ b/test/TWAPOracleWindow.test.js
@@ -1,0 +1,73 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("TWAPOracle window safety", function () {
+  const minWindow = 30 * 60;
+
+  async function deployOracle() {
+    const Oracle = await ethers.getContractFactory("TWAPOracle");
+    const oracle = await Oracle.deploy(ethers.ZeroAddress);
+    await oracle.waitForDeployment();
+    return oracle;
+  }
+
+  it("defaults to and enforces a 30-minute minimum window", async function () {
+    const oracle = await deployOracle();
+
+    expect(await oracle.windowSize()).to.equal(BigInt(minWindow));
+    await expect(oracle.setWindowSize(minWindow - 1)).to.be.revertedWith("Window too short");
+    await expect(oracle.setWindowSize(minWindow * 2))
+      .to.emit(oracle, "WindowUpdated")
+      .withArgs(minWindow * 2);
+  });
+
+  it("rejects multiple observations in the same block", async function () {
+    const oracle = await deployOracle();
+    const DoubleRecorder = await ethers.getContractFactory("DoubleTWAPRecorder");
+    const recorder = await DoubleRecorder.deploy();
+    await recorder.waitForDeployment();
+
+    await expect(recorder.recordTwice(await oracle.getAddress(), 100, 200)).to.be.revertedWith(
+      "Observation already recorded"
+    );
+  });
+
+  it("uses cumulative price over the covered window", async function () {
+    const oracle = await deployOracle();
+
+    await oracle.recordObservation(100);
+    await ethers.provider.send("evm_increaseTime", [minWindow]);
+    await ethers.provider.send("evm_mine");
+    await oracle.recordObservation(200);
+
+    expect(await oracle.getTWAP()).to.equal(100n);
+    expect(await oracle.getObservationCount()).to.equal(2n);
+  });
+
+  it("reverts when the requested window is not covered", async function () {
+    const oracle = await deployOracle();
+    await oracle.setWindowSize(minWindow * 2);
+
+    await oracle.recordObservation(100);
+    await ethers.provider.send("evm_increaseTime", [minWindow]);
+    await ethers.provider.send("evm_mine");
+    await oracle.recordObservation(200);
+
+    await expect(oracle.getTWAP()).to.be.revertedWith("Window not covered");
+  });
+
+  it("reverts on stale latest observations", async function () {
+    const oracle = await deployOracle();
+
+    await oracle.recordObservation(100);
+    await ethers.provider.send("evm_increaseTime", [minWindow]);
+    await ethers.provider.send("evm_mine");
+    await oracle.recordObservation(200);
+
+    await ethers.provider.send("evm_increaseTime", [minWindow + 1]);
+    await ethers.provider.send("evm_mine");
+
+    await expect(oracle.getTWAP()).to.be.revertedWith("Price stale");
+    await expect(oracle.getLatestPrice()).to.be.revertedWith("Price stale");
+  });
+});


### PR DESCRIPTION
/claim #19

## Summary
- Enforced a 30-minute minimum TWAP window and defaulted windowSize to that minimum.
- Added one-observation-per-block protection using lastObservationBlock.
- Added stale latest-observation checks for getTWAP and getLatestPrice.
- Tightened TWAP calculation to require full window coverage and positive elapsed time.
- Added focused Hardhat tests for minimum window, same-block rejection, cumulative average, stale data, and window coverage.
- Omitted the requested raw contributor traceability payload because it would expose private session/startup initialization text.

## Verification
- npx hardhat test test\\TWAPOracleWindow.test.js
- npx hardhat compile --force
- node --check test\\TWAPOracleWindow.test.js
- git diff --check
- prompt/session leak scan over changed files

## Payment
Base USDC: 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92