### PR TITLE
Harden API rate limiter identity and storage

### DIFF
--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -1,11 +1,16 @@
 """Rate limiting middleware for the OpenAgents API."""
 
+import ipaddress
+import os
+import sqlite3
 import time
-from collections import defaultdict
-from fastapi import Request, HTTPException
+from pathlib import Path
+from threading import Lock
+from typing import Callable, Dict, Iterable, Tuple
+
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from typing import Dict, Tuple
 
 
 class RateLimitConfig:
@@ -14,55 +19,155 @@ class RateLimitConfig:
         requests_per_window: int = 100,
         window_seconds: int = 60,
         burst_limit: int = 20,
+        storage_path: str | None = None,
+        trusted_proxies: Iterable[str] | None = None,
+        endpoint_limits: Dict[str, Tuple[int, int]] | None = None,
+        clock: Callable[[], float] | None = None,
     ):
         self.requests_per_window = requests_per_window
         self.window_seconds = window_seconds
         self.burst_limit = burst_limit
+        self.storage_path = storage_path or os.getenv("RATE_LIMIT_DB", "ratelimit.sqlite3")
+        self.trusted_proxy_networks = set()
+        self.trusted_proxy_hosts = set()
+        for proxy in trusted_proxies or []:
+            try:
+                self.trusted_proxy_networks.add(ipaddress.ip_network(proxy, strict=False))
+            except ValueError:
+                self.trusted_proxy_hosts.add(str(proxy))
+        self.endpoint_limits = endpoint_limits or {}
+        self.clock = clock or time.time
 
 
-# BUG: In-memory store — all counters reset when the server restarts,
-# allowing clients to bypass rate limits by waiting for a deploy
-_request_counts: Dict[str, Tuple[int, float]] = defaultdict(lambda: (0, time.time()))
+class SQLiteRateLimitStore:
+    def __init__(self, path: str):
+        self.path = path
+        self._lock = Lock()
+        db_path = Path(path)
+        if db_path.parent and str(db_path.parent) != ".":
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self):
+        conn = sqlite3.connect(self.path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS rate_limit_hits (
+                    client_id TEXT NOT NULL,
+                    endpoint TEXT NOT NULL,
+                    timestamp REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_rate_limit_hits_window
+                ON rate_limit_hits (client_id, endpoint, timestamp)
+                """
+            )
+
+    def hit(
+        self,
+        client_id: str,
+        endpoint: str,
+        now: float,
+        max_requests: int,
+        window_seconds: int,
+    ) -> Tuple[bool, int]:
+        cutoff = now - window_seconds
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute("DELETE FROM rate_limit_hits WHERE timestamp <= ?", (cutoff,))
+                rows = conn.execute(
+                    """
+                    SELECT timestamp
+                    FROM rate_limit_hits
+                    WHERE client_id = ? AND endpoint = ? AND timestamp > ?
+                    ORDER BY timestamp ASC
+                    """,
+                    (client_id, endpoint, cutoff),
+                ).fetchall()
+                if len(rows) >= max_requests:
+                    retry_after = max(1, int(rows[0][0] + window_seconds - now + 0.999))
+                    return True, retry_after
+                conn.execute(
+                    """
+                    INSERT INTO rate_limit_hits (client_id, endpoint, timestamp)
+                    VALUES (?, ?, ?)
+                    """,
+                    (client_id, endpoint, now),
+                )
+                remaining = max_requests - len(rows) - 1
+                return False, remaining
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, config: RateLimitConfig = None):
         super().__init__(app)
         self.config = config or RateLimitConfig()
+        self.store = SQLiteRateLimitStore(self.config.storage_path)
+
+    def _is_trusted_proxy(self, client_ip: str) -> bool:
+        try:
+            parsed = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return client_ip in self.config.trusted_proxy_hosts
+        return any(parsed in proxy for proxy in self.config.trusted_proxy_networks)
+
+    def _first_valid_forwarded_ip(self, forwarded: str) -> str | None:
+        for value in forwarded.split(","):
+            candidate = value.strip()
+            try:
+                ipaddress.ip_address(candidate)
+            except ValueError:
+                continue
+            return candidate
+        return None
 
     def _get_client_ip(self, request: Request) -> str:
-        # BUG: Trusts X-Forwarded-For header without validation — clients can
-        # spoof their IP to bypass rate limiting entirely
+        peer_ip = request.client.host if request.client else "unknown"
         forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        return request.client.host if request.client else "unknown"
+        if forwarded and self._is_trusted_proxy(peer_ip):
+            forwarded_ip = self._first_valid_forwarded_ip(forwarded)
+            if forwarded_ip:
+                return forwarded_ip
+        return peer_ip
 
-    def _is_rate_limited(self, client_ip: str) -> Tuple[bool, int]:
-        global _request_counts
-        count, window_start = _request_counts[client_ip]
-        now = time.time()
+    def _endpoint_key(self, request: Request) -> str:
+        return f"{request.method.upper()} {request.url.path}"
 
-        # BUG: Fixed window instead of sliding window — a burst of requests at
-        # the boundary of two windows allows 2x the intended rate
-        if now - window_start >= self.config.window_seconds:
-            _request_counts[client_ip] = (1, now)
-            return False, self.config.requests_per_window - 1
+    def _limit_for(self, request: Request) -> Tuple[int, int]:
+        method_key = self._endpoint_key(request)
+        path_key = request.url.path
+        if method_key in self.config.endpoint_limits:
+            return self.config.endpoint_limits[method_key]
+        if path_key in self.config.endpoint_limits:
+            return self.config.endpoint_limits[path_key]
+        return self.config.requests_per_window, self.config.window_seconds
 
-        if count >= self.config.requests_per_window:
-            retry_after = int(self.config.window_seconds - (now - window_start))
-            return True, retry_after
-
-        _request_counts[client_ip] = (count + 1, window_start)
-        remaining = self.config.requests_per_window - count - 1
-        return False, remaining
+    def _is_rate_limited(self, client_ip: str, request: Request) -> Tuple[bool, int, int]:
+        limit, window = self._limit_for(request)
+        endpoint = self._endpoint_key(request)
+        is_limited, value = self.store.hit(
+            client_id=client_ip,
+            endpoint=endpoint,
+            now=self.config.clock(),
+            max_requests=limit,
+            window_seconds=window,
+        )
+        return is_limited, value, limit
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path.startswith("/health"):
             return await call_next(request)
 
         client_ip = self._get_client_ip(request)
-        is_limited, value = self._is_rate_limited(client_ip)
+        is_limited, value, limit = self._is_rate_limited(client_ip, request)
 
         if is_limited:
             return JSONResponse(
@@ -76,17 +181,23 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         response.headers["X-RateLimit-Remaining"] = str(value)
-        response.headers["X-RateLimit-Limit"] = str(self.config.requests_per_window)
+        response.headers["X-RateLimit-Limit"] = str(limit)
         return response
 
 
 def create_rate_limiter(
     requests_per_minute: int = 100,
     burst: int = 20,
+    storage_path: str | None = None,
+    trusted_proxies: Iterable[str] | None = None,
+    endpoint_limits: Dict[str, Tuple[int, int]] | None = None,
 ) -> RateLimitMiddleware:
     config = RateLimitConfig(
         requests_per_window=requests_per_minute,
         window_seconds=60,
         burst_limit=burst,
+        storage_path=storage_path,
+        trusted_proxies=trusted_proxies,
+        endpoint_limits=endpoint_limits,
     )
     return RateLimitMiddleware(app=None, config=config)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+pytest>=8.0.0

--- a/api/tests/test_ratelimit_middleware.py
+++ b/api/tests/test_ratelimit_middleware.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+try:
+    from api.middleware.ratelimit import RateLimitConfig, RateLimitMiddleware
+except ImportError:
+    from middleware.ratelimit import RateLimitConfig, RateLimitMiddleware
+
+
+class MutableClock:
+    def __init__(self, value=1000.0):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+    def advance(self, seconds):
+        self.value += seconds
+
+
+def build_client(config):
+    app = FastAPI()
+
+    @app.get("/limited")
+    async def limited():
+        return {"ok": True}
+
+    @app.get("/strict")
+    async def strict():
+        return {"ok": True}
+
+    app.add_middleware(RateLimitMiddleware, config=config)
+    return TestClient(app)
+
+
+def test_untrusted_x_forwarded_for_does_not_bypass_limit(tmp_path: Path):
+    config = RateLimitConfig(
+        requests_per_window=1,
+        window_seconds=60,
+        storage_path=str(tmp_path / "ratelimit.sqlite3"),
+    )
+    client = build_client(config)
+
+    first = client.get("/limited", headers={"X-Forwarded-For": "1.1.1.1"})
+    second = client.get("/limited", headers={"X-Forwarded-For": "2.2.2.2"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+def test_trusted_proxy_uses_valid_forwarded_client_ip(tmp_path: Path):
+    config = RateLimitConfig(
+        requests_per_window=1,
+        window_seconds=60,
+        storage_path=str(tmp_path / "ratelimit.sqlite3"),
+        trusted_proxies={"testclient"},
+    )
+    client = build_client(config)
+
+    first = client.get("/limited", headers={"X-Forwarded-For": "1.1.1.1"})
+    second = client.get("/limited", headers={"X-Forwarded-For": "2.2.2.2"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
+def test_sliding_window_expires_old_hits_smoothly(tmp_path: Path):
+    clock = MutableClock()
+    config = RateLimitConfig(
+        requests_per_window=2,
+        window_seconds=10,
+        storage_path=str(tmp_path / "ratelimit.sqlite3"),
+        clock=clock,
+    )
+    client = build_client(config)
+
+    assert client.get("/limited").status_code == 200
+    clock.advance(5)
+    assert client.get("/limited").status_code == 200
+    clock.advance(4)
+    assert client.get("/limited").status_code == 429
+    clock.advance(2)
+    assert client.get("/limited").status_code == 200
+
+
+def test_limits_survive_middleware_restart(tmp_path: Path):
+    db_path = str(tmp_path / "ratelimit.sqlite3")
+    first_client = build_client(
+        RateLimitConfig(requests_per_window=1, window_seconds=60, storage_path=db_path)
+    )
+    second_client = build_client(
+        RateLimitConfig(requests_per_window=1, window_seconds=60, storage_path=db_path)
+    )
+
+    assert first_client.get("/limited").status_code == 200
+    assert second_client.get("/limited").status_code == 429
+
+
+def test_per_endpoint_limit_overrides_default(tmp_path: Path):
+    config = RateLimitConfig(
+        requests_per_window=10,
+        window_seconds=60,
+        storage_path=str(tmp_path / "ratelimit.sqlite3"),
+        endpoint_limits={"GET /strict": (1, 60)},
+    )
+    client = build_client(config)
+
+    assert client.get("/strict").status_code == 200
+    limited = client.get("/strict")
+
+    assert limited.status_code == 429
+    assert limited.headers["Retry-After"] == "60"


### PR DESCRIPTION
/claim #29

Summary:
- Stops trusting spoofable X-Forwarded-For unless the direct peer is configured as a trusted proxy.
- Replaces fixed-window in-memory counting with a SQLite-backed sliding-window store.
- Adds per-endpoint limit overrides and persistent rate-limit state across middleware restarts.
- Adds focused FastAPI middleware tests for spoofing, trusted proxy forwarding, sliding windows, persistence, and endpoint-specific limits.

Verification:
- python -m pytest .\api\tests\test_ratelimit_middleware.py
- python -m py_compile .\api\middleware\ratelimit.py .\api\tests\test_ratelimit_middleware.py
- git diff --check HEAD~1 HEAD
- Private-runtime text scan across changed files: no matches

Payout: Base USDC 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Traceability: private runtime/session material was intentionally omitted; this PR, commit, and tests provide the public implementation trace.