### PR TITLE
Add API request ID middleware

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,14 @@
-from fastapi import FastAPI, HTTPException, Query
+import logging
+import time
+import uuid
+from contextvars import ContextVar
 from pydantic import BaseModel
+from fastapi import FastAPI, HTTPException, Query, Request
 from typing import Optional
 from datetime import datetime
+
+request_id_context: ContextVar[str] = ContextVar("request_id", default="-")
+logger = logging.getLogger("openagents.api")
 
 app = FastAPI(
     title="OpenAgents API",
@@ -42,6 +49,45 @@ class LeaderboardEntry(BaseModel):
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+
+
+@app.middleware("http")
+async def request_id_middleware(request: Request, call_next):
+    request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    token = request_id_context.set(request_id)
+    started_at = time.perf_counter()
+
+    logger.info(
+        "request started request_id=%s method=%s path=%s",
+        request_id,
+        request.method,
+        request.url.path,
+    )
+
+    try:
+        response = await call_next(request)
+    except Exception:
+        logger.exception(
+            "request failed request_id=%s method=%s path=%s",
+            request_id,
+            request.method,
+            request.url.path,
+        )
+        raise
+    finally:
+        request_id_context.reset(token)
+
+    duration_ms = (time.perf_counter() - started_at) * 1000
+    response.headers["X-Request-ID"] = request_id
+    logger.info(
+        "request completed request_id=%s method=%s path=%s status_code=%s duration_ms=%.2f",
+        request_id,
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
 
 
 @app.get("/agents", response_model=list[AgentResponse])

--- a/tests/test_request_id_middleware.py
+++ b/tests/test_request_id_middleware.py
@@ -1,0 +1,38 @@
+import logging
+import uuid
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_generates_unique_request_id_header():
+    first = client.get("/health")
+    second = client.get("/health")
+
+    first_request_id = first.headers["X-Request-ID"]
+    second_request_id = second.headers["X-Request-ID"]
+
+    uuid.UUID(first_request_id)
+    uuid.UUID(second_request_id)
+    assert first_request_id != second_request_id
+
+
+def test_preserves_client_provided_request_id():
+    request_id = "trace-abc-123"
+
+    response = client.get("/health", headers={"X-Request-ID": request_id})
+
+    assert response.headers["X-Request-ID"] == request_id
+
+
+def test_request_logs_include_request_id(caplog):
+    request_id = "trace-log-456"
+
+    with caplog.at_level(logging.INFO, logger="openagents.api"):
+        client.get("/health", headers={"X-Request-ID": request_id})
+
+    assert any(request_id in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
/claim #164

Summary:
- Adds request ID middleware that generates unique IDs or preserves client-provided X-Request-ID values.
- Adds X-Request-ID response headers and request start/completion/failure log messages containing the request ID.
- Uses a ContextVar so request ID context is available during request handling.
- Adds tests for generated IDs, preserved IDs, and log correlation.

Verification:
- python -m pytest .\tests\test_request_id_middleware.py
- python -m py_compile .\api\main.py .\tests\test_request_id_middleware.py
- git diff --check HEAD~1 HEAD
- Private-runtime text scan across changed files: no matches

Payout: Base USDC 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Traceability: private runtime/session material was intentionally omitted; this PR, commit, and tests provide the public implementation trace.