### PR TITLE
Bound ABI integer encoding

### DIFF
--- a/sdk/src/utils/encoding.ts
+++ b/sdk/src/utils/encoding.ts
@@ -1,32 +1,102 @@
 /**
+ * Contributor traceability:
+ * Agent: Codex
+ * Platform instructions: private runtime/session material intentionally omitted.
+ * Runtime: Windows x64, PowerShell, OpenAgents workspace.
+ */
+
+/**
  * ABI encoding/decoding utilities for EVM-compatible contract interactions.
  */
 
-export type AbiType = "uint256" | "address" | "bytes32" | "string" | "bool";
+export type AbiType = "uint256" | "int256" | "address" | "bytes32" | "string" | "bool";
 
 export interface AbiParam {
   type: AbiType;
   value: string | number | bigint | boolean;
 }
 
+const UINT256_BITS = 256n;
+const UINT256_MODULUS = 1n << UINT256_BITS;
+const MAX_UINT256 = UINT256_MODULUS - 1n;
+const MIN_INT256 = -(1n << 255n);
+const MAX_INT256 = (1n << 255n) - 1n;
+const WORD_HEX_LENGTH = 64;
+
+function requireBigInt(value: bigint | number, name: string): bigint {
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new RangeError(`${name} must be a safe integer or bigint`);
+  }
+
+  return BigInt(value);
+}
+
+function assertInRange(value: bigint, min: bigint, max: bigint, name: string): void {
+  if (value < min || value > max) {
+    throw new RangeError(`${name} exceeds ABI bounds`);
+  }
+}
+
+function requireHex(value: string, name: string): string {
+  if (!value.startsWith("0x")) {
+    throw new Error(`${name} must start with 0x`);
+  }
+
+  const hex = value.slice(2);
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error(`${name} contains non-hex characters`);
+  }
+
+  return hex;
+}
+
+function requireWord(slot: string, name: string): string {
+  const hex = requireHex(slot, name);
+  if (hex.length > WORD_HEX_LENGTH) {
+    throw new RangeError(`${name} exceeds 32 bytes`);
+  }
+
+  return hex.padStart(WORD_HEX_LENGTH, "0");
+}
+
+function padWord(hex: string): string {
+  return hex.padStart(WORD_HEX_LENGTH, "0");
+}
+
 export function encodeUint256(value: bigint | number): string {
-  const n = BigInt(value);
-  // BUG: No overflow check — values > 2^256-1 silently wrap/truncate
-  return n.toString(16).padStart(64, "0");
+  const n = requireBigInt(value, "uint256");
+  assertInRange(n, 0n, MAX_UINT256, "uint256");
+  return padWord(n.toString(16));
+}
+
+export function encodeInt256(value: bigint | number): string {
+  const n = requireBigInt(value, "int256");
+  assertInRange(n, MIN_INT256, MAX_INT256, "int256");
+
+  const twosComplement = n < 0 ? UINT256_MODULUS + n : n;
+  return padWord(twosComplement.toString(16));
 }
 
 export function encodeAddress(address: string): string {
-  const cleaned = address.startsWith("0x") ? address.slice(2) : address;
-  return cleaned.toLowerCase().padStart(64, "0");
+  const cleaned = requireHex(address, "address");
+  if (cleaned.length !== 40) {
+    throw new Error("address must be exactly 20 bytes");
+  }
+
+  return cleaned.toLowerCase().padStart(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeBytes32(data: string): string {
-  const cleaned = data.startsWith("0x") ? data.slice(2) : data;
-  return cleaned.padEnd(64, "0");
+  const cleaned = requireHex(data, "bytes32");
+  if (cleaned.length > WORD_HEX_LENGTH) {
+    throw new RangeError("bytes32 exceeds 32 bytes");
+  }
+
+  return cleaned.padEnd(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeBool(value: boolean): string {
-  return value ? "1".padStart(64, "0") : "0".padStart(64, "0");
+  return value ? "1".padStart(WORD_HEX_LENGTH, "0") : "0".padStart(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeParams(params: AbiParam[]): string {
@@ -34,7 +104,10 @@ export function encodeParams(params: AbiParam[]): string {
   for (const param of params) {
     switch (param.type) {
       case "uint256":
-        encoded += encodeUint256(BigInt(param.value as number));
+        encoded += encodeUint256(param.value as number | bigint);
+        break;
+      case "int256":
+        encoded += encodeInt256(param.value as number | bigint);
         break;
       case "address":
         encoded += encodeAddress(param.value as string);
@@ -45,35 +118,40 @@ export function encodeParams(params: AbiParam[]): string {
       case "bool":
         encoded += encodeBool(param.value as boolean);
         break;
-      case "string":
+      case "string": {
         const hexStr = Buffer.from(param.value as string).toString("hex");
-        encoded += hexStr.padEnd(64, "0");
+        encoded += hexStr.padEnd(WORD_HEX_LENGTH, "0");
         break;
+      }
     }
   }
   return encoded;
 }
 
 export function decodeHex(hex: string): bigint {
-  // BUG: Doesn't validate "0x" prefix — a bare decimal string like "255"
-  // would be parsed as hex 0x255 = 597, silently returning wrong value
-  const cleaned = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const cleaned = requireHex(hex, "hex");
   return BigInt("0x" + cleaned);
 }
 
 export function decodeUint256(slot: string): bigint {
-  // BUG: Doesn't handle short values — if slot is less than 64 chars,
-  // no left-padding is applied before parsing, giving wrong results
-  return BigInt("0x" + slot);
+  const word = requireWord(slot, "uint256 slot");
+  return BigInt("0x" + word);
+}
+
+export function decodeInt256(slot: string): bigint {
+  const word = requireWord(slot, "int256 slot");
+  const unsigned = BigInt("0x" + word);
+  return unsigned >= (1n << 255n) ? unsigned - UINT256_MODULUS : unsigned;
 }
 
 export function decodeAddress(slot: string): string {
-  const raw = slot.slice(-40);
-  return "0x" + raw.toLowerCase();
+  const word = requireWord(slot, "address slot");
+  return "0x" + word.slice(-40).toLowerCase();
 }
 
 export function decodeBool(slot: string): boolean {
-  return BigInt("0x" + slot) !== 0n;
+  const word = requireWord(slot, "bool slot");
+  return BigInt("0x" + word) !== 0n;
 }
 
 export function functionSelector(signature: string): string {
@@ -83,6 +161,11 @@ export function functionSelector(signature: string): string {
 }
 
 export function packCalldata(selector: string, params: AbiParam[]): string {
+  const selectorHex = requireHex(selector, "function selector");
+  if (selectorHex.length !== 8) {
+    throw new Error("function selector must be 4 bytes");
+  }
+
   const encodedParams = encodeParams(params).slice(2);
   return selector + encodedParams;
 }

--- a/test/SDKEncodingBounds.test.js
+++ b/test/SDKEncodingBounds.test.js
@@ -1,0 +1,73 @@
+const { expect } = require("chai");
+
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: {
+    module: "CommonJS",
+    moduleResolution: "node",
+    ignoreDeprecations: "6.0",
+  },
+});
+
+const {
+  decodeHex,
+  decodeInt256,
+  decodeUint256,
+  encodeAddress,
+  encodeBytes32,
+  encodeInt256,
+  encodeParams,
+  encodeUint256,
+} = require("../sdk/src/utils/encoding.ts");
+
+describe("SDK ABI encoding bounds", function () {
+  it("pads uint256 values and rejects overflow or negative values", function () {
+    expect(encodeUint256(1n)).to.equal("0".repeat(63) + "1");
+    expect(encodeUint256((1n << 256n) - 1n)).to.equal("f".repeat(64));
+
+    expect(() => encodeUint256(1n << 256n)).to.throw(RangeError);
+    expect(() => encodeUint256(-1n)).to.throw(RangeError);
+    expect(() => encodeUint256(Number.MAX_SAFE_INTEGER + 1)).to.throw(RangeError);
+  });
+
+  it("requires 0x-prefixed hex inputs", function () {
+    expect(() => decodeHex("ff")).to.throw("must start with 0x");
+    expect(() => encodeAddress("1234567890123456789012345678901234567890")).to.throw("must start with 0x");
+    expect(() => encodeBytes32("abcd")).to.throw("must start with 0x");
+
+    expect(decodeHex("0xff")).to.equal(255n);
+  });
+
+  it("encodes and decodes signed int256 values", function () {
+    const min = -(1n << 255n);
+    const max = (1n << 255n) - 1n;
+
+    expect(encodeInt256(-1n)).to.equal("f".repeat(64));
+    expect(encodeInt256(min)).to.equal("8" + "0".repeat(63));
+    expect(encodeInt256(max)).to.equal("7" + "f".repeat(63));
+    expect(decodeInt256("0x" + "f".repeat(64))).to.equal(-1n);
+    expect(decodeInt256("0x" + "8" + "0".repeat(63))).to.equal(min);
+
+    expect(() => encodeInt256(min - 1n)).to.throw(RangeError);
+    expect(() => encodeInt256(max + 1n)).to.throw(RangeError);
+  });
+
+  it("encodes params with padded signed and unsigned words", function () {
+    const encoded = encodeParams([
+      { type: "uint256", value: 42n },
+      { type: "int256", value: -2n },
+      { type: "bytes32", value: "0x1234" },
+      { type: "address", value: "0x1111111111111111111111111111111111111111" },
+    ]);
+
+    expect(encoded).to.equal(
+      "0x" +
+        "0".repeat(62) + "2a" +
+        "f".repeat(63) + "e" +
+        "1234" + "0".repeat(60) +
+        "0".repeat(24) + "1111111111111111111111111111111111111111"
+    );
+
+    expect(decodeUint256("0x" + "0".repeat(62) + "2a")).to.equal(42n);
+  });
+});


### PR DESCRIPTION
/claim #47

Summary:
- add explicit uint256 and int256 ABI bounds checks
- require 0x-prefixed hex inputs for hex decoding and fixed-size hex encoders
- preserve 32-byte word padding and add signed two's-complement int256 support

Verification:
- npx mocha .\test\SDKEncodingBounds.test.js
- npx tsc --noEmit --target ES2020 --module commonjs --types node .\sdk\src\utils\encoding.ts
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.