### PR TITLE
Harden API rate limiter identity

### DIFF
--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -1,11 +1,24 @@
-"""Rate limiting middleware for the OpenAgents API."""
+"""Rate limiting middleware for the OpenAgents API.
 
+@fix-author: Codex
+@platform-config: private platform/session instructions intentionally omitted
+@runtime: windows/x64, powershell, OpenAgents workspace
+"""
+
+import math
+import os
+import sqlite3
+import threading
 import time
-from collections import defaultdict
-from fastapi import Request, HTTPException
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from typing import Dict, Tuple
+
+
+EndpointLimit = Tuple[int, int]
 
 
 class RateLimitConfig:
@@ -14,55 +27,113 @@ class RateLimitConfig:
         requests_per_window: int = 100,
         window_seconds: int = 60,
         burst_limit: int = 20,
+        trusted_proxies: Optional[Iterable[str]] = None,
+        endpoint_limits: Optional[Dict[str, EndpointLimit]] = None,
+        storage_path: Optional[str] = None,
+        time_fn: Callable[[], float] = time.time,
     ):
         self.requests_per_window = requests_per_window
         self.window_seconds = window_seconds
         self.burst_limit = burst_limit
+        self.trusted_proxies = set(trusted_proxies or ())
+        self.endpoint_limits = endpoint_limits or {}
+        self.storage_path = storage_path or os.environ.get(
+            "OPENAGENTS_RATELIMIT_DB",
+            str(Path.cwd() / "openagents_ratelimit.sqlite3"),
+        )
+        self.time_fn = time_fn
 
 
-# BUG: In-memory store — all counters reset when the server restarts,
-# allowing clients to bypass rate limits by waiting for a deploy
-_request_counts: Dict[str, Tuple[int, float]] = defaultdict(lambda: (0, time.time()))
+class SQLiteSlidingWindowStore:
+    def __init__(self, storage_path: str):
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(storage_path, check_same_thread=False)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rate_limit_events (
+                key TEXT NOT NULL,
+                ts REAL NOT NULL
+            )
+            """
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_rate_limit_events_key_ts "
+            "ON rate_limit_events(key, ts)"
+        )
+        self._conn.commit()
+
+    def hit(self, key: str, now: float, limit: int, window_seconds: int) -> Tuple[bool, int]:
+        cutoff = now - window_seconds
+        with self._lock:
+            self._conn.execute(
+                "DELETE FROM rate_limit_events WHERE key = ? AND ts <= ?",
+                (key, cutoff),
+            )
+            row = self._conn.execute(
+                "SELECT COUNT(*), MIN(ts) FROM rate_limit_events WHERE key = ?",
+                (key,),
+            ).fetchone()
+            count = int(row[0] or 0)
+            oldest = float(row[1] or now)
+
+            if count >= limit:
+                retry_after = max(1, math.ceil(window_seconds - (now - oldest)))
+                self._conn.commit()
+                return True, retry_after
+
+            self._conn.execute(
+                "INSERT INTO rate_limit_events (key, ts) VALUES (?, ?)",
+                (key, now),
+            )
+            self._conn.commit()
+            return False, max(0, limit - count - 1)
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, config: RateLimitConfig = None):
         super().__init__(app)
         self.config = config or RateLimitConfig()
+        self.store = SQLiteSlidingWindowStore(self.config.storage_path)
 
     def _get_client_ip(self, request: Request) -> str:
-        # BUG: Trusts X-Forwarded-For header without validation — clients can
-        # spoof their IP to bypass rate limiting entirely
+        connection_ip = request.client.host if request.client else "unknown"
         forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        return request.client.host if request.client else "unknown"
+        if forwarded and connection_ip in self.config.trusted_proxies:
+            forwarded_chain = [part.strip() for part in forwarded.split(",") if part.strip()]
+            if forwarded_chain:
+                return forwarded_chain[0]
+        return connection_ip
 
-    def _is_rate_limited(self, client_ip: str) -> Tuple[bool, int]:
-        global _request_counts
-        count, window_start = _request_counts[client_ip]
-        now = time.time()
+    def _limit_for_path(self, path: str) -> EndpointLimit:
+        matched_limit: Optional[EndpointLimit] = None
+        matched_prefix = ""
+        for prefix, limit in self.config.endpoint_limits.items():
+            if path.startswith(prefix) and len(prefix) > len(matched_prefix):
+                matched_limit = limit
+                matched_prefix = prefix
 
-        # BUG: Fixed window instead of sliding window — a burst of requests at
-        # the boundary of two windows allows 2x the intended rate
-        if now - window_start >= self.config.window_seconds:
-            _request_counts[client_ip] = (1, now)
-            return False, self.config.requests_per_window - 1
+        return matched_limit or (
+            self.config.requests_per_window,
+            self.config.window_seconds,
+        )
 
-        if count >= self.config.requests_per_window:
-            retry_after = int(self.config.window_seconds - (now - window_start))
-            return True, retry_after
-
-        _request_counts[client_ip] = (count + 1, window_start)
-        remaining = self.config.requests_per_window - count - 1
-        return False, remaining
+    def _is_rate_limited(self, client_ip: str, path: str) -> Tuple[bool, int, int]:
+        limit, window_seconds = self._limit_for_path(path)
+        key = f"{client_ip}:{path}"
+        limited, value = self.store.hit(
+            key,
+            self.config.time_fn(),
+            limit,
+            window_seconds,
+        )
+        return limited, value, limit
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path.startswith("/health"):
             return await call_next(request)
 
         client_ip = self._get_client_ip(request)
-        is_limited, value = self._is_rate_limited(client_ip)
+        is_limited, value, limit = self._is_rate_limited(client_ip, request.url.path)
 
         if is_limited:
             return JSONResponse(
@@ -76,7 +147,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         response.headers["X-RateLimit-Remaining"] = str(value)
-        response.headers["X-RateLimit-Limit"] = str(self.config.requests_per_window)
+        response.headers["X-RateLimit-Limit"] = str(limit)
         return response
 
 

--- a/api/tests/test_ratelimit.py
+++ b/api/tests/test_ratelimit.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+
+from api.middleware.ratelimit import RateLimitConfig, RateLimitMiddleware
+
+
+def _middleware(tmp_path: Path, **kwargs) -> RateLimitMiddleware:
+    app = FastAPI()
+    config = RateLimitConfig(storage_path=str(tmp_path / "ratelimit.sqlite3"), **kwargs)
+    return RateLimitMiddleware(app, config=config)
+
+
+def test_x_forwarded_for_is_ignored_without_trusted_proxy(tmp_path):
+    middleware = _middleware(tmp_path)
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.10"),
+        headers={"X-Forwarded-For": "198.51.100.99"},
+    )
+
+    assert middleware._get_client_ip(request) == "203.0.113.10"
+
+
+def test_x_forwarded_for_allowed_for_trusted_proxy(tmp_path):
+    middleware = _middleware(tmp_path, trusted_proxies={"203.0.113.10"})
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.10"),
+        headers={"X-Forwarded-For": "198.51.100.99, 203.0.113.10"},
+    )
+
+    assert middleware._get_client_ip(request) == "198.51.100.99"
+
+
+def test_sliding_window_smooths_boundary(tmp_path):
+    now = [1000.0]
+    middleware = _middleware(
+        tmp_path,
+        requests_per_window=2,
+        window_seconds=10,
+        time_fn=lambda: now[0],
+    )
+
+    assert middleware._is_rate_limited("ip", "/tasks") == (False, 1, 2)
+    now[0] = 1001.0
+    assert middleware._is_rate_limited("ip", "/tasks") == (False, 0, 2)
+    now[0] = 1002.0
+    assert middleware._is_rate_limited("ip", "/tasks") == (True, 8, 2)
+    now[0] = 1010.1
+    assert middleware._is_rate_limited("ip", "/tasks") == (False, 0, 2)
+
+
+def test_rate_limits_survive_middleware_restart(tmp_path):
+    first = _middleware(tmp_path, requests_per_window=1, window_seconds=60)
+    assert first._is_rate_limited("ip", "/agents") == (False, 0, 1)
+
+    restarted = _middleware(tmp_path, requests_per_window=1, window_seconds=60)
+    limited, retry_after, limit = restarted._is_rate_limited("ip", "/agents")
+
+    assert limited is True
+    assert retry_after > 0
+    assert limit == 1
+
+
+def test_per_endpoint_limits(tmp_path):
+    middleware = _middleware(
+        tmp_path,
+        requests_per_window=10,
+        window_seconds=60,
+        endpoint_limits={"/payments": (1, 60)},
+    )
+
+    assert middleware._is_rate_limited("ip", "/payments/claim") == (False, 0, 1)
+    assert middleware._is_rate_limited("ip", "/payments/claim")[0] is True
+
+    assert middleware._is_rate_limited("ip", "/agents") == (False, 9, 10)


### PR DESCRIPTION
/claim #78

Summary:
- ignore spoofable X-Forwarded-For unless the connection IP is an explicitly trusted proxy
- replace fixed in-memory counters with SQLite-backed sliding-window events that survive middleware restart
- support per-endpoint limit overrides and return endpoint-specific rate-limit headers

Verification:
- python -m pytest .\api\tests\test_ratelimit.py
- python -m py_compile .\api\middleware\ratelimit.py .\api\tests\test_ratelimit.py
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.