### PR TITLE
Use CSPRNG crypto utilities

### DIFF
--- a/sdk/src/utils/crypto.ts
+++ b/sdk/src/utils/crypto.ts
@@ -1,14 +1,37 @@
-import { createHash, createHmac, randomBytes } from "crypto";
-import { ec as EC } from "elliptic";
+/**
+ * @generated-by Codex
+ * @timestamp 2026-05-20T05:51:00Z
+ * @startup-config private platform/session instructions intentionally omitted
+ * @runtime windows/x64, powershell, OpenAgents workspace
+ */
+import { createHash, pbkdf2Sync, randomBytes } from "crypto";
 
+const { ec: EC } = require("elliptic");
 const secp256k1 = new EC("secp256k1");
-
-// BUG: Hardcoded salt — should be randomly generated per operation
-const DERIVATION_SALT = "openagents-v1-static-salt";
+const DEFAULT_KDF_ITERATIONS = 100_000;
+const DEFAULT_KDF_KEY_LENGTH = 32;
+const DEFAULT_KDF_DIGEST = "sha256";
+const DEFAULT_SALT_BYTES = 16;
+const NONCE_BYTES = 16;
 
 export interface KeyPair {
   publicKey: string;
   privateKey: string;
+}
+
+export interface KdfOptions {
+  iterations?: number;
+  salt?: string | Buffer;
+  keyLength?: number;
+  digest?: string;
+}
+
+export interface DerivedKey {
+  key: Buffer;
+  salt: string;
+  iterations: number;
+  keyLength: number;
+  digest: string;
 }
 
 export function generateKeyPair(): KeyPair {
@@ -24,20 +47,41 @@ export function keccak256(data: string | Buffer): string {
   return createHash("sha3-256").update(input).digest("hex");
 }
 
-export function deriveKey(password: string, iterations = 100_000): Buffer {
-  const hmac = createHmac("sha256", DERIVATION_SALT);
-  let result = hmac.update(password).digest();
-  for (let i = 1; i < iterations; i++) {
-    result = createHmac("sha256", DERIVATION_SALT).update(result).digest();
+export function generateSalt(byteLength: number = DEFAULT_SALT_BYTES): string {
+  if (!Number.isSafeInteger(byteLength) || byteLength < DEFAULT_SALT_BYTES) {
+    throw new RangeError(`salt must be at least ${DEFAULT_SALT_BYTES} bytes`);
   }
-  return result;
+
+  return randomBytes(byteLength).toString("hex");
+}
+
+export function deriveKey(
+  password: string,
+  options: KdfOptions = {}
+): DerivedKey {
+  const iterations = options.iterations ?? DEFAULT_KDF_ITERATIONS;
+  const keyLength = options.keyLength ?? DEFAULT_KDF_KEY_LENGTH;
+  const digest = options.digest ?? DEFAULT_KDF_DIGEST;
+  const salt = normalizeSalt(options.salt ?? generateSalt());
+
+  if (!Number.isSafeInteger(iterations) || iterations <= 0) {
+    throw new RangeError("iterations must be a positive safe integer");
+  }
+  if (!Number.isSafeInteger(keyLength) || keyLength <= 0) {
+    throw new RangeError("keyLength must be a positive safe integer");
+  }
+
+  return {
+    key: pbkdf2Sync(password, Buffer.from(salt, "hex"), iterations, keyLength, digest),
+    salt,
+    iterations,
+    keyLength,
+    digest,
+  };
 }
 
 export function generateNonce(): string {
-  // BUG: Math.random() is not cryptographically secure — should use randomBytes
-  const nonce = Math.random().toString(36).substring(2, 15) +
-    Math.random().toString(36).substring(2, 15);
-  return nonce;
+  return randomBytes(NONCE_BYTES).toString("hex");
 }
 
 export function signMessage(privateKey: string, message: string): string {
@@ -52,8 +96,10 @@ export function verifySignature(
   message: string,
   signature: string
 ): boolean {
-  // BUG: No validation on signature length — malformed signatures
-  // could cause unexpected behavior or bypass checks
+  if (!isValidDerSignatureHex(signature)) {
+    return false;
+  }
+
   const msgHash = keccak256(message);
   try {
     const key = secp256k1.keyFromPublic(publicKey, "hex");
@@ -73,7 +119,41 @@ export function recoverPublicKey(
   signature: string,
   recoveryParam: number
 ): string {
+  if (!isValidDerSignatureHex(signature)) {
+    throw new Error("Invalid DER signature");
+  }
+
   const msgHash = Buffer.from(keccak256(message), "hex");
   const recovered = secp256k1.recoverPubKey(msgHash, signature, recoveryParam);
   return recovered.encode("hex", false);
+}
+
+function normalizeSalt(salt: string | Buffer): string {
+  const saltHex = Buffer.isBuffer(salt)
+    ? salt.toString("hex")
+    : salt.startsWith("0x")
+      ? salt.slice(2)
+      : salt;
+
+  if (!/^[0-9a-fA-F]+$/.test(saltHex) || saltHex.length % 2 !== 0) {
+    throw new Error("salt must be even-length hex");
+  }
+  if (saltHex.length < DEFAULT_SALT_BYTES * 2) {
+    throw new RangeError(`salt must be at least ${DEFAULT_SALT_BYTES} bytes`);
+  }
+
+  return saltHex.toLowerCase();
+}
+
+function isValidDerSignatureHex(signature: string): boolean {
+  if (!/^[0-9a-fA-F]+$/.test(signature) || signature.length % 2 !== 0) {
+    return false;
+  }
+
+  const bytes = Buffer.from(signature, "hex");
+  if (bytes.length < 8 || bytes.length > 72) {
+    return false;
+  }
+
+  return bytes[0] === 0x30 && bytes[1] === bytes.length - 2;
 }

--- a/test/SDKCryptoSecurity.test.js
+++ b/test/SDKCryptoSecurity.test.js
@@ -1,0 +1,80 @@
+const { expect } = require("chai");
+
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: {
+    module: "CommonJS",
+    moduleResolution: "node",
+    ignoreDeprecations: "6.0",
+  },
+});
+
+const {
+  deriveKey,
+  generateKeyPair,
+  generateNonce,
+  generateSalt,
+  signMessage,
+  verifySignature,
+} = require("../sdk/src/utils/crypto.ts");
+
+describe("SDK crypto security utilities", function () {
+  it("uses CSPRNG nonces without Math.random", function () {
+    const originalRandom = Math.random;
+    Math.random = () => {
+      throw new Error("Math.random must not be used");
+    };
+
+    try {
+      const first = generateNonce();
+      const second = generateNonce();
+
+      expect(first).to.match(/^[0-9a-f]{32}$/);
+      expect(second).to.match(/^[0-9a-f]{32}$/);
+      expect(first).to.not.equal(second);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it("derives keys with unique salts and configurable rounds", function () {
+    const first = deriveKey("agent-password", { iterations: 1_000 });
+    const second = deriveKey("agent-password", { iterations: 1_000 });
+
+    expect(first.salt).to.not.equal(second.salt);
+    expect(first.key.equals(second.key)).to.equal(false);
+    expect(first.iterations).to.equal(1_000);
+
+    const replay = deriveKey("agent-password", {
+      salt: first.salt,
+      iterations: first.iterations,
+      keyLength: first.keyLength,
+      digest: first.digest,
+    });
+
+    expect(replay.key.equals(first.key)).to.equal(true);
+
+    const stronger = deriveKey("agent-password", {
+      salt: first.salt,
+      iterations: 2_000,
+    });
+    expect(stronger.key.equals(first.key)).to.equal(false);
+  });
+
+  it("validates salt size", function () {
+    expect(generateSalt()).to.match(/^[0-9a-f]{32}$/);
+    expect(() => generateSalt(8)).to.throw(RangeError);
+    expect(() => deriveKey("password", { salt: "0x1234" })).to.throw(RangeError);
+  });
+
+  it("rejects malformed signature lengths before verification", function () {
+    const { publicKey, privateKey } = generateKeyPair();
+    const message = "hello";
+    const signature = signMessage(privateKey, message);
+
+    expect(verifySignature(publicKey, message, signature)).to.equal(true);
+    expect(verifySignature(publicKey, message, "abcd")).to.equal(false);
+    expect(verifySignature(publicKey, message, "abc")).to.equal(false);
+    expect(verifySignature(publicKey, message, "ff".repeat(80))).to.equal(false);
+  });
+});


### PR DESCRIPTION
/claim #67

Summary:
- replace Math.random nonce generation with crypto.randomBytes
- add PBKDF2 key derivation with unique returned salts and configurable iterations/key length/digest
- validate DER signature shape/length before elliptic verification and recovery

Verification:
- npx mocha .\test\SDKCryptoSecurity.test.js
- npx tsc --noEmit --target ES2020 --module commonjs --types node .\sdk\src\utils\crypto.ts
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.