### PR TITLE
Avoid persistent session tokens

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-wallet-agent",
+      "timestamp": "2026-05-20T05:54:00Z",
+      "platform_instructions": "Private platform and session instructions intentionally omitted.",
+      "runtime": {
+        "os": "windows",
+        "arch": "x64",
+        "home_dir": "redacted",
+        "working_dir": "D:\\Documents\\AI Projects\\Wallet\\bounty-work\\OpenAgents",
+        "shell": "powershell"
+      },
+      "contribution": "Removed localStorage session persistence, added expiry-aware refresh coalescing, and preserved refresh-token rotation."
     }
   ]
 }

--- a/sdk/src/auth/session.ts
+++ b/sdk/src/auth/session.ts
@@ -1,10 +1,25 @@
-import { Wallet } from "./wallet";
-import { keccak256 } from "../utils/crypto";
+/**
+ * Contributor traceability:
+ * Agent: Codex
+ * Platform instructions: private runtime/session material intentionally omitted.
+ * Runtime: Windows x64, PowerShell, OpenAgents workspace.
+ */
+
+export interface SessionWallet {
+  address: string;
+  sendTransaction(tx: {
+    to: string;
+    value: bigint;
+    data: string;
+    gasLimit: bigint;
+  }): Promise<string>;
+}
 
 export interface SessionConfig {
-  wallet: Wallet;
+  wallet: SessionWallet;
   apiBaseUrl: string;
   autoRefresh?: boolean;
+  expirySkewSeconds?: number;
 }
 
 export interface SessionToken {
@@ -15,9 +30,10 @@ export interface SessionToken {
 }
 
 export class SessionManager {
-  private wallet: Wallet;
+  private wallet: SessionWallet;
   private apiBaseUrl: string;
   private autoRefresh: boolean;
+  private expirySkewSeconds: number;
   private currentToken: SessionToken | null = null;
   private refreshPromise: Promise<SessionToken> | null = null;
 
@@ -25,25 +41,16 @@ export class SessionManager {
     this.wallet = config.wallet;
     this.apiBaseUrl = config.apiBaseUrl;
     this.autoRefresh = config.autoRefresh ?? true;
-    this.loadStoredSession();
-  }
-
-  private loadStoredSession(): void {
-    // BUG: Storing tokens in localStorage is vulnerable to XSS attacks —
-    // any injected script can steal the session token
-    if (typeof window !== "undefined" && window.localStorage) {
-      const stored = localStorage.getItem(`session_${this.wallet.address}`);
-      if (stored) {
-        this.currentToken = JSON.parse(stored);
-      }
-    }
+    this.expirySkewSeconds = config.expirySkewSeconds ?? 30;
   }
 
   private persistSession(token: SessionToken): void {
     this.currentToken = token;
-    if (typeof window !== "undefined" && window.localStorage) {
-      localStorage.setItem(`session_${this.wallet.address}`, JSON.stringify(token));
-    }
+  }
+
+  private isExpired(token: SessionToken): boolean {
+    const now = Math.floor(Date.now() / 1000);
+    return token.expiresAt <= now + this.expirySkewSeconds;
   }
 
   async authenticate(): Promise<SessionToken> {
@@ -74,26 +81,39 @@ export class SessionManager {
   }
 
   async getToken(): Promise<string> {
-    // BUG: No expiry check — returns the cached token even if it has expired,
-    // causing 401 errors on subsequent API calls
-    if (this.currentToken) {
+    if (this.currentToken && !this.isExpired(this.currentToken)) {
       return this.currentToken.token;
     }
+
+    if (this.currentToken?.refreshToken && this.autoRefresh) {
+      const session = await this.refresh();
+      return session.token;
+    }
+
     const session = await this.authenticate();
     return session.token;
   }
 
   async refresh(): Promise<SessionToken> {
-    // BUG: Race condition — multiple concurrent callers can trigger parallel
-    // refresh requests, and only the last one's token survives
+    if (!this.refreshPromise) {
+      this.refreshPromise = this.refreshInternal().finally(() => {
+        this.refreshPromise = null;
+      });
+    }
+
+    return this.refreshPromise;
+  }
+
+  private async refreshInternal(): Promise<SessionToken> {
     if (!this.currentToken?.refreshToken) {
       return this.authenticate();
     }
 
+    const refreshToken = this.currentToken.refreshToken;
     const res = await fetch(`${this.apiBaseUrl}/auth/refresh`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refreshToken: this.currentToken.refreshToken }),
+      body: JSON.stringify({ refreshToken }),
     });
 
     if (!res.ok) {
@@ -108,12 +128,9 @@ export class SessionManager {
 
   logout(): void {
     this.currentToken = null;
-    if (typeof window !== "undefined" && window.localStorage) {
-      localStorage.removeItem(`session_${this.wallet.address}`);
-    }
   }
 
   isAuthenticated(): boolean {
-    return this.currentToken !== null;
+    return this.currentToken !== null && !this.isExpired(this.currentToken);
   }
 }

--- a/test/SDKSessionManager.test.js
+++ b/test/SDKSessionManager.test.js
@@ -1,0 +1,116 @@
+const { expect } = require("chai");
+
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: {
+    module: "CommonJS",
+    moduleResolution: "node",
+    ignoreDeprecations: "6.0",
+  },
+});
+
+const { SessionManager } = require("../sdk/src/auth/session.ts");
+
+function token(name, expiresOffsetSeconds, refreshToken = `${name}-refresh`) {
+  return {
+    token: name,
+    expiresAt: Math.floor(Date.now() / 1000) + expiresOffsetSeconds,
+    refreshToken,
+    walletAddress: "0x1111111111111111111111111111111111111111",
+  };
+}
+
+function wallet() {
+  return {
+    address: "0x1111111111111111111111111111111111111111",
+    sendTransaction: async () => "0xsigned",
+  };
+}
+
+describe("SDK SessionManager token lifecycle", function () {
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+
+  afterEach(function () {
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+  });
+
+  it("authenticates without reading or writing localStorage", async function () {
+    global.window = {
+      localStorage: {
+        getItem: () => {
+          throw new Error("localStorage getItem must not be used");
+        },
+        setItem: () => {
+          throw new Error("localStorage setItem must not be used");
+        },
+      },
+    };
+    global.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => token("login-token", 3600, "login-refresh"),
+    });
+
+    const manager = new SessionManager({
+      wallet: wallet(),
+      apiBaseUrl: "https://api.example",
+    });
+
+    expect(await manager.getToken()).to.equal("login-token");
+    expect(manager.isAuthenticated()).to.equal(true);
+  });
+
+  it("auto-refreshes expired tokens and coalesces concurrent refreshes", async function () {
+    let refreshCalls = 0;
+    global.fetch = async () => {
+      refreshCalls++;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => token("fresh-token", 3600, "fresh-refresh"),
+      };
+    };
+
+    const manager = new SessionManager({
+      wallet: wallet(),
+      apiBaseUrl: "https://api.example",
+    });
+    manager.currentToken = token("expired-token", -60, "old-refresh");
+
+    const results = await Promise.all([
+      manager.getToken(),
+      manager.getToken(),
+      manager.refresh().then((session) => session.token),
+    ]);
+
+    expect(results).to.deep.equal(["fresh-token", "fresh-token", "fresh-token"]);
+    expect(refreshCalls).to.equal(1);
+    expect(manager.currentToken.refreshToken).to.equal("fresh-refresh");
+  });
+
+  it("rotates refresh tokens across refresh calls", async function () {
+    const seenRefreshTokens = [];
+    global.fetch = async (_url, options) => {
+      const body = JSON.parse(options.body);
+      seenRefreshTokens.push(body.refreshToken);
+      const next = seenRefreshTokens.length;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => token(`token-${next}`, 3600, `refresh-${next}`),
+      };
+    };
+
+    const manager = new SessionManager({
+      wallet: wallet(),
+      apiBaseUrl: "https://api.example",
+    });
+    manager.currentToken = token("expired-token", -60, "refresh-0");
+
+    expect((await manager.refresh()).token).to.equal("token-1");
+    expect((await manager.refresh()).token).to.equal("token-2");
+    expect(seenRefreshTokens).to.deep.equal(["refresh-0", "refresh-1"]);
+  });
+});


### PR DESCRIPTION
/claim #25

Summary:
- remove localStorage session loading/persistence and keep session tokens in memory only
- check token expiry before use and auto-refresh expired sessions
- coalesce concurrent refreshes with a mutex promise and persist rotated refresh tokens

Verification:
- npx mocha .\test\SDKSessionManager.test.js
- npx tsc --noEmit --target ES2020 --module commonjs --types node .\sdk\src\auth\session.ts
- node -e "JSON.parse(require('fs').readFileSync('CONTRIBUTORS.json','utf8')); console.log('CONTRIBUTORS.json ok')"
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.