### PR TITLE
Paginate SDK open task fetches

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * @fix-author: Codex
+ * @date: 2026-05-20
+ * @platform-config: private platform/session instructions intentionally omitted
+ * @runtime: windows/x64, powershell, OpenAgents workspace
+ */
 import { ethers } from "ethers";
 
 export interface AgentConfig {
@@ -7,23 +13,47 @@ export interface AgentConfig {
   rpcUrl: string;
   registryAddress: string;
   routerAddress: string;
+  provider?: ethers.Provider;
+  signer?: ethers.Signer;
+  contractFactory?: (
+    address: string,
+    abi: string[],
+    runner: ethers.ContractRunner | null
+  ) => any;
+}
+
+export interface GetOpenTasksOptions {
+  offset?: number;
+  limit?: number;
+  status?: number | null;
+  batchSize?: number;
+}
+
+export interface OpenTask {
+  id: number;
+  creator: string;
+  description: string;
+  reward: bigint;
+  deadline: bigint;
+  status: number;
 }
 
 export class OpenAgentsSDK {
-  private provider: ethers.JsonRpcProvider;
-  private signer: ethers.Wallet;
+  private provider: ethers.Provider;
+  private signer: ethers.Signer;
   private config: AgentConfig;
+  private taskCountCache: { blockNumber: number; count: number } | null = null;
 
   constructor(config: AgentConfig) {
     this.config = config;
-    this.provider = new ethers.JsonRpcProvider(config.rpcUrl);
-    this.signer = new ethers.Wallet(config.privateKey, this.provider);
+    this.provider = config.provider ?? new ethers.JsonRpcProvider(config.rpcUrl);
+    this.signer = config.signer ?? new ethers.Wallet(config.privateKey, this.provider);
   }
 
   async registerAgent(): Promise<string> {
-    const registry = new ethers.Contract(
+    const registry = this.createContract(
       this.config.registryAddress,
-      ["function registerAgent(string,string) payable returns (bytes32)"],
+      ["function registerAgent(string,string) payable returns (bytes32)", "function registrationFee() view returns (uint256)"],
       this.signer
     );
 
@@ -38,21 +68,13 @@ export class OpenAgentsSDK {
   }
 
   async claimTask(taskId: number, agentId: string): Promise<void> {
-    const router = new ethers.Contract(
-      this.config.routerAddress,
-      ["function assignTask(uint256,bytes32)"],
-      this.signer
-    );
+    const router = this.createRouter(this.signer);
     const tx = await router.assignTask(taskId, agentId);
     await tx.wait();
   }
 
   async submitResult(taskId: number, result: string): Promise<void> {
-    const router = new ethers.Contract(
-      this.config.routerAddress,
-      ["function completeTask(uint256,bytes)"],
-      this.signer
-    );
+    const router = this.createRouter(this.signer);
     const tx = await router.completeTask(
       taskId,
       ethers.toUtf8Bytes(result)
@@ -60,32 +82,81 @@ export class OpenAgentsSDK {
     await tx.wait();
   }
 
-  async getOpenTasks(): Promise<any[]> {
-    const router = new ethers.Contract(
-      this.config.routerAddress,
-      [
-        "function taskCount() view returns (uint256)",
-        "function tasks(uint256) view returns (address,bytes32,string,uint256,uint256,uint8,bytes)",
-      ],
-      this.provider
-    );
+  async getOpenTasks(options: GetOpenTasksOptions = {}): Promise<OpenTask[]> {
+    const offset = Math.max(0, options.offset ?? 0);
+    const limit = Math.max(0, options.limit ?? 50);
+    const batchSize = Math.min(10, Math.max(1, options.batchSize ?? 10));
+    const statusFilter = options.status === undefined ? 0 : options.status;
+    if (limit === 0) {
+      return [];
+    }
 
-    const count = await router.taskCount();
-    const openTasks = [];
+    const router = this.createRouter(this.provider);
+    const count = await this.getCachedTaskCount(router);
+    const end = Math.min(count, offset + limit);
+    const taskIds = [];
+    for (let id = offset; id < end; id++) {
+      taskIds.push(id);
+    }
 
-    for (let i = 0; i < count; i++) {
-      const task = await router.tasks(i);
-      if (task[5] === 0) {
-        openTasks.push({
-          id: i,
-          creator: task[0],
-          description: task[2],
-          reward: task[3],
-          deadline: task[4],
-        });
+    const openTasks: OpenTask[] = [];
+    for (let i = 0; i < taskIds.length; i += batchSize) {
+      const batch = taskIds.slice(i, i + batchSize);
+      const tasks = await Promise.all(
+        batch.map(async (id) => ({ id, task: await router.tasks(id) }))
+      );
+
+      for (const { id, task } of tasks) {
+        const status = Number(task[5]);
+        if (statusFilter === null || status === statusFilter) {
+          openTasks.push({
+            id,
+            creator: task[0],
+            description: task[2],
+            reward: task[3],
+            deadline: task[4],
+            status,
+          });
+        }
       }
     }
 
     return openTasks;
+  }
+
+  private async getCachedTaskCount(router: any): Promise<number> {
+    const blockNumber = await this.provider.getBlockNumber();
+    if (this.taskCountCache?.blockNumber === blockNumber) {
+      return this.taskCountCache.count;
+    }
+
+    const count = Number(await router.taskCount());
+    this.taskCountCache = { blockNumber, count };
+    return count;
+  }
+
+  private createRouter(runner: ethers.ContractRunner | null): any {
+    return this.createContract(
+      this.config.routerAddress,
+      [
+        "function assignTask(uint256,bytes32)",
+        "function completeTask(uint256,bytes)",
+        "function taskCount() view returns (uint256)",
+        "function tasks(uint256) view returns (address,bytes32,string,uint256,uint256,uint8,bytes)",
+      ],
+      runner
+    );
+  }
+
+  private createContract(
+    address: string,
+    abi: string[],
+    runner: ethers.ContractRunner | null
+  ): any {
+    if (this.config.contractFactory) {
+      return this.config.contractFactory(address, abi, runner);
+    }
+
+    return new ethers.Contract(address, abi, runner);
   }
 }

--- a/test/SDKOpenTasks.test.js
+++ b/test/SDKOpenTasks.test.js
@@ -1,0 +1,101 @@
+const { expect } = require("chai");
+
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: {
+    module: "CommonJS",
+    moduleResolution: "node",
+    ignoreDeprecations: "6.0",
+  },
+});
+
+const { OpenAgentsSDK } = require("../sdk/src/index.ts");
+
+function sdkWith(router, provider) {
+  return new OpenAgentsSDK({
+    name: "agent",
+    endpoint: "https://agent.example",
+    privateKey: "0x" + "1".repeat(64),
+    rpcUrl: "http://localhost:8545",
+    registryAddress: "0x" + "2".repeat(40),
+    routerAddress: "0x" + "3".repeat(40),
+    provider,
+    signer: {},
+    contractFactory: () => router,
+  });
+}
+
+function task(id, status = 0) {
+  return [
+    "0x" + String(id % 10).repeat(40),
+    "0x" + "0".repeat(64),
+    `task-${id}`,
+    BigInt(id + 1),
+    BigInt(1000 + id),
+    status,
+    "0x",
+  ];
+}
+
+describe("OpenAgentsSDK getOpenTasks", function () {
+  it("paginates and fetches tasks concurrently in batches of ten", async function () {
+    let active = 0;
+    let maxActive = 0;
+    const fetched = [];
+    const router = {
+      taskCount: async () => 30n,
+      tasks: async (id) => {
+        fetched.push(id);
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active--;
+        return task(id, 0);
+      },
+    };
+    const provider = { getBlockNumber: async () => 7 };
+    const sdk = sdkWith(router, provider);
+
+    const result = await sdk.getOpenTasks({ offset: 5, limit: 12 });
+
+    expect(result.map((entry) => entry.id)).to.deep.equal([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    expect(fetched).to.deep.equal([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    expect(maxActive).to.equal(10);
+  });
+
+  it("filters by requested status", async function () {
+    const router = {
+      taskCount: async () => 5n,
+      tasks: async (id) => task(id, id % 2),
+    };
+    const provider = { getBlockNumber: async () => 8 };
+    const sdk = sdkWith(router, provider);
+
+    const closed = await sdk.getOpenTasks({ limit: 5, status: 1 });
+    const all = await sdk.getOpenTasks({ limit: 5, status: null });
+
+    expect(closed.map((entry) => entry.id)).to.deep.equal([1, 3]);
+    expect(all.map((entry) => entry.id)).to.deep.equal([0, 1, 2, 3, 4]);
+  });
+
+  it("caches task count for one block", async function () {
+    let blockNumber = 10;
+    let countCalls = 0;
+    const router = {
+      taskCount: async () => {
+        countCalls++;
+        return 3n;
+      },
+      tasks: async (id) => task(id, 0),
+    };
+    const provider = { getBlockNumber: async () => blockNumber };
+    const sdk = sdkWith(router, provider);
+
+    await sdk.getOpenTasks({ limit: 2 });
+    await sdk.getOpenTasks({ limit: 2 });
+    blockNumber = 11;
+    await sdk.getOpenTasks({ limit: 2 });
+
+    expect(countCalls).to.equal(2);
+  });
+});


### PR DESCRIPTION
/claim #113

Summary:
- add getOpenTasks offset/limit/status/batchSize options
- fetch task pages concurrently in batches capped at 10 calls
- cache taskCount for the current provider block

Verification:
- npx mocha .\test\SDKOpenTasks.test.js
- npx tsc --noEmit --target ES2020 --module commonjs --types node .\sdk\src\index.ts
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.