### PR TITLE
Add conditional retry policy

### DIFF
--- a/sdk/src/utils/retry.ts
+++ b/sdk/src/utils/retry.ts
@@ -1,28 +1,51 @@
 /**
+ * @generated-by Codex
+ * @timestamp 2026-05-20T06:03:00Z
+ * @startup-config private platform/session instructions intentionally omitted
+ * @runtime windows/x64, powershell, OpenAgents workspace
+ */
+
+/**
  * Retry utility with exponential backoff for unreliable RPC calls.
  */
+
+export type RetryCondition = (error: Error, attempt: number) => boolean;
+export type BackoffMultiplier = number | ((error: Error) => number);
 
 export interface RetryOptions {
   maxRetries?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
+  retryCondition?: RetryCondition;
+  backoffMultipliers?: Record<string, BackoffMultiplier>;
   onRetry?: (attempt: number, error: Error) => void;
+  sleepFn?: (ms: number) => Promise<void>;
 }
 
-const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "onRetry">> = {
-  maxRetries: Infinity, // BUG: No cap — will retry forever by default
+type ResolvedRetryOptions = Required<
+  Omit<RetryOptions, "retryCondition" | "backoffMultipliers" | "onRetry" | "sleepFn">
+>;
+
+const DEFAULT_OPTIONS: ResolvedRetryOptions = {
+  maxRetries: 5,
   baseDelayMs: 500,
   maxDelayMs: 30_000,
 };
 
 export class RetryHandler {
-  private options: Required<Omit<RetryOptions, "onRetry">>;
+  private options: ResolvedRetryOptions;
+  private retryCondition: RetryCondition;
+  private backoffMultipliers: Record<string, BackoffMultiplier>;
   private onRetry?: (attempt: number, error: Error) => void;
+  private sleepFn: (ms: number) => Promise<void>;
   private consecutiveFailures = 0;
 
   constructor(options: RetryOptions = {}) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.retryCondition = options.retryCondition ?? isRetryable;
+    this.backoffMultipliers = options.backoffMultipliers ?? {};
     this.onRetry = options.onRetry;
+    this.sleepFn = options.sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   }
 
   async execute<T>(fn: () => Promise<T>): Promise<T> {
@@ -31,34 +54,54 @@ export class RetryHandler {
     for (let attempt = 0; attempt <= this.options.maxRetries; attempt++) {
       try {
         const result = await fn();
-        // BUG: consecutiveFailures is never reset on success,
-        // so backoff keeps growing even after recovery
+        this.reset();
         return result;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         this.consecutiveFailures++;
 
-        if (attempt < this.options.maxRetries) {
-          this.onRetry?.(attempt + 1, lastError);
-          const delay = this.calculateBackoff(attempt);
-          await this.sleep(delay);
+        const nextAttempt = attempt + 1;
+        const shouldRetry =
+          attempt < this.options.maxRetries &&
+          this.retryCondition(lastError, nextAttempt);
+
+        if (!shouldRetry) {
+          break;
         }
+
+        this.onRetry?.(nextAttempt, lastError);
+        const delay = this.calculateBackoff(attempt, lastError);
+        await this.sleep(delay);
       }
     }
 
     throw lastError ?? new Error("Retry failed with unknown error");
   }
 
-  private calculateBackoff(attempt: number): number {
-    // BUG: 2 ** attempt overflows to Infinity for large attempt values (attempt > ~1023),
-    // and Math.min with Infinity returns maxDelayMs, but intermediate calc can cause issues
-    const exponentialDelay = this.options.baseDelayMs * Math.pow(2, attempt);
+  private calculateBackoff(attempt: number, error: Error): number {
+    const exponent = Math.min(attempt, 30);
+    const exponentialDelay = this.options.baseDelayMs * Math.pow(2, exponent);
     const jitter = Math.random() * this.options.baseDelayMs;
-    return Math.min(exponentialDelay + jitter, this.options.maxDelayMs);
+    const multiplier = this.getBackoffMultiplier(error);
+    return Math.min((exponentialDelay + jitter) * multiplier, this.options.maxDelayMs);
+  }
+
+  private getBackoffMultiplier(error: Error): number {
+    const keys = getErrorKeys(error);
+    for (const key of keys) {
+      const multiplier = this.backoffMultipliers[key];
+      if (typeof multiplier === "number") {
+        return multiplier;
+      }
+      if (typeof multiplier === "function") {
+        return multiplier(error);
+      }
+    }
+    return 1;
   }
 
   private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return this.sleepFn(ms);
   }
 
   getFailureCount(): number {
@@ -79,9 +122,49 @@ export async function withRetry<T>(
 }
 
 export function isRetryable(error: Error): boolean {
-  const retryableCodes = ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "429"];
+  const status = getHttpStatus(error);
+  if (status !== undefined) {
+    return status === 429 || status >= 500;
+  }
+
+  const retryableCodes = ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "ENOTFOUND"];
+  const code = getErrorCode(error);
+  if (code && retryableCodes.includes(code.toUpperCase())) {
+    return true;
+  }
+
   const message = error.message.toLowerCase();
-  return retryableCodes.some(
-    (code) => message.includes(code.toLowerCase())
+  return ["timeout", "network", "temporarily unavailable"].some((needle) =>
+    message.includes(needle)
   );
+}
+
+function getHttpStatus(error: Error): number | undefined {
+  const candidate = error as Error & {
+    status?: number;
+    statusCode?: number;
+    response?: { status?: number };
+  };
+  const status = candidate.status ?? candidate.statusCode ?? candidate.response?.status;
+  if (typeof status === "number") {
+    return status;
+  }
+
+  const match = error.message.match(/\b([45]\d{2})\b/);
+  return match ? Number(match[1]) : undefined;
+}
+
+function getErrorCode(error: Error): string | undefined {
+  const candidate = error as Error & { code?: string };
+  return typeof candidate.code === "string" ? candidate.code : undefined;
+}
+
+function getErrorKeys(error: Error): string[] {
+  const keys = [];
+  const status = getHttpStatus(error);
+  const code = getErrorCode(error);
+  if (status !== undefined) keys.push(String(status));
+  if (code) keys.push(code, code.toUpperCase());
+  keys.push(error.name);
+  return keys;
 }

--- a/test/SDKRetryConditional.test.js
+++ b/test/SDKRetryConditional.test.js
@@ -1,0 +1,112 @@
+const { expect } = require("chai");
+
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: {
+    module: "CommonJS",
+    moduleResolution: "node",
+    ignoreDeprecations: "6.0",
+  },
+});
+
+const { isRetryable, withRetry } = require("../sdk/src/utils/retry.ts");
+
+function statusError(status) {
+  const error = new Error(`HTTP ${status}`);
+  error.status = status;
+  return error;
+}
+
+describe("SDK retry conditional policy", function () {
+  it("retries 5xx errors and calls onRetry", async function () {
+    let attempts = 0;
+    const retryAttempts = [];
+
+    const result = await withRetry(
+      async () => {
+        attempts++;
+        if (attempts < 3) {
+          throw statusError(500);
+        }
+        return "ok";
+      },
+      {
+        maxRetries: 3,
+        baseDelayMs: 1,
+        onRetry: (attempt, error) => retryAttempts.push([attempt, error.status]),
+        sleepFn: async () => {},
+      }
+    );
+
+    expect(result).to.equal("ok");
+    expect(attempts).to.equal(3);
+    expect(retryAttempts).to.deep.equal([[1, 500], [2, 500]]);
+  });
+
+  it("does not retry 4xx errors by default", async function () {
+    let attempts = 0;
+
+    try {
+      await withRetry(
+        async () => {
+          attempts++;
+          throw statusError(400);
+        },
+        { maxRetries: 3, sleepFn: async () => {} }
+      );
+      throw new Error("expected retry failure");
+    } catch (error) {
+      expect(error.status).to.equal(400);
+    }
+
+    expect(attempts).to.equal(1);
+    expect(isRetryable(statusError(400))).to.equal(false);
+  });
+
+  it("allows custom retry conditions to override defaults", async function () {
+    let attempts = 0;
+
+    const result = await withRetry(
+      async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw statusError(400);
+        }
+        return "custom-ok";
+      },
+      {
+        maxRetries: 1,
+        retryCondition: (error) => error.status === 400,
+        sleepFn: async () => {},
+      }
+    );
+
+    expect(result).to.equal("custom-ok");
+    expect(attempts).to.equal(2);
+  });
+
+  it("applies per-error backoff multipliers", async function () {
+    const sleeps = [];
+
+    try {
+      await withRetry(
+        async () => {
+          throw statusError(503);
+        },
+        {
+          maxRetries: 1,
+          baseDelayMs: 10,
+          backoffMultipliers: { "503": 3 },
+          sleepFn: async (ms) => sleeps.push(ms),
+        }
+      );
+      throw new Error("expected retry failure");
+    } catch (error) {
+      expect(error.status).to.equal(503);
+    }
+
+    expect(sleeps).to.have.length(1);
+    expect(sleeps[0]).to.be.at.least(30);
+    expect(sleeps[0]).to.be.below(60);
+  });
+});


### PR DESCRIPTION
/claim #137

Summary:
- add retryCondition support with default retry behavior for network/429/5xx errors and fail-fast 4xx handling
- preserve onRetry callback with attempt number and error
- add per-error backoff multipliers and bounded exponential backoff

Verification:
- npx mocha .\test\SDKRetryConditional.test.js
- npx tsc --noEmit --target ES2020 --module commonjs --types node .\sdk\src\utils\retry.ts
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.