### PR TITLE
Filter soft-deleted agents

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -30,7 +30,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     address = Column(String(42), unique=True, nullable=False)
     username = Column(String(64), unique=True, nullable=True)
-    # BUG: No index on address — wallet lookups on every auth request do full table scans
+    # BUG: No index on address - wallet lookups on every auth request do full table scans
     created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
 
     agents = relationship("Agent", back_populates="owner")
@@ -46,8 +46,9 @@ class Agent(Base):
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+    deleted_at = Column(DateTime, nullable=True)
 
-    # BUG: No cascade delete — deleting a user leaves orphaned agents
+    # BUG: No cascade delete - deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
     tasks = relationship("Task", back_populates="agent")
 

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,4 +1,8 @@
-"""Agent CRUD endpoints for the OpenAgents platform."""
+"""Agent CRUD endpoints for the OpenAgents platform.
+
+@contributor-info: Codex; private session initialization context intentionally omitted.
+@runtime: windows/x64, powershell, OpenAgents workspace.
+"""
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -12,7 +16,7 @@ router = APIRouter(prefix="/agents", tags=["agents"])
 
 
 class AgentCreate(BaseModel):
-    name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    name: str  # BUG: No validation - name can contain SQL injection, XSS, or be empty
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
@@ -22,6 +26,18 @@ class AgentUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     config: Optional[dict] = None
+
+
+def serialize_agent(agent: Agent) -> dict:
+    return {
+        "id": agent.id,
+        "name": agent.name,
+        "description": agent.description,
+        "model_type": agent.model_type,
+        "owner_id": agent.owner_id,
+        "created_at": agent.created_at,
+        "deleted_at": agent.deleted_at,
+    }
 
 
 @router.post("/")
@@ -43,15 +59,21 @@ async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=De
 @router.get("/")
 async def list_agents(
     owner: Optional[str] = None,
+    include_inactive: bool = Query(False),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1),
     db=Depends(get_db),
 ):
     query = db.query(Agent)
+    if not include_inactive:
+        query = query.filter(Agent.deleted_at.is_(None))
     if owner:
-        # BUG: String interpolation in query — vulnerable to SQL injection
+        # BUG: String interpolation in query - vulnerable to SQL injection
         query = query.filter(Agent.owner_id == owner)
-    return query.offset(skip).limit(limit).all()
+    return [
+        serialize_agent(agent)
+        for agent in query.offset(skip).limit(limit).all()
+    ]
 
 
 @router.get("/{agent_id}")
@@ -77,12 +99,12 @@ async def update_agent(
     return agent
 
 
-# BUG: No authentication — anyone can delete any agent
+# BUG: No authentication - anyone can delete any agent
 @router.delete("/{agent_id}")
 async def delete_agent(agent_id: int, db=Depends(get_db)):
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    db.delete(agent)
+    agent.deleted_at = datetime.utcnow()
     db.commit()
-    return {"deleted": True}
+    return {"deleted": True, "deleted_at": agent.deleted_at}

--- a/api/tests/test_agents_soft_delete.py
+++ b/api/tests/test_agents_soft_delete.py
@@ -1,0 +1,85 @@
+import asyncio
+import os
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import Agent, Base, User
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.routes.agents import delete_agent, list_agents
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return TestingSession()
+
+
+def seed_agents(db):
+    user = User(address="0x1111111111111111111111111111111111111111")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    active = Agent(
+        name="active",
+        description="active agent",
+        model_type="gpt-4",
+        config={"platform_instructions": "must not leak"},
+        owner_id=user.id,
+        created_at=datetime.utcnow(),
+    )
+    deleted = Agent(
+        name="deleted",
+        description="deleted agent",
+        model_type="gpt-4",
+        config={"secret": "must not leak"},
+        owner_id=user.id,
+        created_at=datetime.utcnow(),
+        deleted_at=datetime.utcnow(),
+    )
+    db.add_all([active, deleted])
+    db.commit()
+    return active, deleted
+
+
+def test_default_list_filters_deleted_and_excludes_sensitive_config():
+    db = make_session()
+    active, _deleted = seed_agents(db)
+
+    result = run(list_agents(include_inactive=False, skip=0, limit=50, db=db))
+
+    assert [agent["id"] for agent in result] == [active.id]
+    assert "config" not in result[0]
+    assert "platform_instructions" not in result[0]
+
+
+def test_include_inactive_returns_soft_deleted_agents():
+    db = make_session()
+    active, deleted = seed_agents(db)
+
+    result = run(list_agents(include_inactive=True, skip=0, limit=50, db=db))
+
+    assert [agent["id"] for agent in result] == [active.id, deleted.id]
+    assert result[1]["deleted_at"] is not None
+
+
+def test_delete_agent_sets_deleted_at_without_removing_row():
+    db = make_session()
+    active, _deleted = seed_agents(db)
+
+    response = run(delete_agent(active.id, db=db))
+    db.refresh(active)
+
+    assert response["deleted"] is True
+    assert active.deleted_at is not None
+    assert db.query(Agent).filter(Agent.id == active.id).first() is not None
+    assert run(list_agents(include_inactive=False, skip=0, limit=50, db=db)) == []


### PR DESCRIPTION
/claim #119

Summary:
- add Agent.deleted_at for soft deletes
- filter inactive/deleted agents by default and add include_inactive query support
- return shaped list responses that exclude config/platform instruction fields

Verification:
- python -m pytest .\api\tests\test_agents_soft_delete.py
- python -m py_compile .\api\routes\agents.py .\api\models\database.py .\api\tests\test_agents_soft_delete.py
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.