### PR TITLE
Configure API CORS origins

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,15 @@
+"""OpenAgents FastAPI application.
+
+@contributor: Codex
+@platform: private platform/session instructions intentionally omitted
+@runtime: windows/x64, OpenAgents workspace
+@date: 2026-05-20T06:08:00Z
+"""
+
+import os
+
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
@@ -7,6 +18,32 @@ app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
+)
+
+
+def get_allowed_origins() -> list[str]:
+    environment = os.getenv("ENVIRONMENT", "production").lower()
+    raw_origins = os.getenv("ALLOWED_ORIGINS", "")
+    origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+
+    if "*" in origins:
+        return ["*"] if environment == "development" else []
+
+    if origins:
+        return origins
+
+    if environment == "development":
+        return ["http://localhost:3000", "http://localhost:5173"]
+
+    return []
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=get_allowed_origins(),
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
 )
 
 

--- a/api/tests/test_cors.py
+++ b/api/tests/test_cors.py
@@ -1,0 +1,52 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def load_app(monkeypatch, origins, environment="production"):
+    monkeypatch.setenv("ALLOWED_ORIGINS", origins)
+    monkeypatch.setenv("ENVIRONMENT", environment)
+    import api.main
+
+    return importlib.reload(api.main).app
+
+
+def test_cors_preflight_allows_configured_origin(monkeypatch):
+    app = load_app(monkeypatch, "https://frontend.example")
+    client = TestClient(app)
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://frontend.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "GET" in response.headers["access-control-allow-methods"]
+
+
+def test_cors_get_allows_configured_origin(monkeypatch):
+    app = load_app(monkeypatch, "https://frontend.example")
+    client = TestClient(app)
+
+    response = client.get("/health", headers={"Origin": "https://frontend.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_wildcard_only_allowed_in_development(monkeypatch):
+    prod_app = load_app(monkeypatch, "*", "production")
+    prod_client = TestClient(prod_app)
+    prod_response = prod_client.get("/health", headers={"Origin": "https://frontend.example"})
+    assert "access-control-allow-origin" not in prod_response.headers
+
+    dev_app = load_app(monkeypatch, "*", "development")
+    dev_client = TestClient(dev_app)
+    dev_response = dev_client.get("/health", headers={"Origin": "https://frontend.example"})
+    assert dev_response.headers["access-control-allow-origin"] == "https://frontend.example"


### PR DESCRIPTION
/claim #121

Summary:
- add FastAPI CORSMiddleware configured from ALLOWED_ORIGINS
- allow credentials and common API methods including OPTIONS
- keep wildcard origins restricted to ENVIRONMENT=development

Verification:
- python -m pytest .\api\tests\test_cors.py
- python -m py_compile .\api\main.py .\api\tests\test_cors.py
- git diff --check

Payment: USDC on Base to 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92

Private platform/session initialization text was intentionally omitted.