### PR TITLE
Add structured API error responses

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,17 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "claude-code-b3ar-sudo",
+      "timestamp": "2026-05-20T00:00:00Z",
+      "platform_instructions": "Implemented issue #147 structured API errors. Sensitive credentials, private prompts, local paths, and hidden session directives are intentionally not recorded.",
+      "runtime": {
+        "os": "linux",
+        "arch": "x86_64",
+        "tool": "Claude Code"
+      },
+      "contribution": "Added structured FastAPI error responses, request IDs, error code documentation, and tests for validation, auth, not found, rate limit, and internal errors"
     }
   ]
 }

--- a/api/ERRORS.md
+++ b/api/ERRORS.md
@@ -1,0 +1,26 @@
+# API error responses
+
+All API errors use the same response envelope:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [],
+    "request_id": "7f8b0c3a-1dd2-4efb-83f5-2a4afcb57776"
+  }
+}
+```
+
+`X-Request-ID` is also returned as a response header. Clients may send `X-Request-ID`; otherwise the API generates one.
+
+## Error codes
+
+| Code | HTTP status | Meaning |
+|---|---:|---|
+| `VALIDATION_ERROR` | 400, 422 | The request body, path, or query parameters are invalid. Validation errors include field-level `details`. |
+| `NOT_FOUND` | 404 | The requested resource does not exist. |
+| `AUTH_FAILED` | 401, 403 | Authentication failed or the authenticated caller is not authorized. |
+| `RATE_LIMITED` | 429 | The caller exceeded the configured request limit. `details.retry_after` gives the retry delay in seconds. |
+| `INTERNAL_ERROR` | 500+ | An unexpected server error occurred. |

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,125 @@
+"""Structured API error responses."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette import status
+
+ERROR_CODE_BY_STATUS = {
+    status.HTTP_400_BAD_REQUEST: "VALIDATION_ERROR",
+    status.HTTP_401_UNAUTHORIZED: "AUTH_FAILED",
+    status.HTTP_403_FORBIDDEN: "AUTH_FAILED",
+    status.HTTP_404_NOT_FOUND: "NOT_FOUND",
+    status.HTTP_422_UNPROCESSABLE_ENTITY: "VALIDATION_ERROR",
+    status.HTTP_429_TOO_MANY_REQUESTS: "RATE_LIMITED",
+}
+
+ERROR_MESSAGE_BY_CODE = {
+    "VALIDATION_ERROR": "Request validation failed",
+    "NOT_FOUND": "Resource not found",
+    "AUTH_FAILED": "Authentication failed",
+    "RATE_LIMITED": "Rate limit exceeded",
+    "INTERNAL_ERROR": "Internal server error",
+}
+
+
+def request_id_for(request: Request) -> str:
+    request_id = getattr(request.state, "request_id", None)
+    if request_id:
+        return request_id
+    request_id = request.headers.get("X-Request-ID") or str(uuid4())
+    request.state.request_id = request_id
+    return request_id
+
+
+def error_code_for_status(status_code: int) -> str:
+    if status_code >= 500:
+        return "INTERNAL_ERROR"
+    return ERROR_CODE_BY_STATUS.get(status_code, "VALIDATION_ERROR")
+
+
+def error_response(
+    request: Request,
+    status_code: int,
+    code: str | None = None,
+    message: str | None = None,
+    details: Any = None,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    resolved_code = code or error_code_for_status(status_code)
+    response = JSONResponse(
+        status_code=status_code,
+        content={
+            "error": {
+                "code": resolved_code,
+                "message": message or ERROR_MESSAGE_BY_CODE.get(resolved_code, "Request failed"),
+                "details": details,
+                "request_id": request_id_for(request),
+            }
+        },
+        headers=headers,
+    )
+    response.headers["X-Request-ID"] = request_id_for(request)
+    return response
+
+
+def validation_details(exc: RequestValidationError) -> list[dict[str, Any]]:
+    details = []
+    for error in exc.errors():
+        field_path = ".".join(str(part) for part in error.get("loc", []) if part != "body")
+        details.append(
+            {
+                "field": field_path,
+                "message": error.get("msg"),
+                "type": error.get("type"),
+            }
+        )
+    return details
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def request_id_middleware(request: Request, call_next):
+        request.state.request_id = request.headers.get("X-Request-ID") or str(uuid4())
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request.state.request_id
+        return response
+
+    @app.exception_handler(RequestValidationError)
+    async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
+        return error_response(
+            request,
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            code="VALIDATION_ERROR",
+            message="Request validation failed",
+            details=validation_details(exc),
+        )
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(request: Request, exc: HTTPException):
+        code = error_code_for_status(exc.status_code)
+        message = exc.detail if isinstance(exc.detail, str) else ERROR_MESSAGE_BY_CODE.get(code)
+        details = None if isinstance(exc.detail, str) else exc.detail
+        return error_response(
+            request,
+            exc.status_code,
+            code=code,
+            message=message,
+            details=details,
+            headers=exc.headers,
+        )
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        return error_response(
+            request,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            code="INTERNAL_ERROR",
+            message="Internal server error",
+            details=None,
+        )

--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,17 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+try:
+    from .errors import install_error_handlers
+except ImportError:
+    from errors import install_error_handlers
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+install_error_handlers(app)
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -2,10 +2,11 @@
 
 import time
 from collections import defaultdict
-from fastapi import Request, HTTPException
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
 from typing import Dict, Tuple
+
+from ..errors import error_response
 
 
 class RateLimitConfig:
@@ -65,12 +66,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         is_limited, value = self._is_rate_limited(client_ip)
 
         if is_limited:
-            return JSONResponse(
-                status_code=429,
-                content={
-                    "error": "Rate limit exceeded",
-                    "retry_after": value,
-                },
+            return error_response(
+                request,
+                429,
+                code="RATE_LIMITED",
+                message="Rate limit exceeded",
+                details={"retry_after": value},
                 headers={"Retry-After": str(value)},
             )
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,5 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
+pytest>=8.3.0
 web3>=7.6.0

--- a/api/tests/test_errors.py
+++ b/api/tests/test_errors.py
@@ -1,0 +1,93 @@
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.testclient import TestClient
+
+from api.errors import install_error_handlers
+from api.middleware.ratelimit import RateLimitMiddleware, RateLimitConfig
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    install_error_handlers(app)
+
+    @app.get("/validation")
+    async def validation(limit: int = Query(..., ge=1)):
+        return {"limit": limit}
+
+    @app.get("/not-found")
+    async def not_found():
+        raise HTTPException(status_code=404, detail="Thing not found")
+
+    @app.get("/auth")
+    async def auth_failed():
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    @app.get("/internal")
+    async def internal_error():
+        raise RuntimeError("boom")
+
+    return app
+
+
+def assert_error(response, code: str):
+    payload = response.json()
+    assert payload["error"]["code"] == code
+    assert "message" in payload["error"]
+    assert "details" in payload["error"]
+    assert payload["error"]["request_id"]
+    assert response.headers["X-Request-ID"] == payload["error"]["request_id"]
+
+
+def test_validation_error_has_field_details():
+    client = TestClient(build_app())
+
+    response = client.get("/validation?limit=0")
+
+    assert response.status_code == 422
+    assert_error(response, "VALIDATION_ERROR")
+    assert response.json()["error"]["details"][0]["field"] == "query.limit"
+
+
+def test_not_found_error_code():
+    client = TestClient(build_app())
+
+    response = client.get("/not-found")
+
+    assert response.status_code == 404
+    assert_error(response, "NOT_FOUND")
+
+
+def test_auth_failed_error_code():
+    client = TestClient(build_app())
+
+    response = client.get("/auth")
+
+    assert response.status_code == 401
+    assert_error(response, "AUTH_FAILED")
+
+
+def test_internal_error_code():
+    client = TestClient(build_app(), raise_server_exceptions=False)
+
+    response = client.get("/internal")
+
+    assert response.status_code == 500
+    assert_error(response, "INTERNAL_ERROR")
+
+
+def test_rate_limited_error_code():
+    app = FastAPI()
+    install_error_handlers(app)
+    app.add_middleware(RateLimitMiddleware, config=RateLimitConfig(requests_per_window=1, window_seconds=60))
+
+    @app.get("/limited")
+    async def limited():
+        return {"ok": True}
+
+    client = TestClient(app)
+    assert client.get("/limited").status_code == 200
+
+    response = client.get("/limited")
+
+    assert response.status_code == 429
+    assert_error(response, "RATE_LIMITED")
+    assert response.json()["error"]["details"]["retry_after"] > 0


### PR DESCRIPTION
## Summary
- Add a shared FastAPI error handler module returning structured `code`, `message`, `details`, and `request_id` responses.
- Map validation, not found, auth, rate limit, and internal errors to documented error codes.
- Add request ID middleware, update rate-limit responses, document API error codes, and add pytest coverage.
- Add a contributor entry that intentionally avoids recording private credentials, hidden prompts, local paths, or sensitive session data.

## Test plan
- [x] CONTRIBUTORS.json parses as valid JSON
- [x] git diff --check
- [x] Static review of FastAPI handler wiring and rate-limit response integration
- [ ] `python -m py_compile api/**/*.py` — not run here because Python is unavailable in this environment
- [ ] `cd api && pip install -r requirements.txt && pytest` — not run here because Python is unavailable in this environment

Closes #147