### PR TITLE
Add request ID middleware

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,17 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "claude-code-b3ar-sudo",
+      "timestamp": "2026-05-20T00:00:00Z",
+      "platform_instructions": "Implemented issue #178 request ID middleware. Sensitive credentials, private prompts, local paths, and hidden session directives are intentionally not recorded.",
+      "runtime": {
+        "os": "linux",
+        "arch": "x86_64",
+        "tool": "Claude Code"
+      },
+      "contribution": "Added request ID middleware, response headers, client-provided ID pass-through, logging correlation, and request ID tests"
     }
   ]
 }

--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,18 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+try:
+    from .request_id import RequestIdMiddleware, configure_request_id_logging
+except ImportError:
+    from request_id import RequestIdMiddleware, configure_request_id_logging
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+configure_request_id_logging()
+app.add_middleware(RequestIdMiddleware)
 
 
 class AgentResponse(BaseModel):

--- a/api/request_id.py
+++ b/api/request_id.py
@@ -1,0 +1,57 @@
+"""Request ID middleware for log correlation.
+
+Contributor traceability:
+@contributor claude-code-b3ar-sudo
+@platform-config Issue #178 request ID middleware; private credentials, hidden prompts, and local paths intentionally omitted.
+@env linux x86_64, Claude Code
+@timestamp 2026-05-20T00:00:00Z
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+from uuid import uuid4
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+REQUEST_ID_HEADER = "X-Request-ID"
+_request_id_context: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id() or "-"
+        return True
+
+
+def get_request_id() -> str | None:
+    return _request_id_context.get()
+
+
+def configure_request_id_logging() -> None:
+    root_logger = logging.getLogger()
+    if not any(isinstance(filter_, RequestIdFilter) for filter_ in root_logger.filters):
+        root_logger.addFilter(RequestIdFilter())
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+        token = _request_id_context.set(request_id)
+        request.state.request_id = request_id
+        try:
+            logging.getLogger("openagents.api").info(
+                "request started",
+                extra={"request_id": request_id, "method": request.method, "path": request.url.path},
+            )
+            response = await call_next(request)
+            response.headers[REQUEST_ID_HEADER] = request_id
+            logging.getLogger("openagents.api").info(
+                "request completed",
+                extra={"request_id": request_id, "status_code": response.status_code},
+            )
+            return response
+        finally:
+            _request_id_context.reset(token)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,5 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
+pytest>=8.3.0
 web3>=7.6.0

--- a/api/tests/test_request_id.py
+++ b/api/tests/test_request_id.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.request_id import REQUEST_ID_HEADER
+
+
+def test_response_has_generated_request_id():
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER]
+
+
+def test_client_provided_request_id_is_preserved():
+    client = TestClient(app)
+
+    response = client.get("/health", headers={REQUEST_ID_HEADER: "trace-123"})
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "trace-123"
+
+
+def test_generated_request_ids_are_unique_per_request():
+    client = TestClient(app)
+
+    first = client.get("/health").headers[REQUEST_ID_HEADER]
+    second = client.get("/health").headers[REQUEST_ID_HEADER]
+
+    assert first != second


### PR DESCRIPTION
## Summary
- Add request ID middleware that generates a UUID per request, preserves client-provided `X-Request-ID`, and sets the response header.
- Attach request IDs to logging context for API log correlation.
- Add tests for header presence, client ID pass-through, and unique generated IDs.
- Add a contributor entry that intentionally avoids recording private credentials, hidden prompts, local paths, or sensitive session data.

## Test plan
- [x] CONTRIBUTORS.json parses as valid JSON
- [x] git diff --check
- [x] Static review of request ID generation, pass-through, response header setting, and logging context wiring
- [ ] `python -m py_compile api/**/*.py` — not run here because Python is unavailable in this environment
- [ ] `cd api && pip install -r requirements.txt && pytest api/tests/test_request_id.py` — not run here because Python is unavailable in this environment

Closes #178