### PR TITLE
fix: record received escrow amounts

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-openagents-paymentescrow-104",
+      "timestamp": "2026-05-20T09:41:00Z",
+      "platform_instructions": "Private platform/session initialization text intentionally omitted.",
+      "runtime": {
+        "os": "macos",
+        "arch": "arm64",
+        "home_dir": "/Users/nicdunz",
+        "working_dir": "/Users/nicdunz/Documents/money making/runs/2026-05-20-openagents-agenttoken-permit-158/OpenAgents",
+        "shell": "zsh"
+      },
+      "contribution": "Fixed PaymentEscrow funding to store actual received ERC20 amounts and added zero-amount, normal token, and fee-on-transfer coverage"
     }
   ]
 }

--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PaymentEscrow is Ownable {
+    using SafeERC20 for IERC20;
+
     struct Escrow {
         address payer;
         address payee;
@@ -31,22 +34,27 @@ contract PaymentEscrow is Ownable {
         uint256 lockDuration
     ) external returns (uint256) {
         require(payee != address(0), "Invalid payee");
+        require(token != address(0), "Invalid token");
         require(amount > 0, "Amount must be > 0");
 
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20 escrowToken = IERC20(token);
+        uint256 balanceBefore = escrowToken.balanceOf(address(this));
+        escrowToken.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = escrowToken.balanceOf(address(this)) - balanceBefore;
+        require(received > 0, "No tokens received");
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
             payer: msg.sender,
             payee: payee,
             token: token,
-            amount: amount,
+            amount: received,
             releaseTime: block.timestamp + lockDuration,
             released: false,
             refunded: false
         });
 
-        emit EscrowCreated(escrowId, msg.sender, amount);
+        emit EscrowCreated(escrowId, msg.sender, received);
         return escrowId;
     }
 
@@ -56,7 +64,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer || msg.sender == owner(), "Not authorized");
 
         escrow.released = true;
-        IERC20(escrow.token).transfer(escrow.payee, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payee, escrow.amount);
 
         emit EscrowReleased(escrowId, escrow.payee, escrow.amount);
     }
@@ -68,7 +76,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer, "Not payer");
 
         escrow.refunded = true;
-        IERC20(escrow.token).transfer(escrow.payer, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payer, escrow.amount);
 
         emit EscrowRefunded(escrowId, escrow.payer, escrow.amount);
     }

--- a/contracts/test/MockFeeOnTransferToken.sol
+++ b/contracts/test/MockFeeOnTransferToken.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferToken is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(string memory name_, string memory symbol_, uint256 feeBps_) ERC20(name_, symbol_) {
+        require(feeBps_ <= 1_000, "Fee too high");
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0) && feeBps > 0) {
+            uint256 fee = (value * feeBps) / 10_000;
+            uint256 net = value - fee;
+
+            if (fee > 0) {
+                super._update(from, address(0), fee);
+            }
+            super._update(from, to, net);
+            return;
+        }
+
+        super._update(from, to, value);
+    }
+}

--- a/contracts/test/PaymentEscrowHarness.sol
+++ b/contracts/test/PaymentEscrowHarness.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PaymentEscrow.sol";
+
+contract PaymentEscrowHarness is PaymentEscrow {}

--- a/test/PaymentEscrow.test.js
+++ b/test/PaymentEscrow.test.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PaymentEscrow", function () {
+  async function deployFixture(feeBps = 0) {
+    const [owner, payer, payee] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockFeeOnTransferToken");
+    const token = await Token.deploy("Mock Token", "MOCK", feeBps);
+    await token.waitForDeployment();
+
+    const PaymentEscrow = await ethers.getContractFactory("PaymentEscrowHarness");
+    const escrow = await PaymentEscrow.deploy();
+    await escrow.waitForDeployment();
+
+    return { owner, payer, payee, token, escrow };
+  }
+
+  it("rejects zero amount escrows", async function () {
+    const { payer, payee, token, escrow } = await deployFixture();
+
+    await expect(
+      escrow.connect(payer).createEscrow(payee.address, await token.getAddress(), 0, 0)
+    ).to.be.revertedWith("Amount must be > 0");
+  });
+
+  it("stores and releases the full amount for normal ERC20 tokens", async function () {
+    const { payer, payee, token, escrow } = await deployFixture();
+    const amount = ethers.parseEther("100");
+    const escrowAddress = await escrow.getAddress();
+
+    await token.mint(payer.address, amount);
+    await token.connect(payer).approve(escrowAddress, amount);
+
+    await expect(escrow.connect(payer).createEscrow(payee.address, await token.getAddress(), amount, 0))
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0, payer.address, amount);
+
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(amount);
+    expect(await token.balanceOf(escrowAddress)).to.equal(amount);
+
+    await escrow.connect(payer).releaseEscrow(0);
+    expect(await token.balanceOf(payee.address)).to.equal(amount);
+    expect(await token.balanceOf(escrowAddress)).to.equal(0);
+  });
+
+  it("stores the actual received amount for fee-on-transfer tokens", async function () {
+    const { payer, payee, token, escrow } = await deployFixture(1_000);
+    const amount = ethers.parseEther("100");
+    const received = ethers.parseEther("90");
+    const receivedAfterReleaseFee = ethers.parseEther("81");
+    const escrowAddress = await escrow.getAddress();
+
+    await token.mint(payer.address, amount);
+    await token.connect(payer).approve(escrowAddress, amount);
+
+    await expect(escrow.connect(payer).createEscrow(payee.address, await token.getAddress(), amount, 0))
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0, payer.address, received);
+
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(received);
+    expect(await token.balanceOf(escrowAddress)).to.equal(received);
+
+    await escrow.connect(payer).releaseEscrow(0);
+    expect(await token.balanceOf(escrowAddress)).to.equal(0);
+    expect(await token.balanceOf(payee.address)).to.equal(receivedAfterReleaseFee);
+  });
+});


### PR DESCRIPTION
Fixes #104

/claim #104

Payment: USDC | 0xC02e5E5aEd363E5F59466D13A590d73275C6Af59 | Base

Summary:
- uses SafeERC20 for escrow funding, release, and refund paths
- rejects zero token address and zero amount escrows
- measures escrow token balance before/after funding and stores the actual received amount
- adds focused coverage for zero amount, normal ERC20, and fee-on-transfer ERC20 behavior
- omits private platform/session initialization text from source and metadata

Verification:
- `npx solcjs contracts/PaymentEscrow.sol contracts/test/MockFeeOnTransferToken.sol contracts/test/PaymentEscrowHarness.sol --bin --abi --base-path . --include-path node_modules -o .codex-solc-paymentescrow`
- `npx hardhat test test/PaymentEscrow.test.js --config .codex-hardhat-paymentescrow.config.js` with a local focused config scoped to `contracts/test` because the repository root config currently fails on unrelated OpenZeppelin `^0.8.24` dependencies
- `node --check test/PaymentEscrow.test.js`
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`
- `git diff --check`
