### PR TITLE
fix: track active agent count

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-openagents-agentregistry-89",
+      "timestamp": "2026-05-20T09:52:00Z",
+      "platform_instructions": "Private platform/session initialization text intentionally omitted.",
+      "runtime": {
+        "os": "macos",
+        "arch": "arm64",
+        "home_dir": "/Users/nicdunz",
+        "working_dir": "/Users/nicdunz/Documents/money making/runs/2026-05-20-openagents-agenttoken-permit-158/OpenAgents",
+        "shell": "zsh"
+      },
+      "contribution": "Made AgentRegistry active counting O(1) and added pagination plus owner-filter test coverage"
     }
   ]
 }

--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -20,6 +20,9 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public activeCount;
+
+    uint256 public constant MAX_PAGE_SIZE = 100;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -50,6 +53,7 @@ contract AgentRegistry is Ownable {
 
         ownerAgents[msg.sender].push(agentId);
         agentIds.push(agentId);
+        activeCount++;
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
@@ -57,7 +61,9 @@ contract AgentRegistry is Ownable {
 
     function deactivateAgent(bytes32 agentId) external {
         require(agents[agentId].owner == msg.sender, "Not agent owner");
+        require(agents[agentId].active, "Already inactive");
         agents[agentId].active = false;
+        activeCount--;
         emit AgentDeactivated(agentId);
     }
 
@@ -79,10 +85,29 @@ contract AgentRegistry is Ownable {
         return agents[agentId];
     }
 
-    function getActiveAgentCount() external view returns (uint256 count) {
-        for (uint256 i = 0; i < agentIds.length; i++) {
-            if (agents[agentIds[i]].active) count++;
+    function getActiveAgentCount() external view returns (uint256) {
+        return activeCount;
+    }
+
+    function getAgentIds(uint256 offset, uint256 limit) external view returns (bytes32[] memory ids, uint256 total) {
+        total = agentIds.length;
+        if (offset >= total || limit == 0) {
+            return (new bytes32[](0), total);
         }
+
+        uint256 size = limit > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : limit;
+        if (offset + size > total) {
+            size = total - offset;
+        }
+
+        ids = new bytes32[](size);
+        for (uint256 i = 0; i < size; i++) {
+            ids[i] = agentIds[offset + i];
+        }
+    }
+
+    function getAgentsByOwner(address ownerAddr) external view returns (bytes32[] memory) {
+        return ownerAgents[ownerAddr];
     }
 
     function setRegistrationFee(uint256 _fee) external onlyOwner {

--- a/contracts/test/AgentRegistryHarness.sol
+++ b/contracts/test/AgentRegistryHarness.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../AgentRegistry.sol";
+
+contract AgentRegistryHarness is AgentRegistry {
+    constructor(uint256 registrationFee) AgentRegistry(registrationFee) {}
+}

--- a/test/AgentRegistry.test.js
+++ b/test/AgentRegistry.test.js
@@ -1,0 +1,71 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry", function () {
+  async function deployFixture() {
+    const [owner, alice, bob] = await ethers.getSigners();
+    const fee = ethers.parseEther("0.01");
+
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistryHarness");
+    const registry = await AgentRegistry.deploy(fee);
+    await registry.waitForDeployment();
+
+    return { owner, alice, bob, fee, registry };
+  }
+
+  async function register(registry, signer, fee, name) {
+    await registry.connect(signer).registerAgent(name, `https://${name}.example`, { value: fee });
+    const ids = await registry.getAgentsByOwner(signer.address);
+    return ids[ids.length - 1];
+  }
+
+  it("keeps active agent count accurate without scanning all ids", async function () {
+    const { alice, bob, fee, registry } = await deployFixture();
+
+    const aliceOne = await register(registry, alice, fee, "alice-one");
+    await register(registry, alice, fee, "alice-two");
+    await register(registry, bob, fee, "bob-one");
+
+    expect(await registry.activeCount()).to.equal(3);
+    expect(await registry.getActiveAgentCount()).to.equal(3);
+
+    await registry.connect(alice).deactivateAgent(aliceOne);
+
+    expect(await registry.activeCount()).to.equal(2);
+    expect(await registry.getActiveAgentCount()).to.equal(2);
+    await expect(registry.connect(alice).deactivateAgent(aliceOne)).to.be.revertedWith("Already inactive");
+  });
+
+  it("paginates agent ids with total count and bound checks", async function () {
+    const { alice, bob, fee, registry } = await deployFixture();
+    const first = await register(registry, alice, fee, "alice-one");
+    const second = await register(registry, alice, fee, "alice-two");
+    const third = await register(registry, bob, fee, "bob-one");
+
+    let page = await registry.getAgentIds(1, 2);
+    expect(page.total).to.equal(3);
+    expect(page.ids).to.deep.equal([second, third]);
+
+    page = await registry.getAgentIds(10, 2);
+    expect(page.total).to.equal(3);
+    expect(page.ids).to.deep.equal([]);
+
+    page = await registry.getAgentIds(0, 0);
+    expect(page.total).to.equal(3);
+    expect(page.ids).to.deep.equal([]);
+
+    page = await registry.getAgentIds(0, 500);
+    expect(page.total).to.equal(3);
+    expect(page.ids).to.deep.equal([first, second, third]);
+  });
+
+  it("filters agents by owner", async function () {
+    const { alice, bob, fee, registry } = await deployFixture();
+    const aliceOne = await register(registry, alice, fee, "alice-one");
+    const aliceTwo = await register(registry, alice, fee, "alice-two");
+    const bobOne = await register(registry, bob, fee, "bob-one");
+
+    expect(await registry.getAgentsByOwner(alice.address)).to.deep.equal([aliceOne, aliceTwo]);
+    expect(await registry.getAgentsByOwner(bob.address)).to.deep.equal([bobOne]);
+  });
+});


### PR DESCRIPTION
Fixes #89

/claim #89

Payment: USDC | 0xC02e5E5aEd363E5F59466D13A590d73275C6Af59 | Base

Summary:
- tracks active agents with an `activeCount` counter so `getActiveAgentCount()` is O(1)
- increments on registration and decrements only once on deactivation
- adds bounded `getAgentIds(offset, limit)` pagination with total count
- adds `getAgentsByOwner(address)` using the existing owner index
- adds focused tests for counter accuracy, pagination bounds, and owner filtering
- omits private platform/session initialization text from source and metadata

Verification:
- `npx solcjs contracts/AgentRegistry.sol contracts/test/AgentRegistryHarness.sol --bin --abi --base-path . --include-path node_modules -o .codex-solc-agentregistry-89`
- `npx hardhat test test/AgentRegistry.test.js --config .codex-hardhat-agentregistry.config.js` with a local focused config scoped to `contracts/test` because the repository root config currently fails on unrelated OpenZeppelin `^0.8.24` dependencies
- `node --check test/AgentRegistry.test.js`
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`
- `git diff --check`
