### PR TITLE
fix: lock initial AMM liquidity

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-openagents-ammpool-80",
+      "timestamp": "2026-05-20T10:00:00Z",
+      "platform_instructions": "Private platform/session initialization text intentionally omitted.",
+      "runtime": {
+        "os": "macos",
+        "arch": "arm64",
+        "home_dir": "/Users/nicdunz",
+        "working_dir": "/Users/nicdunz/Documents/money making/runs/2026-05-20-openagents-agenttoken-permit-158/OpenAgents",
+        "shell": "zsh"
+      },
+      "contribution": "Locked AMMPool minimum first-deposit liquidity and added reserve/donation/sync coverage"
     }
   ]
 }

--- a/contracts/dex/AMMPool.sol
+++ b/contracts/dex/AMMPool.sol
@@ -18,12 +18,14 @@ contract AMMPool {
     uint256 public reserveB;
     uint256 public totalLiquidity;
     uint256 public constant FEE_BPS = 30; // 0.3%
+    uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     mapping(address => uint256) public liquidity;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB);
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) {
         tokenA = IERC20(_tokenA);
@@ -37,7 +39,11 @@ contract AMMPool {
         require(amountA > 0 && amountB > 0, "Zero amounts");
 
         if (totalLiquidity == 0) {
-            lpTokens = _sqrt(amountA * amountB);
+            uint256 rootLiquidity = _sqrt(amountA * amountB);
+            require(rootLiquidity > MINIMUM_LIQUIDITY, "Insufficient liquidity");
+            lpTokens = rootLiquidity - MINIMUM_LIQUIDITY;
+            liquidity[address(0)] = MINIMUM_LIQUIDITY;
+            totalLiquidity = MINIMUM_LIQUIDITY;
         } else {
             uint256 lpA = (amountA * totalLiquidity) / reserveA;
             uint256 lpB = (amountB * totalLiquidity) / reserveB;
@@ -53,6 +59,7 @@ contract AMMPool {
         totalLiquidity += lpTokens;
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
+        emit Sync(reserveA, reserveB);
     }
 
     function removeLiquidity(uint256 lpTokens) external {
@@ -70,6 +77,7 @@ contract AMMPool {
         require(tokenB.transfer(msg.sender, amountB), "Transfer B failed");
 
         emit LiquidityRemoved(msg.sender, amountA, amountB);
+        emit Sync(reserveA, reserveB);
     }
 
     // BUG: Swap has no deadline parameter — transaction can sit in mempool and execute
@@ -103,6 +111,13 @@ contract AMMPool {
         }
 
         emit Swap(msg.sender, tokenIn, amountIn, amountOut);
+        emit Sync(reserveA, reserveB);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function _sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/contracts/test/AMMPoolHarness.sol
+++ b/contracts/test/AMMPoolHarness.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../dex/AMMPool.sol";
+
+contract AMMPoolHarness is AMMPool {
+    constructor(address tokenA, address tokenB) AMMPool(tokenA, tokenB) {}
+}

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        require(allowance[from][msg.sender] >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}

--- a/test/AMMPool.test.js
+++ b/test/AMMPool.test.js
@@ -1,0 +1,100 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AMMPool", function () {
+  async function deployFixture() {
+    const [owner, firstLp, secondLp, donor] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const tokenA = await Token.deploy("Token A", "TKA");
+    const tokenB = await Token.deploy("Token B", "TKB");
+    await tokenA.waitForDeployment();
+    await tokenB.waitForDeployment();
+
+    const Pool = await ethers.getContractFactory("AMMPoolHarness");
+    const pool = await Pool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    await pool.waitForDeployment();
+
+    return { owner, firstLp, secondLp, donor, tokenA, tokenB, pool };
+  }
+
+  async function fundAndApprove(tokenA, tokenB, pool, signer, amountA, amountB) {
+    const poolAddress = await pool.getAddress();
+    await tokenA.mint(signer.address, amountA);
+    await tokenB.mint(signer.address, amountB);
+    await tokenA.connect(signer).approve(poolAddress, amountA);
+    await tokenB.connect(signer).approve(poolAddress, amountB);
+  }
+
+  it("locks minimum liquidity on the first deposit", async function () {
+    const { firstLp, tokenA, tokenB, pool } = await deployFixture();
+    const amount = 10_000n;
+
+    await fundAndApprove(tokenA, tokenB, pool, firstLp, amount, amount);
+
+    await expect(pool.connect(firstLp).addLiquidity(amount, amount))
+      .to.emit(pool, "LiquidityAdded")
+      .withArgs(firstLp.address, amount, amount, amount - 1000n);
+
+    expect(await pool.MINIMUM_LIQUIDITY()).to.equal(1000);
+    expect(await pool.totalLiquidity()).to.equal(amount);
+    expect(await pool.liquidity(ethers.ZeroAddress)).to.equal(1000);
+    expect(await pool.liquidity(firstLp.address)).to.equal(amount - 1000n);
+  });
+
+  it("uses internal reserves when removing liquidity after direct donations", async function () {
+    const { firstLp, donor, tokenA, tokenB, pool } = await deployFixture();
+    const amount = 10_000n;
+    const poolAddress = await pool.getAddress();
+
+    await fundAndApprove(tokenA, tokenB, pool, firstLp, amount, amount);
+    await pool.connect(firstLp).addLiquidity(amount, amount);
+
+    await tokenA.mint(donor.address, 5_000n);
+    await tokenA.connect(donor).transfer(poolAddress, 5_000n);
+
+    expect(await tokenA.balanceOf(poolAddress)).to.equal(15_000n);
+    expect(await pool.reserveA()).to.equal(10_000n);
+
+    await pool.connect(firstLp).removeLiquidity(9_000n);
+
+    expect(await tokenA.balanceOf(firstLp.address)).to.equal(9_000n);
+    expect(await tokenB.balanceOf(firstLp.address)).to.equal(9_000n);
+    expect(await pool.reserveA()).to.equal(1_000n);
+    expect(await pool.reserveB()).to.equal(1_000n);
+    expect(await tokenA.balanceOf(poolAddress)).to.equal(6_000n);
+  });
+
+  it("prices later liquidity from internal reserves rather than donated balances", async function () {
+    const { firstLp, secondLp, donor, tokenA, tokenB, pool } = await deployFixture();
+    const poolAddress = await pool.getAddress();
+
+    await fundAndApprove(tokenA, tokenB, pool, firstLp, 10_000n, 10_000n);
+    await pool.connect(firstLp).addLiquidity(10_000n, 10_000n);
+
+    await tokenA.mint(donor.address, 5_000n);
+    await tokenA.connect(donor).transfer(poolAddress, 5_000n);
+
+    await fundAndApprove(tokenA, tokenB, pool, secondLp, 1_000n, 1_000n);
+    await pool.connect(secondLp).addLiquidity(1_000n, 1_000n);
+
+    expect(await pool.liquidity(secondLp.address)).to.equal(1_000n);
+    expect(await pool.reserveA()).to.equal(11_000n);
+    expect(await pool.reserveB()).to.equal(11_000n);
+  });
+
+  it("syncs reserves to actual balances when explicitly requested", async function () {
+    const { firstLp, donor, tokenA, tokenB, pool } = await deployFixture();
+    const poolAddress = await pool.getAddress();
+
+    await fundAndApprove(tokenA, tokenB, pool, firstLp, 10_000n, 10_000n);
+    await pool.connect(firstLp).addLiquidity(10_000n, 10_000n);
+
+    await tokenA.mint(donor.address, 5_000n);
+    await tokenA.connect(donor).transfer(poolAddress, 5_000n);
+
+    await expect(pool.sync()).to.emit(pool, "Sync").withArgs(15_000n, 10_000n);
+    expect(await pool.reserveA()).to.equal(15_000n);
+    expect(await pool.reserveB()).to.equal(10_000n);
+  });
+});


### PR DESCRIPTION
Fixes #80

/claim #80

Payment: USDC | 0xC02e5E5aEd363E5F59466D13A590d73275C6Af59 | Base

Summary:
- locks `MINIMUM_LIQUIDITY` of 1000 LP units to `address(0)` on first deposit
- keeps `removeLiquidity` math based on internal reserves instead of raw token balances
- adds `sync()` to explicitly align reserves to actual balances
- preserves the existing `LiquidityAdded`, `LiquidityRemoved`, and `Swap` event surface while adding `Sync`
- adds focused tests for first-deposit lock, donation-resistant reserve math, reserve-based removal, and sync behavior
- omits private platform/session initialization text from source and metadata

Verification:
- `npx solcjs contracts/dex/AMMPool.sol contracts/test/AMMPoolHarness.sol contracts/test/MockERC20.sol --bin --abi --base-path . --include-path node_modules -o .codex-solc-amm-80`
- `npx hardhat test test/AMMPool.test.js --config .codex-hardhat-amm.config.js` with a local focused config scoped to `contracts/test` because the repository root config currently fails on unrelated OpenZeppelin `^0.8.24` dependencies
- `node --check test/AMMPool.test.js`
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`
- `git diff --check`
