### PR TITLE
Fix #94 MultiTokenStaking pool guards

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-openagents-multitokenstaking-94",
+      "timestamp": "2026-05-20T10:04:54Z",
+      "platform_instructions": "Private platform/session initialization text omitted from public repository artifact.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/nicdunz",
+        "working_dir": "/Users/nicdunz/Documents/money making/runs/2026-05-20-openagents-agenttoken-permit-158/OpenAgents",
+        "shell": "zsh"
+      },
+      "contribution": "Fixed MultiTokenStaking duplicate pool acceptance, zero-address validation, overflow-prone reward accounting, and pool weight updates for issue #94"
     }
   ]
 }

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -5,13 +5,20 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title MultiTokenStaking
 /// @notice Allows users to stake multiple ERC20 tokens across different pools,
 ///         each earning a share of a global reward token emission.
 /// @dev Each pool has an allocation weight. Rewards are distributed proportionally.
+/// @custom:contributor Codex
+/// @custom:platform Private platform/session initialization text omitted; source public artifact for OpenAgents #94 bounty.
+/// @custom:runtime os=Darwin arch=arm64 working_dir=/Users/nicdunz/Documents/money making/runs/2026-05-20-openagents-agenttoken-permit-158/OpenAgents
+/// @custom:date 2026-05-20T10:04:54Z
 contract MultiTokenStaking is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
+
+    uint256 private constant ACC_REWARD_PRECISION = 1e12;
 
     struct PoolInfo {
         IERC20 stakeToken;
@@ -31,16 +38,17 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     uint256 public totalAllocPoint;
 
     PoolInfo[] public poolInfo;
+    mapping(address => bool) public poolExists;
     mapping(uint256 => mapping(address => UserInfo)) public userInfo;
 
     event PoolAdded(uint256 indexed pid, address token, uint256 allocPoint);
+    event PoolWeightUpdated(uint256 indexed pid, uint256 oldAllocPoint, uint256 newAllocPoint);
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
 
-    // BUG: Missing zero-address validation — rewardToken can be set to address(0),
-    // causing all reward transfers to silently burn tokens or revert unpredictably.
     constructor(address _rewardToken, uint256 _rewardPerSecond) Ownable(msg.sender) {
+        require(_rewardToken != address(0), "MultiStaking: zero reward token");
         rewardToken = IERC20(_rewardToken);
         rewardPerSecond = _rewardPerSecond;
     }
@@ -48,11 +56,12 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     /// @notice Add a new staking pool.
     /// @param _allocPoint Allocation weight for reward distribution.
     /// @param _stakeToken The ERC20 token to be staked in this pool.
-    // BUG: No duplicate token check — the same token can be added multiple times,
-    // causing reward accounting to break as totalAllocPoint inflates and existing
-    // stakers in the original pool get diluted unexpectedly.
     function addPool(uint256 _allocPoint, address _stakeToken) external onlyOwner {
+        require(_stakeToken != address(0), "MultiStaking: zero stake token");
+        require(!poolExists[_stakeToken], "MultiStaking: duplicate pool");
+
         totalAllocPoint += _allocPoint;
+        poolExists[_stakeToken] = true;
         poolInfo.push(PoolInfo({
             stakeToken: IERC20(_stakeToken),
             allocPoint: _allocPoint,
@@ -63,23 +72,35 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         emit PoolAdded(poolInfo.length - 1, _stakeToken, _allocPoint);
     }
 
+    /// @notice Update a pool's allocation weight.
+    /// @param pid Pool ID to update.
+    /// @param newAllocPoint New allocation weight for reward distribution.
+    function setPoolWeight(uint256 pid, uint256 newAllocPoint) external onlyOwner {
+        require(pid < poolInfo.length, "MultiStaking: invalid pool");
+        updatePool(pid);
+
+        PoolInfo storage pool = poolInfo[pid];
+        uint256 oldAllocPoint = pool.allocPoint;
+        totalAllocPoint = totalAllocPoint - oldAllocPoint + newAllocPoint;
+        pool.allocPoint = newAllocPoint;
+
+        emit PoolWeightUpdated(pid, oldAllocPoint, newAllocPoint);
+    }
+
     /// @notice Update reward variables for a given pool.
     /// @param pid Pool ID to update.
     function updatePool(uint256 pid) public {
         PoolInfo storage pool = poolInfo[pid];
         if (block.timestamp <= pool.lastRewardTime) return;
 
-        if (pool.totalStaked == 0) {
+        if (pool.totalStaked == 0 || pool.allocPoint == 0 || totalAllocPoint == 0) {
             pool.lastRewardTime = block.timestamp;
             return;
         }
 
         uint256 elapsed = block.timestamp - pool.lastRewardTime;
-        // BUG: Reward calculation can overflow for large elapsed * rewardPerSecond * allocPoint
-        // values. With high rewardPerSecond (e.g., 1e18) and long time gaps, the intermediate
-        // multiplication exceeds uint256 before the division by totalAllocPoint.
-        uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
-        pool.accRewardPerShare += reward * 1e12 / pool.totalStaked;
+        uint256 reward = _poolReward(elapsed, pool.allocPoint);
+        pool.accRewardPerShare += Math.mulDiv(reward, ACC_REWARD_PRECISION, pool.totalStaked);
         pool.lastRewardTime = block.timestamp;
     }
 
@@ -92,7 +113,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         updatePool(pid);
 
         if (user.amount > 0) {
-            uint256 pending = user.amount * pool.accRewardPerShare / 1e12 - user.rewardDebt;
+            uint256 pending = _accrued(user.amount, pool.accRewardPerShare) - user.rewardDebt;
             if (pending > 0) {
                 rewardToken.safeTransfer(msg.sender, pending);
                 emit Harvest(msg.sender, pid, pending);
@@ -104,7 +125,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
             user.amount += amount;
             pool.totalStaked += amount;
         }
-        user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
+        user.rewardDebt = _accrued(user.amount, pool.accRewardPerShare);
         emit Deposit(msg.sender, pid, amount);
     }
 
@@ -117,7 +138,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         require(user.amount >= amount, "MultiStaking: insufficient balance");
         updatePool(pid);
 
-        uint256 pending = user.amount * pool.accRewardPerShare / 1e12 - user.rewardDebt;
+        uint256 pending = _accrued(user.amount, pool.accRewardPerShare) - user.rewardDebt;
         if (pending > 0) {
             rewardToken.safeTransfer(msg.sender, pending);
             emit Harvest(msg.sender, pid, pending);
@@ -128,7 +149,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
             pool.totalStaked -= amount;
             pool.stakeToken.safeTransfer(msg.sender, amount);
         }
-        user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
+        user.rewardDebt = _accrued(user.amount, pool.accRewardPerShare);
         emit Withdraw(msg.sender, pid, amount);
     }
 
@@ -137,11 +158,22 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         PoolInfo memory pool = poolInfo[pid];
         UserInfo memory user = userInfo[pid][_user];
         uint256 accRewardPerShare = pool.accRewardPerShare;
-        if (block.timestamp > pool.lastRewardTime && pool.totalStaked > 0) {
+        if (block.timestamp > pool.lastRewardTime && pool.totalStaked > 0 && pool.allocPoint > 0 && totalAllocPoint > 0) {
             uint256 elapsed = block.timestamp - pool.lastRewardTime;
-            uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
-            accRewardPerShare += reward * 1e12 / pool.totalStaked;
+            uint256 reward = _poolReward(elapsed, pool.allocPoint);
+            accRewardPerShare += Math.mulDiv(reward, ACC_REWARD_PRECISION, pool.totalStaked);
         }
-        return user.amount * accRewardPerShare / 1e12 - user.rewardDebt;
+        return _accrued(user.amount, accRewardPerShare) - user.rewardDebt;
+    }
+
+    function _poolReward(uint256 elapsed, uint256 allocPoint) internal view returns (uint256) {
+        uint256 rewardWhole = Math.mulDiv(elapsed, rewardPerSecond, totalAllocPoint);
+        uint256 rewardRemainder = mulmod(elapsed, rewardPerSecond, totalAllocPoint);
+        return Math.mulDiv(rewardWhole, allocPoint, 1)
+            + Math.mulDiv(rewardRemainder, allocPoint, totalAllocPoint);
+    }
+
+    function _accrued(uint256 amount, uint256 accRewardPerShare) internal pure returns (uint256) {
+        return Math.mulDiv(amount, accRewardPerShare, ACC_REWARD_PRECISION);
     }
 }

--- a/test/MultiTokenStakingPoolGuards.test.js
+++ b/test/MultiTokenStakingPoolGuards.test.js
@@ -1,0 +1,96 @@
+// @contributor Codex
+// @platform Private platform/session initialization text omitted; public OpenAgents #94 bounty test artifact.
+// @runtime os=Darwin arch=arm64 working_dir=/Users/nicdunz/Documents/money making/runs/2026-05-20-openagents-agenttoken-permit-158/OpenAgents
+// @date 2026-05-20T10:04:54Z
+
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("MultiTokenStaking pool guards", function () {
+  async function deployToken(name, symbol, initialSupply = 0n) {
+    const Token = await ethers.getContractFactory("AgentToken");
+    const token = await Token.deploy(name, symbol, initialSupply);
+    await token.waitForDeployment();
+    return token;
+  }
+
+  async function deployStaking(rewardPerSecond = 1n) {
+    const rewardToken = await deployToken("Reward", "RWD");
+    const Staking = await ethers.getContractFactory("MultiTokenStaking");
+    const staking = await Staking.deploy(await rewardToken.getAddress(), rewardPerSecond);
+    await staking.waitForDeployment();
+    return { staking, rewardToken };
+  }
+
+  it("rejects zero reward and stake token addresses", async function () {
+    const Staking = await ethers.getContractFactory("MultiTokenStaking");
+    await expect(Staking.deploy(ethers.ZeroAddress, 1n)).to.be.revertedWith("MultiStaking: zero reward token");
+
+    const { staking } = await deployStaking();
+    await expect(staking.addPool(100n, ethers.ZeroAddress)).to.be.revertedWith("MultiStaking: zero stake token");
+  });
+
+  it("rejects duplicate stake-token pools", async function () {
+    const { staking } = await deployStaking();
+    const stakeToken = await deployToken("Stake", "STK");
+    const stakeTokenAddress = await stakeToken.getAddress();
+
+    await staking.addPool(100n, stakeTokenAddress);
+
+    expect(await staking.poolExists(stakeTokenAddress)).to.equal(true);
+    await expect(staking.addPool(1n, stakeTokenAddress)).to.be.revertedWith("MultiStaking: duplicate pool");
+  });
+
+  it("lets the owner update a pool weight and total allocation", async function () {
+    const { staking } = await deployStaking();
+    const stakeToken = await deployToken("Stake", "STK");
+
+    await staking.addPool(100n, await stakeToken.getAddress());
+    await expect(staking.setPoolWeight(0, 250n))
+      .to.emit(staking, "PoolWeightUpdated")
+      .withArgs(0, 100n, 250n);
+
+    const pool = await staking.poolInfo(0);
+    expect(pool.allocPoint).to.equal(250n);
+    expect(await staking.totalAllocPoint()).to.equal(250n);
+  });
+
+  it("uses full-precision reward math so large emissions do not overflow", async function () {
+    const [, alice] = await ethers.getSigners();
+    const rewardPerSecond = 1n << 254n;
+    const { staking } = await deployStaking(rewardPerSecond);
+    const stakeToken = await deployToken("StakeA", "STKA");
+    const secondStakeToken = await deployToken("StakeB", "STKB");
+    const amount = ethers.parseEther("1");
+
+    await staking.addPool(1n, await stakeToken.getAddress());
+    await staking.addPool(2n, await secondStakeToken.getAddress());
+    await stakeToken.mint(alice.address, amount);
+    await stakeToken.connect(alice).approve(await staking.getAddress(), amount);
+    await staking.connect(alice).deposit(0, amount);
+
+    await time.increase(4);
+
+    const pending = await staking.pendingReward(0, alice.address);
+    expect(pending).to.be.gt(0n);
+    await expect(staking.updatePool(0)).not.to.be.reverted;
+  });
+
+  it("keeps allocation precision while avoiding overflow-prone multiplication order", async function () {
+    const [, alice] = await ethers.getSigners();
+    const { staking } = await deployStaking(199n);
+    const stakeToken = await deployToken("StakeC", "STKC");
+    const secondStakeToken = await deployToken("StakeD", "STKD");
+
+    await staking.addPool(50n, await stakeToken.getAddress());
+    await staking.addPool(50n, await secondStakeToken.getAddress());
+    await stakeToken.mint(alice.address, 1n);
+    await stakeToken.connect(alice).approve(await staking.getAddress(), 1n);
+    await staking.connect(alice).deposit(0, 1n);
+
+    await time.increase(1);
+
+    expect(await staking.pendingReward(0, alice.address)).to.equal(99n);
+  });
+});


### PR DESCRIPTION
Fixes #94

/claim #94

Payment: USDC | 0xC02e5E5aEd363E5F59466D13A590d73275C6Af59 | Base

Summary:
- rejects zero reward-token and stake-token addresses
- tracks existing stake-token pools and reverts duplicate pool adds
- replaces overflow-prone reward math with full-precision mulDiv accounting while preserving allocation precision
- adds owner-only pool-weight updates with total allocation adjustment
- adds focused tests for duplicate revert, zero rejected, weight updates, overflow-safe large emissions, and precision preservation

Verification:
- `npx hardhat test test/MultiTokenStakingPoolGuards.test.js --config .codex-hardhat-multitoken94.config.js` with a local focused config scoped to MultiTokenStaking/AgentToken because the repository root config currently fails on unrelated `contracts/oracle/ChainlinkAdapter.sol` parse errors and OpenZeppelin `^0.8.24` dependencies
- `npx solcjs contracts/staking/MultiTokenStaking.sol contracts/token/AgentToken.sol --bin --abi --base-path . --include-path node_modules -o .codex-solc-multitoken94`
- `node --check test/MultiTokenStakingPoolGuards.test.js`
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`
- `git diff --check`
