### PR TITLE
Fix PrizeSplit pull claims for rejecting winners

### DIFF
--- a/contracts/lottery/PrizeSplit.sol
+++ b/contracts/lottery/PrizeSplit.sol
@@ -2,17 +2,23 @@
 pragma solidity ^0.8.20;
 
 /// @title PrizeSplit
-/// @notice Distributes prize pool among multiple winners with configurable shares
-/// @dev Winners claim their share after the admin finalizes the round
+/// @notice Distributes prize pool among multiple winners with configurable shares.
+/// @dev Winners claim their share after the admin finalizes the round.
 contract PrizeSplit {
+    uint256 public constant CLAIM_DEADLINE = 90 days;
+
     address public admin;
+    address public treasury;
     uint256 public totalPrize;
     uint256 public roundId;
 
     struct Round {
         address[] winners;
         uint256 prizePool;
+        uint256 finalizedAt;
+        uint256 claimedTotal;
         bool finalized;
+        bool reclaimed;
         mapping(address => uint256) shares;
         mapping(address => bool) claimed;
     }
@@ -22,6 +28,8 @@ contract PrizeSplit {
     event RoundFunded(uint256 indexed roundId, uint256 amount);
     event RoundFinalized(uint256 indexed roundId, uint256 winnerCount);
     event PrizeClaimed(address indexed winner, uint256 amount, uint256 indexed roundId);
+    event UnclaimedPrizesReclaimed(uint256 indexed roundId, address indexed treasury, uint256 amount);
+    event TreasuryUpdated(address indexed treasury);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -30,6 +38,13 @@ contract PrizeSplit {
 
     constructor() {
         admin = msg.sender;
+        treasury = msg.sender;
+    }
+
+    function setTreasury(address newTreasury) external onlyAdmin {
+        require(newTreasury != address(0), "Invalid treasury");
+        treasury = newTreasury;
+        emit TreasuryUpdated(newTreasury);
     }
 
     function fundRound() external payable onlyAdmin {
@@ -39,43 +54,57 @@ contract PrizeSplit {
         emit RoundFunded(roundId, msg.value);
     }
 
-    // BUG: No zero-winner check — if winners array is empty, the function
-    // succeeds silently and the prize pool becomes permanently locked
     function finalizeRound(uint256 _roundId, address[] calldata winners) external onlyAdmin {
         Round storage round = rounds[_roundId];
         require(!round.finalized, "Already finalized");
         require(round.prizePool > 0, "No prize pool");
+        require(winners.length > 0, "No winners");
 
-        // BUG: Rounding error loses dust — integer division truncates remainder,
-        // so (prizePool % winners.length) wei is permanently locked in the contract
         uint256 sharePerWinner = round.prizePool / winners.length;
 
         for (uint256 i = 0; i < winners.length; i++) {
+            require(winners[i] != address(0), "Invalid winner");
             round.winners.push(winners[i]);
             round.shares[winners[i]] = sharePerWinner;
         }
 
         round.finalized = true;
+        round.finalizedAt = block.timestamp;
         emit RoundFinalized(_roundId, winners.length);
     }
 
-    // BUG: Reentrancy — state (claimed flag) is set after the external call,
-    // allowing a malicious contract to re-enter claimPrize and drain funds
     function claimPrize(uint256 _roundId) external {
         Round storage round = rounds[_roundId];
         require(round.finalized, "Not finalized");
+        require(block.timestamp <= round.finalizedAt + CLAIM_DEADLINE, "Claim expired");
         require(round.shares[msg.sender] > 0, "No share");
         require(!round.claimed[msg.sender], "Already claimed");
 
         uint256 amount = round.shares[msg.sender];
+        round.claimed[msg.sender] = true;
+        round.claimedTotal += amount;
+        totalPrize -= amount;
 
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "Transfer failed");
 
-        // State updated after external call — reentrancy window
-        round.claimed[msg.sender] = true;
-
         emit PrizeClaimed(msg.sender, amount, _roundId);
+    }
+
+    function reclaimUnclaimedPrizes(uint256 _roundId) external onlyAdmin {
+        Round storage round = rounds[_roundId];
+        require(round.finalized, "Not finalized");
+        require(block.timestamp > round.finalizedAt + CLAIM_DEADLINE, "Claim active");
+        require(!round.reclaimed, "Already reclaimed");
+
+        uint256 amount = round.prizePool - round.claimedTotal;
+        round.reclaimed = true;
+        totalPrize -= amount;
+
+        (bool sent, ) = treasury.call{value: amount}("");
+        require(sent, "Treasury transfer failed");
+
+        emit UnclaimedPrizesReclaimed(_roundId, treasury, amount);
     }
 
     function getShare(uint256 _roundId, address winner) external view returns (uint256) {
@@ -84,5 +113,13 @@ contract PrizeSplit {
 
     function isClaimed(uint256 _roundId, address winner) external view returns (bool) {
         return rounds[_roundId].claimed[winner];
+    }
+
+    function getReclaimableAmount(uint256 _roundId) external view returns (uint256) {
+        Round storage round = rounds[_roundId];
+        if (!round.finalized || round.reclaimed) {
+            return 0;
+        }
+        return round.prizePool - round.claimedTotal;
     }
 }

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/RejectEtherWinner.sol
+++ b/contracts/test/RejectEtherWinner.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IPrizeSplit {
+    function claimPrize(uint256 roundId) external;
+}
+
+contract RejectEtherWinner {
+    function claimPrize(IPrizeSplit prizeSplit, uint256 roundId) external {
+        prizeSplit.claimPrize(roundId);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/PrizeSplitPullClaims.test.js
+++ b/test/PrizeSplitPullClaims.test.js
@@ -1,0 +1,80 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PrizeSplit pull claims", function () {
+  const claimDeadlineSeconds = 90 * 24 * 60 * 60;
+
+  async function deployPrizeSplit() {
+    const [admin, winner, otherWinner, treasury] = await ethers.getSigners();
+
+    const PrizeSplit = await ethers.getContractFactory("PrizeSplit");
+    const prizeSplit = await PrizeSplit.deploy();
+    await prizeSplit.waitForDeployment();
+
+    const RejectEtherWinner = await ethers.getContractFactory("RejectEtherWinner");
+    const rejectWinner = await RejectEtherWinner.deploy();
+    await rejectWinner.waitForDeployment();
+
+    await prizeSplit.setTreasury(treasury.address);
+
+    return { admin, winner, otherWinner, treasury, prizeSplit, rejectWinner };
+  }
+
+  async function fundAndFinalize(prizeSplit, winners, prize = ethers.parseEther("2")) {
+    await prizeSplit.fundRound({ value: prize });
+    const roundId = await prizeSplit.roundId();
+    await prizeSplit.finalizeRound(roundId, winners);
+    return roundId;
+  }
+
+  async function expireClaims() {
+    await ethers.provider.send("evm_increaseTime", [claimDeadlineSeconds + 1]);
+    await ethers.provider.send("evm_mine");
+  }
+
+  it("lets other winners claim when a contract winner rejects ETH", async function () {
+    const { prizeSplit, rejectWinner, winner } = await deployPrizeSplit();
+    const rejectWinnerAddress = await rejectWinner.getAddress();
+    const roundId = await fundAndFinalize(prizeSplit, [rejectWinnerAddress, winner.address]);
+
+    await expect(rejectWinner.claimPrize(prizeSplit, roundId)).to.be.revertedWith("Transfer failed");
+    expect(await prizeSplit.isClaimed(roundId, rejectWinnerAddress)).to.equal(false);
+
+    await expect(prizeSplit.connect(winner).claimPrize(roundId))
+      .to.emit(prizeSplit, "PrizeClaimed")
+      .withArgs(winner.address, ethers.parseEther("1"), roundId);
+
+    expect(await prizeSplit.isClaimed(roundId, winner.address)).to.equal(true);
+    expect(await prizeSplit.totalPrize()).to.equal(ethers.parseEther("1"));
+  });
+
+  it("reclaims unclaimed prizes to treasury after the 90 day deadline", async function () {
+    const { prizeSplit, winner, otherWinner, treasury } = await deployPrizeSplit();
+    const roundId = await fundAndFinalize(prizeSplit, [winner.address, otherWinner.address]);
+
+    await expireClaims();
+
+    await expect(prizeSplit.connect(winner).claimPrize(roundId)).to.be.revertedWith("Claim expired");
+    await expect(prizeSplit.reclaimUnclaimedPrizes(roundId))
+      .to.emit(prizeSplit, "UnclaimedPrizesReclaimed")
+      .withArgs(roundId, treasury.address, ethers.parseEther("2"));
+
+    expect(await ethers.provider.getBalance(await prizeSplit.getAddress())).to.equal(0n);
+    expect(await prizeSplit.totalPrize()).to.equal(0n);
+  });
+
+  it("reclaims only the remaining balance after partial claims", async function () {
+    const { prizeSplit, winner, otherWinner, treasury } = await deployPrizeSplit();
+    const roundId = await fundAndFinalize(prizeSplit, [winner.address, otherWinner.address]);
+
+    await prizeSplit.connect(winner).claimPrize(roundId);
+    await expireClaims();
+
+    await expect(prizeSplit.reclaimUnclaimedPrizes(roundId))
+      .to.emit(prizeSplit, "UnclaimedPrizesReclaimed")
+      .withArgs(roundId, treasury.address, ethers.parseEther("1"));
+
+    expect(await prizeSplit.totalPrize()).to.equal(0n);
+    expect(await ethers.provider.getBalance(await prizeSplit.getAddress())).to.equal(0n);
+  });
+});


### PR DESCRIPTION
/claim #126
Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Summary:
- Converts PrizeSplit to individual pull claims with state updates before external ETH transfer.
- Adds a 90-day claim deadline and treasury reclaim for unclaimed prizes.
- Adds a RejectEtherWinner fixture and focused tests for rejecting winners, deadline expiry, and partial reclaim.
- Adds minimal Hardhat compiler compatibility and a Chainlink tuple syntax build fix required for the current full-project compile.

Verification:
- npx hardhat test .\test\PrizeSplitPullClaims.test.js (3 passing)
- npx hardhat compile (Nothing to compile)
- node --check .\test\PrizeSplitPullClaims.test.js
- git diff --check (CRLF warnings only)

Note: Private runtime/session initialization text is intentionally not included in public files or comments.