### PR TITLE
Fix AMMPool minimum liquidity attack

### DIFF
--- a/contracts/dex/AMMPool.sol
+++ b/contracts/dex/AMMPool.sol
@@ -18,12 +18,14 @@ contract AMMPool {
     uint256 public reserveB;
     uint256 public totalLiquidity;
     uint256 public constant FEE_BPS = 30; // 0.3%
+    uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     mapping(address => uint256) public liquidity;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB);
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) {
         tokenA = IERC20(_tokenA);
@@ -37,12 +39,18 @@ contract AMMPool {
         require(amountA > 0 && amountB > 0, "Zero amounts");
 
         if (totalLiquidity == 0) {
-            lpTokens = _sqrt(amountA * amountB);
+            uint256 initialLiquidity = _sqrt(amountA * amountB);
+            require(initialLiquidity > MINIMUM_LIQUIDITY, "Insufficient initial liquidity");
+            liquidity[address(0)] = MINIMUM_LIQUIDITY;
+            totalLiquidity = MINIMUM_LIQUIDITY;
+            lpTokens = initialLiquidity - MINIMUM_LIQUIDITY;
         } else {
             uint256 lpA = (amountA * totalLiquidity) / reserveA;
             uint256 lpB = (amountB * totalLiquidity) / reserveB;
             lpTokens = lpA < lpB ? lpA : lpB;
         }
+
+        require(lpTokens > 0, "Insufficient liquidity minted");
 
         require(tokenA.transferFrom(msg.sender, address(this), amountA), "Transfer A failed");
         require(tokenB.transferFrom(msg.sender, address(this), amountB), "Transfer B failed");
@@ -53,6 +61,7 @@ contract AMMPool {
         totalLiquidity += lpTokens;
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
+        emit Sync(reserveA, reserveB);
     }
 
     function removeLiquidity(uint256 lpTokens) external {
@@ -70,6 +79,7 @@ contract AMMPool {
         require(tokenB.transfer(msg.sender, amountB), "Transfer B failed");
 
         emit LiquidityRemoved(msg.sender, amountA, amountB);
+        emit Sync(reserveA, reserveB);
     }
 
     // BUG: Swap has no deadline parameter — transaction can sit in mempool and execute
@@ -103,6 +113,13 @@ contract AMMPool {
         }
 
         emit Swap(msg.sender, tokenIn, amountIn, amountOut);
+        emit Sync(reserveA, reserveB);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function _sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    constructor(string memory tokenName, string memory tokenSymbol) {
+        name = tokenName;
+        symbol = tokenSymbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(to != address(0), "Invalid recipient");
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        require(currentAllowance >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] = currentAllowance - amount;
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "Invalid recipient");
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/AMMPoolMinimumLiquidity.test.js
+++ b/test/AMMPoolMinimumLiquidity.test.js
@@ -1,0 +1,97 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AMMPool minimum liquidity", function () {
+  async function deployPool() {
+    const [owner, firstLp, secondLp, trader, donor] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const tokenA = await Token.deploy("Token A", "TKNA");
+    await tokenA.waitForDeployment();
+    const tokenB = await Token.deploy("Token B", "TKNB");
+    await tokenB.waitForDeployment();
+
+    const AMMPool = await ethers.getContractFactory("AMMPool");
+    const pool = await AMMPool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    await pool.waitForDeployment();
+
+    for (const signer of [firstLp, secondLp, trader, donor]) {
+      await tokenA.mint(signer.address, 200000n);
+      await tokenB.mint(signer.address, 200000n);
+      await tokenA.connect(signer).approve(await pool.getAddress(), 200000n);
+      await tokenB.connect(signer).approve(await pool.getAddress(), 200000n);
+    }
+
+    return { owner, firstLp, secondLp, trader, donor, tokenA, tokenB, pool };
+  }
+
+  it("locks 1000 LP units on the first deposit", async function () {
+    const { firstLp, pool } = await deployPool();
+
+    await expect(pool.connect(firstLp).addLiquidity(10000n, 10000n))
+      .to.emit(pool, "LiquidityAdded")
+      .withArgs(firstLp.address, 10000n, 10000n, 9000n);
+
+    expect(await pool.MINIMUM_LIQUIDITY()).to.equal(1000n);
+    expect(await pool.totalLiquidity()).to.equal(10000n);
+    expect(await pool.liquidity(ethers.ZeroAddress)).to.equal(1000n);
+    expect(await pool.liquidity(firstLp.address)).to.equal(9000n);
+  });
+
+  it("rejects initial deposits that cannot cover the minimum liquidity lock", async function () {
+    const { firstLp, pool } = await deployPool();
+
+    await expect(pool.connect(firstLp).addLiquidity(1000n, 1000n)).to.be.revertedWith(
+      "Insufficient initial liquidity",
+    );
+  });
+
+  it("uses internal reserves so token donations do not change pricing", async function () {
+    const { firstLp, trader, donor, tokenA, tokenB, pool } = await deployPool();
+    const poolAddress = await pool.getAddress();
+    await pool.connect(firstLp).addLiquidity(10000n, 10000n);
+
+    await tokenA.connect(donor).transfer(poolAddress, 90000n);
+    expect(await pool.getReserves()).to.deep.equal([10000n, 10000n]);
+
+    const amountIn = 1000n;
+    const amountInWithFee = amountIn * 9970n;
+    const expectedOut = (amountInWithFee * 10000n) / (10000n * 10000n + amountInWithFee);
+
+    await expect(pool.connect(trader).swap(await tokenA.getAddress(), amountIn, expectedOut))
+      .to.emit(pool, "Swap")
+      .withArgs(trader.address, await tokenA.getAddress(), amountIn, expectedOut);
+
+    expect(await pool.getReserves()).to.deep.equal([11000n, 10000n - expectedOut]);
+    expect(await tokenB.balanceOf(trader.address)).to.equal(200000n + expectedOut);
+  });
+
+  it("removes liquidity from internal reserves and leaves donated tokens untouched", async function () {
+    const { firstLp, donor, tokenA, tokenB, pool } = await deployPool();
+    const poolAddress = await pool.getAddress();
+    await pool.connect(firstLp).addLiquidity(10000n, 10000n);
+
+    await tokenA.connect(donor).transfer(poolAddress, 50000n);
+    await tokenB.connect(donor).transfer(poolAddress, 50000n);
+
+    await expect(pool.connect(firstLp).removeLiquidity(9000n))
+      .to.emit(pool, "LiquidityRemoved")
+      .withArgs(firstLp.address, 9000n, 9000n);
+
+    expect(await pool.getReserves()).to.deep.equal([1000n, 1000n]);
+    expect(await tokenA.balanceOf(poolAddress)).to.equal(51000n);
+    expect(await tokenB.balanceOf(poolAddress)).to.equal(51000n);
+  });
+
+  it("syncs internal reserves to actual token balances when explicitly called", async function () {
+    const { firstLp, donor, tokenA, tokenB, pool } = await deployPool();
+    const poolAddress = await pool.getAddress();
+    await pool.connect(firstLp).addLiquidity(10000n, 10000n);
+
+    await tokenA.connect(donor).transfer(poolAddress, 500n);
+    await tokenB.connect(donor).transfer(poolAddress, 300n);
+
+    await expect(pool.sync()).to.emit(pool, "Sync").withArgs(10500n, 10300n);
+    expect(await pool.getReserves()).to.deep.equal([10500n, 10300n]);
+  });
+});


### PR DESCRIPTION
/claim #71
Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Summary:
- Locks MINIMUM_LIQUIDITY (1000 LP units) to address(0) on the first AMMPool deposit.
- Keeps add/remove/swap accounting based on internal reserves so direct token donations do not alter pricing or withdrawal math.
- Adds explicit sync() for intentional reserve reconciliation and preserves existing LiquidityAdded/LiquidityRemoved/Swap events.
- Adds MockERC20 and focused AMMPool tests for first-deposit lock, insufficient initial liquidity, donation-resistant swap pricing, reserve-based removal, and sync().
- Adds minimal Hardhat compiler compatibility and Chainlink tuple syntax build fix required for the current full-project compile.

Verification:
- npx hardhat test .\test\AMMPoolMinimumLiquidity.test.js (5 passing)
- npx hardhat compile (Nothing to compile)
- node --check .\test\AMMPoolMinimumLiquidity.test.js
- git diff --check (CRLF warnings only)

Full-suite note:
- npx hardhat test also runs the pre-existing StakingRewards suite, which is blocked on missing StakingToken/RewardToken artifacts unrelated to this AMMPool change.

Note: Private runtime/session initialization text is intentionally not included in public files or comments.