### PR TITLE
Fix AgentToken mint cap and permit expiry

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/token/AgentToken.sol
+++ b/contracts/token/AgentToken.sol
@@ -9,8 +9,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 /// @dev Used as the native token for the OpenAgents platform.
 contract AgentToken is ERC20, ERC20Burnable {
     address public owner;
-    // BUG: No max supply cap — tokens can be minted infinitely, leading to
-    // unbounded inflation and devaluation of existing holders' tokens.
+    uint256 public constant MAX_SUPPLY = 1_000_000_000 ether;
 
     bytes32 public constant PERMIT_TYPEHASH = keccak256(
         "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
@@ -20,13 +19,18 @@ contract AgentToken is ERC20, ERC20Burnable {
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    modifier onlyOwner() {
+        require(msg.sender == owner, "AgentToken: not owner");
+        _;
+    }
+
     constructor(
         string memory name_,
         string memory symbol_,
         uint256 initialSupply
     ) ERC20(name_, symbol_) {
         owner = msg.sender;
-        _mint(msg.sender, initialSupply);
+        _mintCapped(msg.sender, initialSupply);
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
             keccak256(bytes(name_)),
@@ -39,19 +43,21 @@ contract AgentToken is ERC20, ERC20Burnable {
     /// @notice Mint new tokens to a recipient.
     /// @param to Recipient address.
     /// @param amount Amount of tokens to mint.
-    // BUG: No access control — anyone can call mint and create tokens for themselves.
-    // Should be restricted to owner or a minter role.
-    function mint(address to, uint256 amount) external {
-        _mint(to, amount);
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mintCapped(to, amount);
     }
 
     /// @notice Transfer ownership of the contract.
     /// @param newOwner The new owner address.
-    function transferOwnership(address newOwner) external {
-        require(msg.sender == owner, "AgentToken: not owner");
+    function transferOwnership(address newOwner) external onlyOwner {
         require(newOwner != address(0), "AgentToken: zero address");
         emit OwnershipTransferred(owner, newOwner);
         owner = newOwner;
+    }
+
+    function _mintCapped(address to, uint256 amount) internal {
+        require(totalSupply() + amount <= MAX_SUPPLY, "AgentToken: cap exceeded");
+        _mint(to, amount);
     }
 
     /// @notice EIP-2612 permit: approve via signature.
@@ -71,8 +77,8 @@ contract AgentToken is ERC20, ERC20Burnable {
         bytes32 r,
         bytes32 s
     ) external {
-        // BUG: Deadline is not checked — expired permits are still accepted, allowing
-        // old signatures to be used indefinitely. Should require(block.timestamp <= deadline).
+        require(block.timestamp <= deadline, "AgentToken: expired permit");
+
         bytes32 structHash = keccak256(abi.encode(
             PERMIT_TYPEHASH,
             _owner,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/AgentTokenSecurity.test.js
+++ b/test/AgentTokenSecurity.test.js
@@ -1,0 +1,87 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentToken security controls", function () {
+  async function deployToken(initialSupply = 1000n) {
+    const [owner, holder, spender, other] = await ethers.getSigners();
+
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const token = await AgentToken.deploy("Agent Token", "AGENT", initialSupply);
+    await token.waitForDeployment();
+
+    return { owner, holder, spender, other, token };
+  }
+
+  it("restricts minting to the owner", async function () {
+    const { owner, other, token } = await deployToken();
+
+    await expect(token.connect(other).mint(other.address, 1n)).to.be.revertedWith("AgentToken: not owner");
+
+    await token.connect(owner).mint(other.address, 250n);
+    expect(await token.balanceOf(other.address)).to.equal(250n);
+  });
+
+  it("caps initial and future supply", async function () {
+    const { owner, other, token } = await deployToken();
+    const maxSupply = await token.MAX_SUPPLY();
+    const remaining = maxSupply - (await token.totalSupply());
+
+    await token.connect(owner).mint(other.address, remaining);
+    await expect(token.connect(owner).mint(other.address, 1n)).to.be.revertedWith("AgentToken: cap exceeded");
+
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    await expect(AgentToken.deploy("Too Much", "TOO", maxSupply + 1n)).to.be.revertedWith(
+      "AgentToken: cap exceeded",
+    );
+  });
+
+  it("rejects expired permits before accepting a signature", async function () {
+    const { holder, spender, token } = await deployToken();
+    await token.mint(holder.address, 100n);
+
+    const latest = await ethers.provider.getBlock("latest");
+    const deadline = BigInt(latest.timestamp - 1);
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    const nonce = await token.nonces(holder.address);
+
+    const signature = await holder.signTypedData(
+      {
+        name: "Agent Token",
+        version: "1",
+        chainId,
+        verifyingContract: await token.getAddress(),
+      },
+      {
+        Permit: [
+          { name: "owner", type: "address" },
+          { name: "spender", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+        ],
+      },
+      {
+        owner: holder.address,
+        spender: spender.address,
+        value: 50n,
+        nonce,
+        deadline,
+      },
+    );
+    const { v, r, s } = ethers.Signature.from(signature);
+
+    await expect(token.permit(holder.address, spender.address, 50n, deadline, v, r, s)).to.be.revertedWith(
+      "AgentToken: expired permit",
+    );
+  });
+
+  it("burns holder tokens", async function () {
+    const { holder, token } = await deployToken();
+    await token.mint(holder.address, 100n);
+
+    await token.connect(holder).burn(40n);
+
+    expect(await token.balanceOf(holder.address)).to.equal(60n);
+    expect(await token.totalSupply()).to.equal(1060n);
+  });
+});


### PR DESCRIPTION
/claim #70
Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Summary:
- Restricts AgentToken.mint() to the owner and reuses the same owner check for ownership transfer.
- Adds MAX_SUPPLY and enforces it for both constructor minting and future owner mints.
- Rejects expired EIP-2612 permit signatures before nonce use or approval.
- Keeps ERC20Burnable burn support and adds tests proving holder burn behavior.
- Adds minimal Hardhat compiler compatibility and Chainlink tuple syntax build fix required for the current full-project compile.

Verification:
- npx hardhat test .\test\AgentTokenSecurity.test.js (4 passing)
- npx hardhat compile
- node --check .\test\AgentTokenSecurity.test.js
- git diff --check (CRLF warnings only)

Full-suite note:
- npx hardhat test also runs the pre-existing StakingRewards suite, which is blocked on missing StakingToken/RewardToken artifacts unrelated to this AgentToken change.

Note: Private runtime/session initialization text is intentionally not included in public files or comments.