### PR TITLE
Fix MultiTokenStaking duplicate pools and reward math

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title MultiTokenStaking
 /// @notice Allows users to stake multiple ERC20 tokens across different pools,
@@ -32,15 +33,15 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
 
     PoolInfo[] public poolInfo;
     mapping(uint256 => mapping(address => UserInfo)) public userInfo;
+    mapping(address => bool) public poolExists;
 
     event PoolAdded(uint256 indexed pid, address token, uint256 allocPoint);
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
 
-    // BUG: Missing zero-address validation — rewardToken can be set to address(0),
-    // causing all reward transfers to silently burn tokens or revert unpredictably.
     constructor(address _rewardToken, uint256 _rewardPerSecond) Ownable(msg.sender) {
+        require(_rewardToken != address(0), "MultiStaking: zero reward token");
         rewardToken = IERC20(_rewardToken);
         rewardPerSecond = _rewardPerSecond;
     }
@@ -48,11 +49,12 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     /// @notice Add a new staking pool.
     /// @param _allocPoint Allocation weight for reward distribution.
     /// @param _stakeToken The ERC20 token to be staked in this pool.
-    // BUG: No duplicate token check — the same token can be added multiple times,
-    // causing reward accounting to break as totalAllocPoint inflates and existing
-    // stakers in the original pool get diluted unexpectedly.
     function addPool(uint256 _allocPoint, address _stakeToken) external onlyOwner {
+        require(_stakeToken != address(0), "MultiStaking: zero stake token");
+        require(!poolExists[_stakeToken], "MultiStaking: duplicate pool");
+
         totalAllocPoint += _allocPoint;
+        poolExists[_stakeToken] = true;
         poolInfo.push(PoolInfo({
             stakeToken: IERC20(_stakeToken),
             allocPoint: _allocPoint,
@@ -75,10 +77,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
 
         uint256 elapsed = block.timestamp - pool.lastRewardTime;
-        // BUG: Reward calculation can overflow for large elapsed * rewardPerSecond * allocPoint
-        // values. With high rewardPerSecond (e.g., 1e18) and long time gaps, the intermediate
-        // multiplication exceeds uint256 before the division by totalAllocPoint.
-        uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
+        uint256 reward = _poolReward(elapsed, pool.allocPoint);
         pool.accRewardPerShare += reward * 1e12 / pool.totalStaked;
         pool.lastRewardTime = block.timestamp;
     }
@@ -139,9 +138,14 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         uint256 accRewardPerShare = pool.accRewardPerShare;
         if (block.timestamp > pool.lastRewardTime && pool.totalStaked > 0) {
             uint256 elapsed = block.timestamp - pool.lastRewardTime;
-            uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
+            uint256 reward = _poolReward(elapsed, pool.allocPoint);
             accRewardPerShare += reward * 1e12 / pool.totalStaked;
         }
         return user.amount * accRewardPerShare / 1e12 - user.rewardDebt;
+    }
+
+    function _poolReward(uint256 elapsed, uint256 allocPoint) internal view returns (uint256) {
+        uint256 rewardPerAllocPoint = Math.mulDiv(elapsed, rewardPerSecond, totalAllocPoint);
+        return Math.mulDiv(rewardPerAllocPoint, allocPoint, 1);
     }
 }

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    constructor(string memory tokenName, string memory tokenSymbol) {
+        name = tokenName;
+        symbol = tokenSymbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(to != address(0), "Invalid recipient");
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        require(currentAllowance >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] = currentAllowance - amount;
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "Invalid recipient");
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/MultiTokenStakingPoolGuards.test.js
+++ b/test/MultiTokenStakingPoolGuards.test.js
@@ -1,0 +1,56 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MultiTokenStaking pool guards", function () {
+  async function deployFixture(rewardPerSecond = 100n) {
+    const [owner, staker] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const rewardToken = await Token.deploy("Reward", "RWD");
+    await rewardToken.waitForDeployment();
+    const stakeToken = await Token.deploy("Stake", "STK");
+    await stakeToken.waitForDeployment();
+    const otherStakeToken = await Token.deploy("Other Stake", "OSTK");
+    await otherStakeToken.waitForDeployment();
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    const staking = await MultiTokenStaking.deploy(await rewardToken.getAddress(), rewardPerSecond);
+    await staking.waitForDeployment();
+
+    await stakeToken.mint(staker.address, 1000n);
+    await stakeToken.connect(staker).approve(await staking.getAddress(), 1000n);
+
+    return { owner, staker, rewardToken, stakeToken, otherStakeToken, staking };
+  }
+
+  it("rejects zero reward and stake token addresses", async function () {
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    await expect(MultiTokenStaking.deploy(ethers.ZeroAddress, 1n)).to.be.revertedWith(
+      "MultiStaking: zero reward token",
+    );
+
+    const { staking } = await deployFixture();
+    await expect(staking.addPool(1n, ethers.ZeroAddress)).to.be.revertedWith("MultiStaking: zero stake token");
+  });
+
+  it("rejects duplicate staking token pools", async function () {
+    const { stakeToken, staking } = await deployFixture();
+    const stakeTokenAddress = await stakeToken.getAddress();
+
+    await staking.addPool(100n, stakeTokenAddress);
+    expect(await staking.poolExists(stakeTokenAddress)).to.equal(true);
+
+    await expect(staking.addPool(100n, stakeTokenAddress)).to.be.revertedWith("MultiStaking: duplicate pool");
+  });
+
+  it("continues to accrue rewards through the safe reward helper", async function () {
+    const { staker, stakeToken, staking } = await deployFixture();
+    await staking.addPool(100n, await stakeToken.getAddress());
+    await staking.connect(staker).deposit(0, 100n);
+
+    await ethers.provider.send("evm_increaseTime", [10]);
+    await ethers.provider.send("evm_mine");
+
+    expect(await staking.pendingReward(0, staker.address)).to.equal(1000n);
+  });
+});


### PR DESCRIPTION
/claim #79
Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Summary:
- Rejects zero reward-token and stake-token addresses.
- Adds poolExists tracking to reject duplicate staking token pools before totalAllocPoint changes.
- Moves pool reward calculation into a Math.mulDiv-based helper to avoid the direct elapsed * rewardPerSecond * allocPoint multiplication path.
- Adds MockERC20 and focused tests for zero-address validation, duplicate-pool rejection, and continued reward accrual.
- Adds minimal Hardhat compiler compatibility and Chainlink tuple syntax build fix required for the current full-project compile.

Verification:
- npx hardhat test .\test\MultiTokenStakingPoolGuards.test.js (3 passing)
- npx hardhat compile
- node --check .\test\MultiTokenStakingPoolGuards.test.js
- git diff --check (CRLF warnings only)

Full-suite note:
- npx hardhat test also runs the pre-existing StakingRewards suite, which is blocked on missing StakingToken/RewardToken artifacts unrelated to this MultiTokenStaking change.

Note: Private runtime/session initialization text is intentionally not included in public files or comments.