### PR TITLE
Add MultiTokenStaking emergency withdraw

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,12 +73,16 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
+        roundId;
+        startedAt;
+        updatedAt;
+        answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -37,6 +37,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
+    event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
 
     // BUG: Missing zero-address validation — rewardToken can be set to address(0),
     // causing all reward transfers to silently burn tokens or revert unpredictably.
@@ -130,6 +131,22 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
         user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
         emit Withdraw(msg.sender, pid, amount);
+    }
+
+    /// @notice Withdraw staked tokens immediately without claiming rewards.
+    /// @param pid Pool ID.
+    function emergencyWithdraw(uint256 pid) external nonReentrant {
+        PoolInfo storage pool = poolInfo[pid];
+        UserInfo storage user = userInfo[pid][msg.sender];
+        uint256 amount = user.amount;
+        require(amount > 0, "MultiStaking: nothing to withdraw");
+
+        user.amount = 0;
+        user.rewardDebt = 0;
+        pool.totalStaked -= amount;
+        pool.stakeToken.safeTransfer(msg.sender, amount);
+
+        emit EmergencyWithdraw(msg.sender, pid, amount);
     }
 
     /// @notice View pending rewards for a user in a pool.

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    constructor(string memory tokenName, string memory tokenSymbol) {
+        name = tokenName;
+        symbol = tokenSymbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(to != address(0), "Invalid recipient");
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        require(currentAllowance >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] = currentAllowance - amount;
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "Invalid recipient");
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/MultiTokenStakingEmergencyWithdraw.test.js
+++ b/test/MultiTokenStakingEmergencyWithdraw.test.js
@@ -1,0 +1,50 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MultiTokenStaking emergencyWithdraw", function () {
+  async function deployFixture() {
+    const [owner, staker] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const rewardToken = await Token.deploy("Reward", "RWD");
+    await rewardToken.waitForDeployment();
+    const stakeToken = await Token.deploy("Stake", "STK");
+    await stakeToken.waitForDeployment();
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    const staking = await MultiTokenStaking.deploy(await rewardToken.getAddress(), 100n);
+    await staking.waitForDeployment();
+
+    await rewardToken.mint(await staking.getAddress(), 100000n);
+    await stakeToken.mint(staker.address, 1000n);
+    await stakeToken.connect(staker).approve(await staking.getAddress(), 1000n);
+
+    await staking.addPool(100n, await stakeToken.getAddress());
+
+    return { owner, staker, rewardToken, stakeToken, staking };
+  }
+
+  it("returns staked tokens without distributing rewards and resets accounting", async function () {
+    const { staker, rewardToken, stakeToken, staking } = await deployFixture();
+
+    await staking.connect(staker).deposit(0, 100n);
+    await ethers.provider.send("evm_increaseTime", [10]);
+    await ethers.provider.send("evm_mine");
+
+    expect(await staking.pendingReward(0, staker.address)).to.be.gt(0n);
+    const rewardBalanceBefore = await rewardToken.balanceOf(staker.address);
+
+    await expect(staking.connect(staker).emergencyWithdraw(0))
+      .to.emit(staking, "EmergencyWithdraw")
+      .withArgs(staker.address, 0, 100n);
+
+    const user = await staking.userInfo(0, staker.address);
+    const pool = await staking.poolInfo(0);
+
+    expect(user.amount).to.equal(0n);
+    expect(user.rewardDebt).to.equal(0n);
+    expect(pool.totalStaked).to.equal(0n);
+    expect(await stakeToken.balanceOf(staker.address)).to.equal(1000n);
+    expect(await rewardToken.balanceOf(staker.address)).to.equal(rewardBalanceBefore);
+  });
+});


### PR DESCRIPTION
/claim #195
Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base

Summary:
- Adds emergencyWithdraw(uint256 pid) to return staked principal immediately without distributing pending rewards.
- Resets user amount and rewardDebt, decrements pool.totalStaked, transfers the stake token back, and emits EmergencyWithdraw(user, pid, amount).
- Adds MockERC20 and a focused normal-stake-then-emergency-withdraw test covering principal return, no reward distribution, and pool/user accounting reset.
- Adds minimal Hardhat compiler compatibility and Chainlink tuple syntax build fix required for the current full-project compile.

Verification:
- npx hardhat test .\test\MultiTokenStakingEmergencyWithdraw.test.js (1 passing)
- npx hardhat compile
- node --check .\test\MultiTokenStakingEmergencyWithdraw.test.js
- git diff --check (CRLF warnings only)

Full-suite note:
- npx hardhat test also runs the pre-existing StakingRewards suite, which is blocked on missing StakingToken/RewardToken artifacts unrelated to this MultiTokenStaking change.

Note: Private runtime/session initialization text is intentionally not included in public files or comments.