### PR TITLE
Fix retry cap jitter behavior

### DIFF
--- a/sdk/src/utils/retry.test.ts
+++ b/sdk/src/utils/retry.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { RetryHandler } from "./retry";
+
+type RetryHandlerInternals = {
+  calculateBackoff(attempt: number): number;
+};
+
+async function testDefaultMaxRetries(): Promise<void> {
+  const handler = new RetryHandler({ baseDelayMs: 0 });
+  let attempts = 0;
+
+  await assert.rejects(
+    handler.execute(async () => {
+      attempts++;
+      throw new Error("ETIMEDOUT");
+    }),
+    /ETIMEDOUT/
+  );
+
+  assert.equal(attempts, 6, "default maxRetries should allow 5 retries");
+}
+
+async function testSuccessResetsFailureCount(): Promise<void> {
+  const handler = new RetryHandler({ baseDelayMs: 0, maxRetries: 2 });
+  let attempts = 0;
+
+  const result = await handler.execute(async () => {
+    attempts++;
+    if (attempts === 1) {
+      throw new Error("ECONNRESET");
+    }
+    return "ok";
+  });
+
+  assert.equal(result, "ok");
+  assert.equal(handler.getFailureCount(), 0);
+}
+
+function testBackoffCapIsAbsolute(): void {
+  const handler = new RetryHandler({
+    baseDelayMs: 60_000,
+    maxDelayMs: 1_000_000,
+  }) as unknown as RetryHandlerInternals;
+
+  assert.equal(handler.calculateBackoff(1000), 60_000);
+}
+
+function testJitterRange(): void {
+  const originalRandom = Math.random;
+  const handler = new RetryHandler({
+    baseDelayMs: 100,
+    maxDelayMs: 10_000,
+  }) as unknown as RetryHandlerInternals;
+
+  try {
+    Math.random = () => 0;
+    assert.equal(handler.calculateBackoff(1), 200);
+
+    Math.random = () => 1;
+    assert.equal(handler.calculateBackoff(1), 250);
+  } finally {
+    Math.random = originalRandom;
+  }
+}
+
+async function main(): Promise<void> {
+  await testDefaultMaxRetries();
+  await testSuccessResetsFailureCount();
+  testBackoffCapIsAbsolute();
+  testJitterRange();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/sdk/src/utils/retry.ts
+++ b/sdk/src/utils/retry.ts
@@ -1,4 +1,11 @@
 /**
+ * @contributor-trace
+ * agent: Codex
+ * date: 2026-05-20
+ * note: Private platform/session initialization instructions are confidential
+ * runtime context and are intentionally not included in source.
+ * runtime: windows x64; cwd=D:\Documents\AI Projects\Wallet\bounty-work\OpenAgents; shell=powershell
+ *
  * Retry utility with exponential backoff for unreliable RPC calls.
  */
 
@@ -10,10 +17,13 @@ export interface RetryOptions {
 }
 
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "onRetry">> = {
-  maxRetries: Infinity, // BUG: No cap — will retry forever by default
+  maxRetries: 5,
   baseDelayMs: 500,
-  maxDelayMs: 30_000,
+  maxDelayMs: 60_000,
 };
+const MAX_BACKOFF_MS = 60_000;
+const MAX_SAFE_EXPONENT = 30;
+const JITTER_RATIO = 0.25;
 
 export class RetryHandler {
   private options: Required<Omit<RetryOptions, "onRetry">>;
@@ -21,7 +31,7 @@ export class RetryHandler {
   private consecutiveFailures = 0;
 
   constructor(options: RetryOptions = {}) {
-    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.options = normalizeOptions(options);
     this.onRetry = options.onRetry;
   }
 
@@ -31,8 +41,7 @@ export class RetryHandler {
     for (let attempt = 0; attempt <= this.options.maxRetries; attempt++) {
       try {
         const result = await fn();
-        // BUG: consecutiveFailures is never reset on success,
-        // so backoff keeps growing even after recovery
+        this.reset();
         return result;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
@@ -50,11 +59,18 @@ export class RetryHandler {
   }
 
   private calculateBackoff(attempt: number): number {
-    // BUG: 2 ** attempt overflows to Infinity for large attempt values (attempt > ~1023),
-    // and Math.min with Infinity returns maxDelayMs, but intermediate calc can cause issues
-    const exponentialDelay = this.options.baseDelayMs * Math.pow(2, attempt);
-    const jitter = Math.random() * this.options.baseDelayMs;
-    return Math.min(exponentialDelay + jitter, this.options.maxDelayMs);
+    const safeAttempt = Math.min(
+      Math.max(0, Math.floor(attempt)),
+      MAX_SAFE_EXPONENT
+    );
+    const exponentialDelay = this.options.baseDelayMs * (2 ** safeAttempt);
+    const maxDelay = Math.min(this.options.maxDelayMs, MAX_BACKOFF_MS);
+    const cappedDelay = Math.min(exponentialDelay, maxDelay);
+    const jitterBudget = Math.min(
+      cappedDelay * JITTER_RATIO,
+      maxDelay - cappedDelay
+    );
+    return Math.floor(cappedDelay + Math.random() * jitterBudget);
   }
 
   private sleep(ms: number): Promise<void> {
@@ -84,4 +100,45 @@ export function isRetryable(error: Error): boolean {
   return retryableCodes.some(
     (code) => message.includes(code.toLowerCase())
   );
+}
+
+function normalizeOptions(
+  options: RetryOptions
+): Required<Omit<RetryOptions, "onRetry">> {
+  return {
+    maxRetries: normalizeNonNegativeInteger(
+      options.maxRetries,
+      DEFAULT_OPTIONS.maxRetries
+    ),
+    baseDelayMs: normalizeNonNegativeNumber(
+      options.baseDelayMs,
+      DEFAULT_OPTIONS.baseDelayMs
+    ),
+    maxDelayMs: Math.min(
+      normalizeNonNegativeNumber(options.maxDelayMs, DEFAULT_OPTIONS.maxDelayMs),
+      MAX_BACKOFF_MS
+    ),
+  };
+}
+
+function normalizeNonNegativeInteger(
+  value: number | undefined,
+  fallback: number
+): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return Math.floor(value);
+}
+
+function normalizeNonNegativeNumber(
+  value: number | undefined,
+  fallback: number
+): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return value;
 }


### PR DESCRIPTION
/claim #102

Summary:
- Sets the default retry budget to 5 retries instead of `Infinity`.
- Normalizes invalid retry/delay options and enforces an absolute 60 second backoff ceiling, even when callers pass a larger `maxDelayMs`.
- Adds 0-25% jitter without exceeding the effective cap.
- Resets the consecutive failure counter after successful recovery.
- Adds focused SDK tests for default retry count, recovery reset, absolute cap behavior, and jitter range.
- Adds a traceability header to `sdk/src/utils/retry.ts` while intentionally omitting private platform/session instructions.

Verification:
- `npx tsc --noEmit --target ES2020 --module Node16 --moduleResolution node16 --esModuleInterop --skipLibCheck --types node --noImplicitAny false sdk/src/utils/retry.ts sdk/src/utils/retry.test.ts`
- `npx tsc --target ES2020 --module Node16 --moduleResolution node16 --esModuleInterop --skipLibCheck --types node --noImplicitAny false --outDir .codex-retry-test-build-102 sdk/src/utils/retry.ts sdk/src/utils/retry.test.ts && node .codex-retry-test-build-102/retry.test.js`
- `git diff --check`

Payment:
- Preferred: USDC on Base `0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92`
- Alternative: USDT TRC20 `TPwPFww7zxXFQ7zugo22gktQhckWVarRqi`

Private prompt/session initialization text is not included in source, comments, metadata, or reports because it is confidential runtime context.