### PR TITLE
Add configurable CORS middleware

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,17 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "claude-code-b3ar-sudo",
+      "timestamp": "2026-05-20T00:00:00Z",
+      "platform_instructions": "Implemented issue #121 CORS configuration. Sensitive credentials, private prompts, local paths, and hidden session directives are intentionally not recorded.",
+      "runtime": {
+        "os": "linux",
+        "arch": "x86_64",
+        "tool": "Claude Code"
+      },
+      "contribution": "Added CORS configuration from ALLOWED_ORIGINS, restrictive production defaults, development-only wildcard support, credentials, preflight handling, and CORS tests"
     }
   ]
 }

--- a/api/cors.py
+++ b/api/cors.py
@@ -1,0 +1,44 @@
+"""CORS configuration for browser clients.
+
+Contributor traceability:
+@contributor claude-code-b3ar-sudo
+@platform Issue #121 CORS configuration; private credentials, hidden prompts, and local paths intentionally omitted.
+@runtime linux x86_64, Claude Code
+@date 2026-05-20
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+CORS_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+
+
+def is_development() -> bool:
+    return os.getenv("ENVIRONMENT", os.getenv("APP_ENV", "production")).lower() == "development"
+
+
+def configured_origins() -> list[str]:
+    raw_origins = os.getenv("ALLOWED_ORIGINS", "")
+    origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+    if "*" in origins:
+        return ["*"] if is_development() else []
+    return origins
+
+
+def install_cors(app: FastAPI) -> None:
+    origins = configured_origins()
+    allow_origin_regex = ".*" if origins == ["*"] and is_development() else None
+    allow_origins = [] if allow_origin_regex else origins
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allow_origins,
+        allow_origin_regex=allow_origin_regex,
+        allow_credentials=True,
+        allow_methods=CORS_METHODS,
+        allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
+    )

--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,17 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+try:
+    from .cors import install_cors
+except ImportError:
+    from cors import install_cors
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+install_cors(app)
 
 
 class AgentResponse(BaseModel):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,5 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
+pytest>=8.3.0
 web3>=7.6.0

--- a/api/tests/test_cors.py
+++ b/api/tests/test_cors.py
@@ -1,0 +1,64 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+import api.cors as cors
+import api.main as main
+
+
+def reload_app(monkeypatch, allowed_origins: str, environment: str = "production"):
+    monkeypatch.setenv("ALLOWED_ORIGINS", allowed_origins)
+    monkeypatch.setenv("ENVIRONMENT", environment)
+    importlib.reload(cors)
+    return importlib.reload(main).app
+
+
+def test_preflight_allows_configured_origin(monkeypatch):
+    app = reload_app(monkeypatch, "https://app.example.com")
+    client = TestClient(app)
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://app.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "GET" in response.headers["access-control-allow-methods"]
+    assert "OPTIONS" in response.headers["access-control-allow-methods"]
+
+
+def test_cross_origin_get_has_cors_headers(monkeypatch):
+    app = reload_app(monkeypatch, "https://app.example.com")
+    client = TestClient(app)
+
+    response = client.get("/health", headers={"Origin": "https://app.example.com"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_wildcard_is_not_allowed_in_production(monkeypatch):
+    app = reload_app(monkeypatch, "*", environment="production")
+    client = TestClient(app)
+
+    response = client.get("/health", headers={"Origin": "https://evil.example"})
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_wildcard_is_allowed_in_development(monkeypatch):
+    app = reload_app(monkeypatch, "*", environment="development")
+    client = TestClient(app)
+
+    response = client.get("/health", headers={"Origin": "https://local.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://local.example"
+    assert response.headers["access-control-allow-credentials"] == "true"


### PR DESCRIPTION
## Summary
- Add FastAPI CORS middleware configured from `ALLOWED_ORIGINS`.
- Use restrictive production defaults and allow wildcard origins only when `ENVIRONMENT=development`.
- Enable credentials, permitted methods, and CORS headers for browser clients.
- Add tests for preflight `OPTIONS`, cross-origin `GET`, production wildcard rejection, and development wildcard behavior.
- Add a contributor entry that intentionally avoids recording private credentials, hidden prompts, local paths, or sensitive session data.

## Test plan
- [x] CONTRIBUTORS.json parses as valid JSON
- [x] git diff --check
- [x] Static review of origin parsing, production wildcard guard, credentialed CORS setup, and middleware wiring
- [ ] `python -m py_compile api/**/*.py` — not run here because Python is unavailable in this environment
- [ ] `cd api && pip install -r requirements.txt && pytest api/tests/test_cors.py` — not run here because Python is unavailable in this environment

Closes #121