### PR TITLE
Add component health endpoint

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,17 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "claude-code-b3ar-sudo",
+      "timestamp": "2026-05-20T00:00:00Z",
+      "platform_instructions": "Implemented issue #41 health component status. Sensitive credentials, private prompts, local paths, and hidden session directives are intentionally not recorded.",
+      "runtime": {
+        "os": "linux",
+        "arch": "x86_64",
+        "tool": "Claude Code"
+      },
+      "contribution": "Added component health checks for DB, RPC, disk, and memory with latency, worst-status aggregation, 10-second caching, 200/503 responses, and tests"
     }
   ]
 }

--- a/api/health.py
+++ b/api/health.py
@@ -1,0 +1,127 @@
+"""Component health checks for the OpenAgents API.
+
+Contributor traceability:
+@contributor claude-code-b3ar-sudo
+@platform Issue #41 health component status; private credentials, hidden prompts, and local paths intentionally omitted.
+@runtime linux x86_64, Claude Code
+@date 2026-05-20
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from datetime import datetime
+from typing import Callable, Dict
+
+from fastapi.responses import JSONResponse
+
+CACHE_SECONDS = 10
+_HEALTH_CACHE: dict | None = None
+_HEALTH_CACHE_AT = 0.0
+
+
+def timed_check(check: Callable[[], dict]) -> dict:
+    started = time.monotonic()
+    try:
+        result = check()
+    except Exception as exc:
+        result = {"status": "unhealthy", "details": str(exc)}
+    result["latency_ms"] = round((time.monotonic() - started) * 1000, 2)
+    return result
+
+
+def check_database() -> dict:
+    try:
+        from .models.database import engine
+    except ImportError:
+        from models.database import engine
+
+    with engine.connect() as connection:
+        connection.exec_driver_sql("SELECT 1")
+    return {"status": "healthy"}
+
+
+def check_rpc() -> dict:
+    rpc_url = os.getenv("RPC_URL") or os.getenv("WEB3_PROVIDER_URI")
+    if not rpc_url:
+        return {"status": "healthy", "details": "RPC endpoint not configured"}
+
+    try:
+        import httpx
+    except ImportError:
+        return {"status": "unhealthy", "details": "httpx is not installed"}
+
+    response = httpx.post(
+        rpc_url,
+        json={"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1},
+        timeout=2.0,
+    )
+    if response.status_code >= 400:
+        return {"status": "unhealthy", "details": f"HTTP {response.status_code}"}
+    return {"status": "healthy"}
+
+
+def check_disk() -> dict:
+    threshold = float(os.getenv("HEALTH_DISK_MIN_FREE_PERCENT", "5"))
+    usage = shutil.disk_usage(os.getenv("HEALTH_DISK_PATH", "/"))
+    free_percent = usage.free / usage.total * 100
+    return {
+        "status": "healthy" if free_percent >= threshold else "unhealthy",
+        "free_percent": round(free_percent, 2),
+        "threshold_percent": threshold,
+    }
+
+
+def check_memory() -> dict:
+    threshold = float(os.getenv("HEALTH_MEMORY_MIN_AVAILABLE_PERCENT", "5"))
+    meminfo = {}
+    with open("/proc/meminfo") as file:
+        for line in file:
+            key, value = line.split(":", 1)
+            meminfo[key] = int(value.strip().split()[0])
+    total = meminfo["MemTotal"]
+    available = meminfo.get("MemAvailable", meminfo.get("MemFree", 0))
+    available_percent = available / total * 100
+    return {
+        "status": "healthy" if available_percent >= threshold else "unhealthy",
+        "available_percent": round(available_percent, 2),
+        "threshold_percent": threshold,
+    }
+
+
+def collect_health() -> dict:
+    components = {
+        "db": timed_check(check_database),
+        "rpc": timed_check(check_rpc),
+        "disk": timed_check(check_disk),
+        "memory": timed_check(check_memory),
+    }
+    overall_status = "unhealthy" if any(c["status"] == "unhealthy" for c in components.values()) else "healthy"
+    return {
+        "status": overall_status,
+        "components": components,
+        "cache_ttl_seconds": CACHE_SECONDS,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+
+def cached_health() -> dict:
+    global _HEALTH_CACHE, _HEALTH_CACHE_AT
+    now = time.monotonic()
+    if _HEALTH_CACHE is not None and now - _HEALTH_CACHE_AT < CACHE_SECONDS:
+        cached = dict(_HEALTH_CACHE)
+        cached["cached"] = True
+        return cached
+    _HEALTH_CACHE = collect_health()
+    _HEALTH_CACHE_AT = now
+    fresh = dict(_HEALTH_CACHE)
+    fresh["cached"] = False
+    return fresh
+
+
+def health_response() -> JSONResponse:
+    payload = cached_health()
+    status_code = 503 if payload["status"] == "unhealthy" else 200
+    return JSONResponse(status_code=status_code, content=payload)

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,11 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+try:
+    from .health import health_response
+except ImportError:
+    from health import health_response
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
@@ -104,9 +109,4 @@ async def leaderboard(limit: int = Query(20, le=50)):
 
 @app.get("/health")
 async def health():
-    return {
-        "status": "ok",
-        "agents_indexed": len(agents_cache),
-        "tasks_indexed": len(tasks_cache),
-        "timestamp": datetime.utcnow().isoformat(),
-    }
+    return health_response()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,6 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
+pytest>=8.3.0
+SQLAlchemy>=2.0.0
 web3>=7.6.0

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,0 +1,64 @@
+from fastapi.responses import JSONResponse
+
+import api.health as health
+
+
+def reset_cache():
+    health._HEALTH_CACHE = None
+    health._HEALTH_CACHE_AT = 0.0
+
+
+def test_health_payload_contains_component_status_and_latency(monkeypatch):
+    reset_cache()
+    monkeypatch.setattr(health, "check_database", lambda: {"status": "healthy"})
+    monkeypatch.setattr(health, "check_rpc", lambda: {"status": "healthy"})
+    monkeypatch.setattr(health, "check_disk", lambda: {"status": "healthy"})
+    monkeypatch.setattr(health, "check_memory", lambda: {"status": "healthy"})
+
+    payload = health.cached_health()
+
+    assert payload["status"] == "healthy"
+    assert payload["cached"] is False
+    assert set(payload["components"]) == {"db", "rpc", "disk", "memory"}
+    assert all("latency_ms" in component for component in payload["components"].values())
+
+
+def test_overall_status_reflects_worst_component(monkeypatch):
+    reset_cache()
+    monkeypatch.setattr(health, "check_database", lambda: {"status": "healthy"})
+    monkeypatch.setattr(health, "check_rpc", lambda: {"status": "unhealthy", "details": "down"})
+    monkeypatch.setattr(health, "check_disk", lambda: {"status": "healthy"})
+    monkeypatch.setattr(health, "check_memory", lambda: {"status": "healthy"})
+
+    payload = health.cached_health()
+
+    assert payload["status"] == "unhealthy"
+    assert payload["components"]["rpc"]["status"] == "unhealthy"
+
+
+def test_health_response_uses_503_when_unhealthy(monkeypatch):
+    reset_cache()
+    monkeypatch.setattr(health, "cached_health", lambda: {"status": "unhealthy", "components": {}})
+
+    response = health.health_response()
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 503
+
+
+def test_health_result_is_cached(monkeypatch):
+    reset_cache()
+    calls = {"count": 0}
+
+    def collect():
+        calls["count"] += 1
+        return {"status": "healthy", "components": {}, "timestamp": "now", "cache_ttl_seconds": 10}
+
+    monkeypatch.setattr(health, "collect_health", collect)
+
+    first = health.cached_health()
+    second = health.cached_health()
+
+    assert calls["count"] == 1
+    assert first["cached"] is False
+    assert second["cached"] is True


### PR DESCRIPTION
## Summary
- Add component health checks for DB, RPC, disk, and memory with per-component latency.
- Aggregate overall health from the worst component and return HTTP 200 for healthy, 503 for unhealthy.
- Cache health results for 10 seconds to keep `/health` fast.
- Add tests for component latency/status, worst-status aggregation, 503 response, and cache behavior.
- Add a contributor entry that intentionally avoids recording private credentials, hidden prompts, local paths, or sensitive session data.

## Test plan
- [x] CONTRIBUTORS.json parses as valid JSON
- [x] git diff --check
- [x] Static review of component checks, latency collection, worst-status aggregation, 200/503 response selection, and cache behavior
- [ ] `python -m py_compile api/**/*.py` — not run here because Python is unavailable in this environment
- [ ] `cd api && pip install -r requirements.txt && pytest api/tests/test_health.py` — not run here because Python is unavailable in this environment

Closes #41