### PR TITLE
Add database indexes and cascades

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,17 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "claude-code-b3ar-sudo",
+      "timestamp": "2026-05-20T00:00:00Z",
+      "platform_instructions": "Implemented issue #37 database model indexes and cascades. Sensitive credentials, private prompts, local paths, and hidden session directives are intentionally not recorded.",
+      "runtime": {
+        "os": "linux",
+        "arch": "x86_64",
+        "tool": "Claude Code"
+      },
+      "contribution": "Added database indexes, User-to-Agent cascade delete, timezone-aware UTC timestamps, automatic updated_at hooks, and model regression tests"
     }
   ]
 }

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -1,19 +1,28 @@
-"""SQLAlchemy models and database session management."""
+"""SQLAlchemy models and database session management.
 
-from sqlalchemy import (
-    create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
-)
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
-from datetime import datetime
+Contributor traceability:
+@contributor claude-code-b3ar-sudo
+@platform Issue #37 database indexes and cascades; private credentials, hidden prompts, and local paths intentionally omitted.
+@runtime linux x86_64, Claude Code
+@date 2026-05-20
+"""
+
+from datetime import datetime, timezone
 import os
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, JSON, String, Text, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, sessionmaker
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
 
 engine = create_engine(DATABASE_URL, echo=False)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 def get_db():
@@ -28,26 +37,25 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    address = Column(String(42), unique=True, nullable=False)
-    username = Column(String(64), unique=True, nullable=True)
-    # BUG: No index on address — wallet lookups on every auth request do full table scans
-    created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
+    address = Column(String(42), unique=True, nullable=False, index=True)
+    username = Column(String(64), unique=True, nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
-    agents = relationship("Agent", back_populates="owner")
+    agents = relationship("Agent", back_populates="owner", cascade="all, delete-orphan", passive_deletes=True)
 
 
 class Agent(Base):
     __tablename__ = "agents"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(128), nullable=False)
+    name = Column(String(128), nullable=False, index=True)
     description = Column(Text, nullable=True)
-    model_type = Column(String(32), default="gpt-4")
+    model_type = Column(String(32), default="gpt-4", index=True)
     config = Column(JSON, default=dict)
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    owner_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
 
-    # BUG: No cascade delete — deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
     tasks = relationship("Task", back_populates="agent")
 
@@ -59,12 +67,12 @@ class Task(Base):
     title = Column(String(256), nullable=False)
     description = Column(Text, nullable=True)
     reward_amount = Column(Float, nullable=False)
-    status = Column(String(32), default="open")
-    creator_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    agent_id = Column(Integer, ForeignKey("agents.id"), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=True)
-    deadline = Column(DateTime, nullable=True)
+    status = Column(String(32), default="open", nullable=False, index=True)
+    creator_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    agent_id = Column(Integer, ForeignKey("agents.id"), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    deadline = Column(DateTime(timezone=True), nullable=True, index=True)
 
     agent = relationship("Agent", back_populates="tasks")
     payments = relationship("Payment", back_populates="task")
@@ -74,14 +82,14 @@ class Payment(Base):
     __tablename__ = "payments"
 
     id = Column(Integer, primary_key=True, index=True)
-    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
-    from_address = Column(String(42), nullable=False)
-    to_address = Column(String(42), nullable=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False, index=True)
+    from_address = Column(String(42), nullable=False, index=True)
+    to_address = Column(String(42), nullable=True, index=True)
     amount = Column(Float, nullable=False)
-    token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
-    status = Column(String(32), default="pending")
-    created_at = Column(DateTime, default=datetime.utcnow)
-    claimed_at = Column(DateTime, nullable=True)
+    token_address = Column(String(42), default="0x0000000000000000000000000000000000000000", index=True)
+    status = Column(String(32), default="pending", nullable=False, index=True)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    claimed_at = Column(DateTime(timezone=True), nullable=True)
 
     task = relationship("Task", back_populates="payments")
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,6 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
+pytest>=8.3.0
+SQLAlchemy>=2.0.0
 web3>=7.6.0

--- a/api/tests/test_database_models.py
+++ b/api/tests/test_database_models.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from api.models.database import Agent, Payment, Task, User, utc_now
+
+
+def test_wallet_and_status_columns_are_indexed():
+    assert User.__table__.c.address.index is True
+    assert Task.__table__.c.status.index is True
+    assert Payment.__table__.c.status.index is True
+
+
+def test_user_to_agent_cascade_is_configured():
+    owner_id_fk = next(iter(Agent.__table__.c.owner_id.foreign_keys))
+
+    assert owner_id_fk.ondelete == "CASCADE"
+    assert "delete-orphan" in User.agents.property.cascade
+
+
+def test_timestamps_are_timezone_aware():
+    now = utc_now()
+
+    assert isinstance(now, datetime)
+    assert now.tzinfo is timezone.utc
+    assert User.__table__.c.created_at.type.timezone is True
+    assert Agent.__table__.c.created_at.type.timezone is True
+    assert Task.__table__.c.created_at.type.timezone is True
+    assert Payment.__table__.c.created_at.type.timezone is True
+
+
+def test_updated_at_has_onupdate_hook():
+    assert Agent.__table__.c.updated_at.onupdate is not None
+    assert Task.__table__.c.updated_at.onupdate is not None


### PR DESCRIPTION
## Summary
- Add indexes to wallet/address, status, foreign-key, and other high-value lookup columns.
- Configure User-to-Agent cascade deletion with `ondelete="CASCADE"` and relationship cascade behavior.
- Replace naive timestamps with UTC-aware timestamps and add automatic `updated_at` hooks.
- Add regression tests for indexes, cascade configuration, timezone-aware timestamps, and `updated_at` hooks.
- Add a contributor entry that intentionally avoids recording private credentials, hidden prompts, local paths, or sensitive session data.

## Test plan
- [x] CONTRIBUTORS.json parses as valid JSON
- [x] git diff --check
- [x] Static review of model indexes, cascade options, timezone-aware timestamp columns, and onupdate hooks
- [ ] `python -m py_compile api/**/*.py` — not run here because Python is unavailable in this environment
- [ ] `cd api && pip install -r requirements.txt && pytest api/tests/test_database_models.py` — not run here because Python is unavailable in this environment

Closes #37