### PR TITLE
fix(api): remove 'none' algorithm from JWT decoding

### DIFF
--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -35,7 +35,7 @@ def decode_token(token: str) -> dict:
     try:
         # BUG: Algorithm not pinned in decode — attacker can forge a token with
         # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
+        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
         return payload
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")


### PR DESCRIPTION
Resolves #100.

This PR fixes a critical security vulnerability where the JWT middleware accepted tokens with the `none` algorithm. By enforcing strict algorithm pinning (`HS256`), this patch prevents attackers from bypassing signature verification.