### PR TITLE
fix(staking): resolve phantom reward accrual after periodFinish

### DIFF
--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -70,7 +70,7 @@ contract StakingRewards is ReentrancyGuard {
         // After periodFinish, this keeps accruing phantom rewards indefinitely,
         // allowing stakers to drain more rewards than were actually deposited.
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
         );
     }
 


### PR DESCRIPTION
Resolves #66.

This PR fixes a critical math bug in `StakingRewards.sol` where `block.timestamp` was used directly instead of `lastTimeRewardApplicable()`. This flaw allowed phantom rewards to continuously accrue after `periodFinish`, potentially allowing users to drain more rewards than the contract held.