### PR TITLE
fix: [SDK] Fix WebSocket provider loses messages during reconnect

### DIFF
--- a/sdk/src/providers/websocket.ts
+++ b/sdk/src/providers/websocket.ts
@@ -4,11 +4,25 @@ export interface WsProviderConfig {
   url: string;
   reconnectIntervalMs?: number;
   maxReconnectAttempts?: number;
+  pingIntervalMs?: number;
+  pongTimeoutMs?: number;
 }
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (reason: Error) => void;
+}
+
+interface QueueItem {
+  method: string;
+  params: unknown[];
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+}
+
+interface ActiveSubscription {
+  event: string;
+  callback: (data: unknown) => void;
 }
 
 export class WebSocketProvider extends EventEmitter {
@@ -17,53 +31,83 @@ export class WebSocketProvider extends EventEmitter {
   private requestId = 0;
   private pendingRequests = new Map<number, PendingRequest>();
   private subscriptions = new Map<string, (data: unknown) => void>();
+  private activeSubscriptions = new Map<string, ActiveSubscription>();
+  private messageQueue: QueueItem[] = [];
+  
   private reconnectInterval: number;
   private maxReconnectAttempts: number;
   private reconnectCount = 0;
   private isConnected = false;
+
+  // Heartbeat Configs
+  private pingInterval: number;
+  private pongTimeout: number;
+  private pingTimeoutId: any = null;
+  private pongTimeoutId: any = null;
 
   constructor(config: WsProviderConfig) {
     super();
     this.url = config.url;
     this.reconnectInterval = config.reconnectIntervalMs ?? 3000;
     this.maxReconnectAttempts = config.maxReconnectAttempts ?? 10;
+    this.pingInterval = config.pingIntervalMs ?? 15000;
+    this.pongTimeout = config.pongTimeoutMs ?? 5000;
   }
 
   async connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url);
+      try {
+        this.ws = new WebSocket(this.url);
+      } catch (err) {
+        reject(err);
+        return;
+      }
 
       this.ws.onopen = () => {
         this.isConnected = true;
         this.reconnectCount = 0;
-        // BUG: No heartbeat/ping mechanism — connection can silently die
-        // without the client knowing, leading to stale state
+        
+        // Start heartbeat loop and flush any buffered messages
+        this.startHeartbeat();
+        this.flushQueue();
+        this.resubscribe().catch((err) => {
+          this.emit("error", new Error(`Resubscription failed: ${err.message}`));
+        });
+
         this.emit("connected");
         resolve();
       };
 
       this.ws.onmessage = (event) => {
-        const data = JSON.parse(event.data as string);
-        if (data.id && this.pendingRequests.has(data.id)) {
-          const pending = this.pendingRequests.get(data.id)!;
-          this.pendingRequests.delete(data.id);
-          data.error ? pending.reject(new Error(data.error.message)) : pending.resolve(data.result);
-        } else if (data.method === "eth_subscription") {
-          const subId = data.params?.subscription;
-          this.subscriptions.get(subId)?.(data.params.result);
+        // Reset pong timeout upon receiving any socket frame (confirms active liveness)
+        this.resetPongTimeout();
+
+        try {
+          const data = JSON.parse(event.data as string);
+          if (data.id && this.pendingRequests.has(data.id)) {
+            const pending = this.pendingRequests.get(data.id)!;
+            this.pendingRequests.delete(data.id);
+            data.error ? pending.reject(new Error(data.error.message)) : pending.resolve(data.result);
+          } else if (data.method === "eth_subscription") {
+            const subId = data.params?.subscription;
+            this.subscriptions.get(subId)?.(data.params.result);
+          }
+        } catch (err) {
+          this.emit("error", new Error(`Failed to parse WebSocket message: ${err}`));
         }
       };
 
       this.ws.onclose = () => {
         this.isConnected = false;
-        // BUG: Messages sent while disconnected are silently dropped —
-        // no queue to buffer and replay after reconnection
+        this.stopHeartbeat();
         this.emit("disconnected");
         this.attemptReconnect();
       };
 
       this.ws.onerror = (err) => {
-        if (!this.isConnected) reject(new Error("WebSocket connection failed"));
+        if (!this.isConnected) {
+          reject(new Error("WebSocket connection failed"));
+        }
         this.emit("error", err);
       };
     });
@@ -76,20 +120,91 @@ export class WebSocketProvider extends EventEmitter {
     }
     this.reconnectCount++;
     setTimeout(() => {
-      // BUG: Reconnect does not resubscribe to previous subscriptions —
-      // all active eth_subscribe listeners are silently lost
       this.connect().catch(() => this.attemptReconnect());
     }, this.reconnectInterval);
   }
 
-  async send(method: string, params: unknown[] = []): Promise<unknown> {
-    if (!this.ws || !this.isConnected) {
-      throw new Error("WebSocket not connected");
+  private flushQueue(): void {
+    const queue = [...this.messageQueue];
+    this.messageQueue = [];
+    
+    for (const item of queue) {
+      this.send(item.method, item.params)
+        .then(item.resolve)
+        .catch(item.reject);
     }
-    const id = ++this.requestId;
+  }
+
+  private async resubscribe(): Promise<void> {
+    const oldSubs = Array.from(this.activeSubscriptions.entries());
+    this.activeSubscriptions.clear();
+    this.subscriptions.clear();
+
+    for (const [oldSubId, sub] of oldSubs) {
+      try {
+        const newSubId = await this.subscribe(sub.event, sub.callback);
+        this.emit("resubscribed", { oldSubId, newSubId, event: sub.event });
+      } catch (err: any) {
+        // Restore old metadata so we can retry on subsequent reconnection attempts
+        this.activeSubscriptions.set(oldSubId, sub);
+        this.subscriptions.set(oldSubId, sub.callback);
+        this.emit("error", new Error(`Failed to resubscribe to ${sub.event}: ${err.message}`));
+      }
+    }
+  }
+
+  // Heartbeat/Ping-Pong Mechanics
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.pingTimeoutId = setInterval(() => {
+      if (!this.isConnected) return;
+
+      // Heartbeat probe uses low-overhead eth_blockNumber call
+      this.send("eth_blockNumber")
+        .then(() => {
+          this.resetPongTimeout();
+        })
+        .catch(() => {
+          this.ws?.close();
+        });
+
+      this.pongTimeoutId = setTimeout(() => {
+        this.ws?.close();
+      }, this.pongTimeout);
+    }, this.pingInterval);
+  }
+
+  private resetPongTimeout(): void {
+    if (this.pongTimeoutId) {
+      clearTimeout(this.pongTimeoutId);
+      this.pongTimeoutId = null;
+    }
+  }
+
+  private stopHeartbeat(): void {
+    if (this.pingTimeoutId) {
+      clearInterval(this.pingTimeoutId);
+      this.pingTimeoutId = null;
+    }
+    this.resetPongTimeout();
+  }
+
+  async send(method: string, params: unknown[] = []): Promise<unknown> {
     return new Promise((resolve, reject) => {
+      if (!this.ws || !this.isConnected) {
+        // Disconnected buffer routing
+        this.messageQueue.push({ method, params, resolve, reject });
+        return;
+      }
+      
+      const id = ++this.requestId;
       this.pendingRequests.set(id, { resolve, reject });
-      this.ws!.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      try {
+        this.ws!.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      } catch (err) {
+        this.pendingRequests.delete(id);
+        reject(err);
+      }
     });
   }
 
@@ -99,18 +214,24 @@ export class WebSocketProvider extends EventEmitter {
   ): Promise<string> {
     const subId = (await this.send("eth_subscribe", [event])) as string;
     this.subscriptions.set(subId, callback);
+    this.activeSubscriptions.set(subId, { event, callback });
     return subId;
   }
 
   async unsubscribe(subscriptionId: string): Promise<boolean> {
     this.subscriptions.delete(subscriptionId);
+    this.activeSubscriptions.delete(subscriptionId);
     return (await this.send("eth_unsubscribe", [subscriptionId])) as boolean;
   }
 
   disconnect(): void {
+    this.stopHeartbeat();
     this.ws?.close();
     this.ws = null;
     this.isConnected = false;
     this.pendingRequests.clear();
+    this.activeSubscriptions.clear();
+    this.subscriptions.clear();
+    this.messageQueue = [];
   }
 }


### PR DESCRIPTION
Fixes WebSocket message drop on disconnect/reconnect and adds heartbeat check.

### Implementation:
1. **Heartbeat/Ping-Pong:** Implemented low-overhead `eth_blockNumber` pings to catch dead sockets and force reconnects.
2. **Buffer Queue:** All messages sent while offline are enqueued and auto-flushed upon reconnection.
3. **Automated Resubscriptions:** Tracks active subscriptions and re-registers them upon reconnect, mapping to new IDs.

/claim #26
💳 Payment: USDC | 0x25f58A305A5095fb8Eb84b422a14d705A8dfa278 | Base