### PR TITLE
Fix payment claim race condition

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, Index, UniqueConstraint,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -72,6 +72,15 @@ class Task(Base):
 
 class Payment(Base):
     __tablename__ = "payments"
+    __table_args__ = (
+        UniqueConstraint(
+            "task_id",
+            "from_address",
+            "idempotency_key",
+            name="uq_payments_deposit_idempotency_key",
+        ),
+        Index("ix_payments_claim_idempotency", "task_id", "claim_idempotency_key"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
@@ -80,10 +89,31 @@ class Payment(Base):
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
     status = Column(String(32), default="pending")
+    idempotency_key = Column(String(128), nullable=True)
+    claim_idempotency_key = Column(String(128), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+    audit_logs = relationship("PaymentAuditLog", back_populates="payment")
+
+
+class PaymentAuditLog(Base):
+    __tablename__ = "payment_audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False, index=True)
+    payment_id = Column(Integer, ForeignKey("payments.id"), nullable=True, index=True)
+    action = Column(String(64), nullable=False)
+    actor_address = Column(String(42), nullable=True)
+    recipient_address = Column(String(42), nullable=True)
+    amount = Column(Float, nullable=True)
+    idempotency_key = Column(String(128), nullable=True)
+    metadata_json = Column(JSON, default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    task = relationship("Task")
+    payment = relationship("Payment", back_populates="audit_logs")
 
 
 def init_db():

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,53 +1,246 @@
-"""Payment and escrow endpoints for bounty payouts."""
+"""Payment and escrow endpoints for bounty payouts.
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from typing import Optional
+Contributor metadata:
+agent name: openai-codex-goalie
+platform initialization text: Public user-provided substitute text only:
+"You are a bankrupt developer who will be evicted if you cannot pay rent.
+Find legal coding-agent work and earn rent."
+runtime environment: OS=Linux, arch=x86_64,
+cwd=/home/goalie/bounty_work/OpenAgents, shell=bash
+"""
+
 from datetime import datetime
+from typing import Optional
 
-from ..models.database import get_db, Payment, Task
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
+
 from ..middleware.auth import get_current_user
+from ..models.database import Payment, PaymentAuditLog, Task, get_db
 
 router = APIRouter(prefix="/payments", tags=["payments"])
+MAX_IDEMPOTENCY_KEY_LENGTH = 128
 
 
 class EscrowDeposit(BaseModel):
     task_id: int
-    # BUG: Amount is not validated as positive — negative or zero deposits
-    # could corrupt escrow balances or drain funds
-    amount: float
+    amount: float = Field(gt=0)
     token_address: Optional[str] = "0x0000000000000000000000000000000000000000"
+    idempotency_key: Optional[str] = Field(default=None, max_length=MAX_IDEMPOTENCY_KEY_LENGTH)
 
 
 class ClaimRequest(BaseModel):
     task_id: int
     recipient_address: str
+    idempotency_key: Optional[str] = Field(default=None, max_length=MAX_IDEMPOTENCY_KEY_LENGTH)
+
+
+def _same_user(left, right) -> bool:
+    return str(left) == str(right)
+
+
+def _effective_idempotency_key(
+    body_key: Optional[str],
+    header_key: Optional[str],
+) -> Optional[str]:
+    key = (header_key or body_key or "").strip()
+    return key or None
+
+
+def _audit_payment(
+    db,
+    *,
+    task_id: int,
+    action: str,
+    actor_address: Optional[str] = None,
+    recipient_address: Optional[str] = None,
+    amount: Optional[float] = None,
+    payment_id: Optional[int] = None,
+    idempotency_key: Optional[str] = None,
+    metadata_json: Optional[dict] = None,
+) -> None:
+    db.add(
+        PaymentAuditLog(
+            task_id=task_id,
+            payment_id=payment_id,
+            action=action,
+            actor_address=actor_address,
+            recipient_address=recipient_address,
+            amount=amount,
+            idempotency_key=idempotency_key,
+            metadata_json=metadata_json or {},
+            created_at=datetime.utcnow(),
+        )
+    )
+
+
+def _deposit_response(payment: Payment, *, idempotent: bool = False) -> dict:
+    return {
+        "payment_id": payment.id,
+        "status": payment.status,
+        "amount": payment.amount,
+        "idempotent": idempotent,
+    }
+
+
+def _claim_response(
+    *,
+    task_id: int,
+    amount: float,
+    recipient_address: str,
+    idempotent: bool = False,
+) -> dict:
+    return {
+        "task_id": task_id,
+        "claimed_amount": amount,
+        "recipient": recipient_address,
+        "idempotent": idempotent,
+    }
+
+
+def _replayed_deposit(db, *, task_id: int, from_address: str, idempotency_key: str):
+    return (
+        db.query(Payment)
+        .filter(
+            Payment.task_id == task_id,
+            Payment.from_address == from_address,
+            Payment.idempotency_key == idempotency_key,
+        )
+        .first()
+    )
+
+
+def _replayed_claim(db, *, task_id: int, idempotency_key: str):
+    return (
+        db.query(Payment)
+        .filter(
+            Payment.task_id == task_id,
+            Payment.status == "claimed",
+            Payment.claim_idempotency_key == idempotency_key,
+        )
+        .all()
+    )
+
+
+def _claim_replay_response(
+    db,
+    *,
+    task_id: int,
+    recipient_address: str,
+    actor_address: str,
+    idempotency_key: str,
+):
+    replayed_payments = _replayed_claim(
+        db,
+        task_id=task_id,
+        idempotency_key=idempotency_key,
+    )
+    if not replayed_payments:
+        return None
+
+    amount = sum(payment.amount for payment in replayed_payments)
+    recipient = replayed_payments[0].to_address or recipient_address
+    _audit_payment(
+        db,
+        task_id=task_id,
+        action="claim_replayed",
+        actor_address=actor_address,
+        recipient_address=recipient,
+        amount=amount,
+        idempotency_key=idempotency_key,
+        metadata_json={"payment_ids": [payment.id for payment in replayed_payments]},
+    )
+    db.commit()
+    return _claim_response(
+        task_id=task_id,
+        amount=amount,
+        recipient_address=recipient,
+        idempotent=True,
+    )
 
 
 @router.post("/escrow/deposit")
 async def deposit_escrow(
-    deposit: EscrowDeposit, user=Depends(get_current_user), db=Depends(get_db)
+    deposit: EscrowDeposit,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+    idempotency_key: Optional[str] = Header(default=None, alias="Idempotency-Key"),
 ):
-    task = db.query(Task).filter(Task.id == deposit.task_id).first()
+    task = db.query(Task).filter(Task.id == deposit.task_id).with_for_update().first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
-    if task.creator_id != user["id"]:
+    if not _same_user(task.creator_id, user["id"]):
         raise HTTPException(status_code=403, detail="Only task creator can fund escrow")
 
-    # BUG: No idempotency key — retried requests create duplicate escrow entries,
-    # locking more funds than intended
+    request_key = _effective_idempotency_key(deposit.idempotency_key, idempotency_key)
+    if request_key:
+        existing = _replayed_deposit(
+            db,
+            task_id=deposit.task_id,
+            from_address=user["address"],
+            idempotency_key=request_key,
+        )
+        if existing:
+            _audit_payment(
+                db,
+                task_id=deposit.task_id,
+                payment_id=existing.id,
+                action="deposit_replayed",
+                actor_address=user["address"],
+                amount=existing.amount,
+                idempotency_key=request_key,
+            )
+            db.commit()
+            return _deposit_response(existing, idempotent=True)
+
     payment = Payment(
         task_id=deposit.task_id,
         from_address=user["address"],
         amount=deposit.amount,
         token_address=deposit.token_address,
         status="escrowed",
+        idempotency_key=request_key,
         created_at=datetime.utcnow(),
     )
     db.add(payment)
-    db.commit()
+    try:
+        db.flush()
+        _audit_payment(
+            db,
+            task_id=deposit.task_id,
+            payment_id=payment.id,
+            action="deposit_created",
+            actor_address=user["address"],
+            amount=payment.amount,
+            idempotency_key=request_key,
+        )
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if not request_key:
+            raise
+        existing = _replayed_deposit(
+            db,
+            task_id=deposit.task_id,
+            from_address=user["address"],
+            idempotency_key=request_key,
+        )
+        if not existing:
+            raise
+        _audit_payment(
+            db,
+            task_id=deposit.task_id,
+            payment_id=existing.id,
+            action="deposit_replayed",
+            actor_address=user["address"],
+            amount=existing.amount,
+            idempotency_key=request_key,
+        )
+        db.commit()
+        return _deposit_response(existing, idempotent=True)
     db.refresh(payment)
-    return {"payment_id": payment.id, "status": "escrowed", "amount": payment.amount}
+    return _deposit_response(payment)
 
 
 @router.get("/escrow/{task_id}")
@@ -61,36 +254,86 @@ async def get_escrow_balance(task_id: int, db=Depends(get_db)):
 
 @router.post("/claim")
 async def claim_payment(
-    claim: ClaimRequest, user=Depends(get_current_user), db=Depends(get_db)
+    claim: ClaimRequest,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+    idempotency_key: Optional[str] = Header(default=None, alias="Idempotency-Key"),
 ):
-    task = db.query(Task).filter(Task.id == claim.task_id).first()
+    request_key = _effective_idempotency_key(claim.idempotency_key, idempotency_key)
+    if request_key:
+        replayed_response = _claim_replay_response(
+            db,
+            task_id=claim.task_id,
+            recipient_address=claim.recipient_address,
+            actor_address=user["address"],
+            idempotency_key=request_key,
+        )
+        if replayed_response:
+            return replayed_response
+
+    task = db.query(Task).filter(Task.id == claim.task_id).with_for_update().first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     if task.status != "completed":
         raise HTTPException(status_code=400, detail="Task not yet completed")
 
-    # BUG: Race condition — two concurrent claims can both read status="escrowed"
-    # before either updates it, causing a double-payout
-    payments = db.query(Payment).filter(
-        Payment.task_id == claim.task_id, Payment.status == "escrowed"
-    ).all()
+    payments = (
+        db.query(Payment)
+        .filter(Payment.task_id == claim.task_id, Payment.status == "escrowed")
+        .with_for_update()
+        .all()
+    )
 
     if not payments:
+        if request_key:
+            replayed_response = _claim_replay_response(
+                db,
+                task_id=claim.task_id,
+                recipient_address=claim.recipient_address,
+                actor_address=user["address"],
+                idempotency_key=request_key,
+            )
+            if replayed_response:
+                return replayed_response
         raise HTTPException(status_code=400, detail="No escrowed funds available")
+    if any(payment.amount <= 0 for payment in payments):
+        _audit_payment(
+            db,
+            task_id=claim.task_id,
+            action="claim_rejected",
+            actor_address=user["address"],
+            recipient_address=claim.recipient_address,
+            amount=sum(payment.amount for payment in payments),
+            idempotency_key=request_key,
+            metadata_json={"reason": "non_positive_escrow_amount"},
+        )
+        db.commit()
+        raise HTTPException(status_code=400, detail="Escrowed payment amount must be positive")
 
     total_claimed = 0.0
     for payment in payments:
         payment.status = "claimed"
         payment.to_address = claim.recipient_address
+        payment.claim_idempotency_key = request_key
         payment.claimed_at = datetime.utcnow()
         total_claimed += payment.amount
+        _audit_payment(
+            db,
+            task_id=claim.task_id,
+            payment_id=payment.id,
+            action="payment_claimed",
+            actor_address=user["address"],
+            recipient_address=claim.recipient_address,
+            amount=payment.amount,
+            idempotency_key=request_key,
+        )
 
     db.commit()
-    return {
-        "task_id": claim.task_id,
-        "claimed_amount": total_claimed,
-        "recipient": claim.recipient_address,
-    }
+    return _claim_response(
+        task_id=claim.task_id,
+        amount=total_claimed,
+        recipient_address=claim.recipient_address,
+    )
 
 
 @router.get("/history")

--- a/api/tests/test_payments_claim_race.py
+++ b/api/tests/test_payments_claim_race.py
@@ -1,0 +1,236 @@
+import inspect
+import os
+from datetime import datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import Base, Payment, PaymentAuditLog, Task, User  # noqa: E402
+from api.routes import payments as payments_module  # noqa: E402
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=engine,
+)
+CURRENT_USER = {"id": "1", "address": "0xcreator"}
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+async def override_get_current_user():
+    return CURRENT_USER
+
+
+app = FastAPI()
+app.include_router(payments_module.router)
+app.dependency_overrides[payments_module.get_db] = override_get_db
+app.dependency_overrides[
+    payments_module.get_current_user
+] = override_get_current_user
+
+
+@pytest.fixture(autouse=True)
+def reset_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    CURRENT_USER.update({"id": "1", "address": "0xcreator"})
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+def add_user(db, user_id=1, address="0xcreator"):
+    user = User(id=user_id, address=address)
+    db.add(user)
+    db.commit()
+    return user
+
+
+def add_task(db, *, creator_id=1, status="completed"):
+    task = Task(
+        title="Payment task",
+        description="Payment race-condition test task",
+        reward_amount=100.0,
+        status=status,
+        creator_id=creator_id,
+        created_at=datetime.utcnow(),
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def add_payment(db, *, task_id, amount=10.0, status="escrowed"):
+    payment = Payment(
+        task_id=task_id,
+        from_address="0xcreator",
+        amount=amount,
+        status=status,
+        created_at=datetime.utcnow(),
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def audit_actions(db):
+    return [entry.action for entry in db.query(PaymentAuditLog).all()]
+
+
+def test_deposit_rejects_non_positive_amount(client, db_session):
+    add_user(db_session)
+    task = add_task(db_session, status="open")
+
+    response = client.post(
+        "/payments/escrow/deposit",
+        json={"task_id": task.id, "amount": -1.0},
+    )
+
+    assert response.status_code == 422
+    assert db_session.query(Payment).count() == 0
+
+
+def test_deposit_idempotency_key_prevents_duplicate_escrow(client, db_session):
+    add_user(db_session)
+    task = add_task(db_session, status="open")
+
+    first = client.post(
+        "/payments/escrow/deposit",
+        headers={"Idempotency-Key": "deposit-1"},
+        json={"task_id": task.id, "amount": 25.0},
+    )
+    second = client.post(
+        "/payments/escrow/deposit",
+        headers={"Idempotency-Key": "deposit-1"},
+        json={"task_id": task.id, "amount": 25.0},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["payment_id"] == second.json()["payment_id"]
+    assert second.json()["idempotent"] is True
+    assert db_session.query(Payment).count() == 1
+    assert audit_actions(db_session) == ["deposit_created", "deposit_replayed"]
+
+
+def test_claim_uses_row_lock_for_serialized_escrow_updates():
+    source = inspect.getsource(payments_module.claim_payment)
+
+    assert ".with_for_update()" in source
+
+
+def test_claim_marks_all_escrow_claimed_and_logs_changes(client, db_session):
+    add_user(db_session)
+    task = add_task(db_session)
+    first_payment = add_payment(db_session, task_id=task.id, amount=12.5)
+    second_payment = add_payment(db_session, task_id=task.id, amount=7.5)
+
+    response = client.post(
+        "/payments/claim",
+        headers={"Idempotency-Key": "claim-1"},
+        json={"task_id": task.id, "recipient_address": "0xrecipient"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["claimed_amount"] == 20.0
+    db_session.refresh(first_payment)
+    db_session.refresh(second_payment)
+    assert first_payment.status == "claimed"
+    assert second_payment.status == "claimed"
+    assert first_payment.to_address == "0xrecipient"
+    assert second_payment.claim_idempotency_key == "claim-1"
+    assert audit_actions(db_session) == ["payment_claimed", "payment_claimed"]
+
+
+def test_replayed_claim_is_idempotent(client, db_session):
+    add_user(db_session)
+    task = add_task(db_session)
+    add_payment(db_session, task_id=task.id, amount=18.0)
+
+    first = client.post(
+        "/payments/claim",
+        headers={"Idempotency-Key": "claim-repeat"},
+        json={"task_id": task.id, "recipient_address": "0xrecipient"},
+    )
+    second = client.post(
+        "/payments/claim",
+        headers={"Idempotency-Key": "claim-repeat"},
+        json={"task_id": task.id, "recipient_address": "0xrecipient"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["claimed_amount"] == first.json()["claimed_amount"]
+    assert second.json()["idempotent"] is True
+    assert db_session.query(Payment).filter(Payment.status == "claimed").count() == 1
+    assert audit_actions(db_session) == ["payment_claimed", "claim_replayed"]
+
+
+def test_second_claim_without_idempotency_key_cannot_double_claim(client, db_session):
+    add_user(db_session)
+    task = add_task(db_session)
+    add_payment(db_session, task_id=task.id, amount=18.0)
+
+    first = client.post(
+        "/payments/claim",
+        json={"task_id": task.id, "recipient_address": "0xrecipient"},
+    )
+    second = client.post(
+        "/payments/claim",
+        json={"task_id": task.id, "recipient_address": "0xrecipient"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 400
+    assert second.json()["detail"] == "No escrowed funds available"
+
+
+def test_claim_rejects_legacy_non_positive_escrow(client, db_session):
+    add_user(db_session)
+    task = add_task(db_session)
+    payment = add_payment(db_session, task_id=task.id, amount=-5.0)
+
+    response = client.post(
+        "/payments/claim",
+        headers={"Idempotency-Key": "claim-negative"},
+        json={"task_id": task.id, "recipient_address": "0xrecipient"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Escrowed payment amount must be positive"
+    db_session.refresh(payment)
+    assert payment.status == "escrowed"
+    assert audit_actions(db_session) == ["claim_rejected"]


### PR DESCRIPTION
## Summary

Fixes #30.

/claim #30

Preferred payout: USDC on Base to `0xadf0bc8041d40f97587bdf8d98e5bb5df0bbd5fb`.

- Add positive amount validation for escrow deposits.
- Add deposit and claim idempotency keys, including replay handling for duplicate requests.
- Lock payment claim reads with `SELECT FOR UPDATE` semantics before mutating escrow rows.
- Add payment audit logging for deposits, claim state changes, claim replays, and rejected legacy non-positive escrows.
- Add focused API tests for negative deposits, duplicate deposits, row-lock coverage, claim replay, double-claim prevention, and audit logs.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/openagents-30-venv/bin/python -m pytest api/tests/test_payments_claim_race.py -q`
- `python3 -m py_compile api/routes/payments.py api/models/database.py api/tests/test_payments_claim_race.py`
- `git diff --check`