### PR TITLE
Fix CompoundVault harvest access control and pricing

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "openai-codex-tupm96",
+      "timestamp": "2026-05-25T09:36:09Z",
+      "platform_instructions": "Private runtime and system/developer instructions are intentionally omitted. User requested Web3 smart-contract bounty work and provided PayPal payout details for public bounty claiming.",
+      "runtime": {
+        "os": "windows",
+        "arch": "x64",
+        "home_dir": "C:\\Users\\tupm96",
+        "working_dir": "C:\\Users\\tupm96\\Desktop\\bounty\\OpenAgents",
+        "shell": "PowerShell"
+      },
+      "contribution": "Fixed CompoundVault harvest authorization, fresh price-per-share accounting, fee floor, and harvest threshold behavior for bounty #22"
     }
   ]
 }

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -72,13 +72,7 @@ contract ChainlinkAdapter {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (, int256 answer,,,) = config.feed.latestRoundData();
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/test/CompoundVaultHarness.sol
+++ b/contracts/test/CompoundVaultHarness.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../vault/CompoundVault.sol";
+
+contract CompoundVaultHarness is CompoundVault {
+    constructor(
+        address baseToken_,
+        address rewardToken_,
+        address strategy_,
+        address feeRecipient_,
+        uint256 feeBps_
+    ) CompoundVault(baseToken_, rewardToken_, strategy_, feeRecipient_, feeBps_) {}
+
+    function setAccounting(uint256 shares, uint256 deposited) external onlyOwner {
+        totalShares = shares;
+        totalDeposited = deposited;
+    }
+
+    function setLastPricePerShare(uint256 pricePerShare_) external onlyOwner {
+        lastPricePerShare = pricePerShare_;
+    }
+}

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/vault/CompoundVault.sol
+++ b/contracts/vault/CompoundVault.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 /// @notice Auto-compounding vault that periodically harvests yield and reinvests.
 /// @dev Deposits into an underlying strategy, harvests rewards, sells for the base
 ///      asset, and re-deposits to compound returns. Charges a performance fee.
+/// @custom:contributor Bounty #22 - harvest authorization, fresh pricing, fee floor, and threshold hardening.
 contract CompoundVault is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -17,12 +18,14 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     IERC20 public immutable rewardToken;
     address public strategy;
     address public feeRecipient;
+    address public keeper;
 
     uint256 public totalShares;
     uint256 public totalDeposited;
     uint256 public performanceFeeBps; // basis points (e.g., 1000 = 10%)
     uint256 public lastHarvestTime;
     uint256 public lastPricePerShare;
+    uint256 public harvestThreshold;
 
     mapping(address => uint256) public userShares;
 
@@ -30,6 +33,13 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     event Withdrawn(address indexed user, uint256 amount, uint256 shares);
     event Harvested(uint256 profit, uint256 fee, uint256 timestamp);
     event Compounded(uint256 amount, uint256 newPricePerShare);
+    event KeeperUpdated(address indexed oldKeeper, address indexed newKeeper);
+    event HarvestThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+
+    modifier onlyHarvester() {
+        require(msg.sender == owner() || msg.sender == keeper, "Vault: not harvester");
+        _;
+    }
 
     constructor(
         address _baseToken,
@@ -38,13 +48,18 @@ contract CompoundVault is Ownable, ReentrancyGuard {
         address _feeRecipient,
         uint256 _feeBps
     ) Ownable(msg.sender) {
+        require(_baseToken != address(0), "Vault: zero base token");
+        require(_rewardToken != address(0), "Vault: zero reward token");
+        require(_feeRecipient != address(0), "Vault: zero fee recipient");
         require(_feeBps <= 3000, "Vault: fee too high");
         baseToken = IERC20(_baseToken);
         rewardToken = IERC20(_rewardToken);
         strategy = _strategy;
         feeRecipient = _feeRecipient;
+        keeper = msg.sender;
         performanceFeeBps = _feeBps;
         lastPricePerShare = 1e18;
+        harvestThreshold = 1;
     }
 
     /// @notice Deposit base tokens and receive vault shares.
@@ -84,30 +99,29 @@ contract CompoundVault is Ownable, ReentrancyGuard {
 
     /// @notice Harvest rewards from the strategy and calculate profit.
     /// @return profit The net profit after fees.
-    // BUG: No caller restriction — anyone can call harvest at any time, potentially
-    // front-running the actual compound step or harvesting at a suboptimal time,
-    // causing MEV extraction or locking in losses before a price recovery.
-    function harvest() external returns (uint256 profit) {
+    function harvest() external nonReentrant onlyHarvester returns (uint256 profit) {
         uint256 rewardBalance = rewardToken.balanceOf(address(this));
         require(rewardBalance > 0, "Vault: nothing to harvest");
 
-        // BUG: Uses lastPricePerShare which is only updated during compound(), not
-        // during harvest. If compound() hasn't been called recently, the price is
-        // stale and the profit calculation is inaccurate — potentially overcharging
-        // or undercharging the performance fee.
-        uint256 estimatedValue = (rewardBalance * lastPricePerShare) / 1e18;
+        uint256 currentPricePerShare = _pricePerShare();
+        uint256 estimatedValue = (rewardBalance * currentPricePerShare) / 1e18;
+        require(estimatedValue >= harvestThreshold, "Vault: below threshold");
 
-        // BUG: Fee calculation truncates to zero for small profit amounts.
-        // E.g., if estimatedValue is 9 and performanceFeeBps is 1000 (10%),
-        // fee = 9 * 1000 / 10000 = 0. Accumulated over many small harvests,
-        // the protocol collects zero fees while still processing transactions.
-        uint256 fee = (estimatedValue * performanceFeeBps) / 10000;
+        uint256 fee;
+        if (performanceFeeBps > 0) {
+            fee = (estimatedValue * performanceFeeBps) / 10000;
+            if (fee == 0) {
+                fee = 1;
+            }
+        }
+        require(fee <= estimatedValue, "Vault: fee exceeds harvest");
         profit = estimatedValue - fee;
 
         if (fee > 0) {
             rewardToken.safeTransfer(feeRecipient, fee);
         }
 
+        lastPricePerShare = currentPricePerShare;
         lastHarvestTime = block.timestamp;
         emit Harvested(profit, fee, block.timestamp);
     }
@@ -142,8 +156,27 @@ contract CompoundVault is Ownable, ReentrancyGuard {
         feeRecipient = _feeRecipient;
     }
 
+    /// @notice Update the keeper authorized to harvest alongside the owner.
+    /// @dev Set to address(0) to disable keeper harvesting.
+    function setKeeper(address _keeper) external onlyOwner {
+        address oldKeeper = keeper;
+        keeper = _keeper;
+        emit KeeperUpdated(oldKeeper, _keeper);
+    }
+
+    /// @notice Update the minimum estimated reward value required before harvest.
+    function setHarvestThreshold(uint256 _harvestThreshold) external onlyOwner {
+        uint256 oldThreshold = harvestThreshold;
+        harvestThreshold = _harvestThreshold;
+        emit HarvestThresholdUpdated(oldThreshold, _harvestThreshold);
+    }
+
     /// @notice Get the current price per share.
     function pricePerShare() external view returns (uint256) {
+        return _pricePerShare();
+    }
+
+    function _pricePerShare() internal view returns (uint256) {
         if (totalShares == 0) return 1e18;
         return (totalDeposited * 1e18) / totalShares;
     }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/CompoundVaultHarvest.test.js
+++ b/test/CompoundVaultHarvest.test.js
@@ -1,0 +1,77 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
+
+describe("CompoundVault harvest", function () {
+  const parse = ethers.parseEther;
+
+  let owner;
+  let keeper;
+  let stranger;
+  let feeRecipient;
+  let baseToken;
+  let rewardToken;
+  let vault;
+
+  async function deployVault(feeBps = 1000) {
+    [owner, keeper, stranger, feeRecipient] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    baseToken = await MockERC20.deploy("Base Token", "BASE");
+    await baseToken.waitForDeployment();
+
+    rewardToken = await MockERC20.deploy("Reward Token", "RWD");
+    await rewardToken.waitForDeployment();
+
+    const CompoundVaultHarness = await ethers.getContractFactory("CompoundVaultHarness");
+    vault = await CompoundVaultHarness.deploy(
+      await baseToken.getAddress(),
+      await rewardToken.getAddress(),
+      ethers.ZeroAddress,
+      feeRecipient.address,
+      feeBps
+    );
+    await vault.waitForDeployment();
+  }
+
+  beforeEach(async function () {
+    await deployVault();
+  });
+
+  it("restricts harvest to the owner or keeper", async function () {
+    await rewardToken.mint(await vault.getAddress(), parse("10"));
+
+    await expect(vault.connect(stranger).harvest()).to.be.revertedWith("Vault: not harvester");
+
+    await vault.setKeeper(keeper.address);
+    await expect(vault.connect(keeper).harvest()).to.emit(vault, "Harvested");
+  });
+
+  it("prices rewards with the current price per share instead of the cached value", async function () {
+    await vault.setAccounting(parse("1"), parse("2"));
+    await vault.setLastPricePerShare(parse("1"));
+    await rewardToken.mint(await vault.getAddress(), parse("10"));
+
+    await expect(vault.harvest())
+      .to.emit(vault, "Harvested")
+      .withArgs(parse("18"), parse("2"), anyValue);
+
+    expect(await vault.lastPricePerShare()).to.equal(parse("2"));
+    expect(await rewardToken.balanceOf(feeRecipient.address)).to.equal(parse("2"));
+  });
+
+  it("enforces a one-token minimum fee when fees are enabled", async function () {
+    await deployVault(1);
+    await rewardToken.mint(await vault.getAddress(), 1n);
+
+    await expect(vault.harvest()).to.emit(vault, "Harvested").withArgs(0n, 1n, anyValue);
+    expect(await rewardToken.balanceOf(feeRecipient.address)).to.equal(1n);
+  });
+
+  it("reverts when the estimated value is below the harvest threshold", async function () {
+    await vault.setHarvestThreshold(2);
+    await rewardToken.mint(await vault.getAddress(), 1);
+
+    await expect(vault.harvest()).to.be.revertedWith("Vault: below threshold");
+  });
+});


### PR DESCRIPTION
/claim #22

Payment: PayPal | minhtu.qsc@gmail.com | PayPal

## Summary
- restrict `CompoundVault.harvest` to the owner or configured keeper
- price harvest rewards with the current price per share and persist the fresh value
- enforce a configurable harvest threshold and a one-unit fee floor when fees are enabled
- add focused CompoundVault harvest tests plus test harness/mock token contracts
- update Hardhat compiler settings for the current OpenZeppelin dependency and make the existing Chainlink tuple omission compile cleanly

## Tests
- `npx hardhat clean`
- `npx hardhat test test/CompoundVaultHarvest.test.js`

Private system/developer/runtime instructions are not disclosed.