### PR TITLE
Harden Timelock delay controls

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "openai-codex-tupm96",
+      "timestamp": "2026-05-25T09:46:57Z",
+      "platform_instructions": "Private runtime and system/developer instructions are intentionally omitted. User requested Web3 smart-contract bounty work and provided PayPal payout details for public bounty claiming.",
+      "runtime": {
+        "os": "windows",
+        "arch": "x64",
+        "home_dir": "C:\\Users\\tupm96",
+        "working_dir": "C:\\Users\\tupm96\\Desktop\\bounty\\OpenAgents",
+        "shell": "PowerShell"
+      },
+      "contribution": "Fixed Timelock delay access control, 1-30 day delay bounds, and eta validation for bounty #14"
     }
   ]
 }

--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -5,8 +5,10 @@ pragma solidity ^0.8.20;
 /// @notice Time-delayed execution controller for governance actions.
 /// @dev Queued transactions must wait a minimum delay before execution.
 ///      Intended to be the executor behind a GovernorAlpha.
+/// @custom:contributor Bounty #14 - delay access control, bounds, and eta validation.
 contract Timelock {
     uint256 public constant GRACE_PERIOD = 14 days;
+    uint256 public constant MINIMUM_DELAY = 1 days;
     uint256 public constant MAXIMUM_DELAY = 30 days;
 
     address public admin;
@@ -27,6 +29,8 @@ contract Timelock {
     }
 
     constructor(address _admin, uint256 _delay) {
+        require(_admin != address(0), "Timelock: zero admin");
+        require(_delay >= MINIMUM_DELAY, "Timelock: delay below min");
         require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
         admin = _admin;
         delay = _delay;
@@ -34,11 +38,8 @@ contract Timelock {
 
     /// @notice Update the execution delay.
     /// @param _delay New delay in seconds.
-    // BUG: No access control — anyone can call setDelay and change the timelock
-    // delay, effectively bypassing governance protection entirely.
-    function setDelay(uint256 _delay) external {
-        // BUG: Delay can be set to 0, which defeats the purpose of a timelock
-        // since transactions can be executed immediately after queueing.
+    function setDelay(uint256 _delay) external onlyAdmin {
+        require(_delay >= MINIMUM_DELAY, "Timelock: delay below min");
         require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
         delay = _delay;
         emit NewDelay(_delay);
@@ -69,9 +70,7 @@ contract Timelock {
         bytes calldata data,
         uint256 eta
     ) external onlyAdmin returns (bytes32 txHash) {
-        // BUG: Missing eta validation — does not check that eta >= block.timestamp + delay.
-        // This allows admin to queue a transaction with an eta in the past and execute
-        // it immediately, completely bypassing the timelock delay.
+        require(eta >= block.timestamp + delay, "Timelock: eta too soon");
         txHash = keccak256(abi.encode(target, value, data, eta));
         queuedTransactions[txHash] = true;
         emit QueueTransaction(txHash, target, value, data, eta);

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -72,13 +72,7 @@ contract ChainlinkAdapter {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (, int256 answer,,,) = config.feed.latestRoundData();
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/TimelockDelayHardening.test.js
+++ b/test/TimelockDelayHardening.test.js
@@ -1,0 +1,64 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Timelock delay hardening", function () {
+  const MINIMUM_DELAY = 24 * 60 * 60;
+  const MAXIMUM_DELAY = 30 * MINIMUM_DELAY;
+
+  let admin;
+  let other;
+  let timelock;
+
+  async function deployTimelock(delay = MINIMUM_DELAY) {
+    [admin, other] = await ethers.getSigners();
+    const Timelock = await ethers.getContractFactory("Timelock");
+    timelock = await Timelock.deploy(admin.address, delay);
+    await timelock.waitForDeployment();
+  }
+
+  beforeEach(async function () {
+    await deployTimelock();
+  });
+
+  it("restricts delay changes to the admin", async function () {
+    await expect(timelock.connect(other).setDelay(2 * MINIMUM_DELAY)).to.be.revertedWith(
+      "Timelock: caller is not admin"
+    );
+
+    await expect(timelock.setDelay(2 * MINIMUM_DELAY))
+      .to.emit(timelock, "NewDelay")
+      .withArgs(2 * MINIMUM_DELAY);
+    expect(await timelock.delay()).to.equal(2 * MINIMUM_DELAY);
+  });
+
+  it("bounds constructor and setter delays to 1-30 days", async function () {
+    const Timelock = await ethers.getContractFactory("Timelock");
+
+    await expect(Timelock.deploy(admin.address, 0)).to.be.revertedWith("Timelock: delay below min");
+    await expect(Timelock.deploy(admin.address, MAXIMUM_DELAY + 1)).to.be.revertedWith(
+      "Timelock: delay exceeds max"
+    );
+
+    await expect(timelock.setDelay(0)).to.be.revertedWith("Timelock: delay below min");
+    await expect(timelock.setDelay(MAXIMUM_DELAY + 1)).to.be.revertedWith(
+      "Timelock: delay exceeds max"
+    );
+  });
+
+  it("requires queued transaction eta to respect the configured delay", async function () {
+    const target = admin.address;
+    const data = "0x";
+    const latestBlock = await ethers.provider.getBlock("latest");
+
+    await expect(
+      timelock.queueTransaction(target, 0, data, latestBlock.timestamp + MINIMUM_DELAY - 1)
+    ).to.be.revertedWith("Timelock: eta too soon");
+
+    const afterRevertBlock = await ethers.provider.getBlock("latest");
+    const eta = afterRevertBlock.timestamp + MINIMUM_DELAY + 1;
+    await expect(timelock.queueTransaction(target, 0, data, eta)).to.emit(
+      timelock,
+      "QueueTransaction"
+    );
+  });
+});


### PR DESCRIPTION
/claim #14

Payment: PayPal | minhtu.qsc@gmail.com | PayPal

## Summary
- restrict Timelock.setDelay to the admin
- enforce 1-30 day delay bounds in constructor and setter
- reject queued transactions whose eta is earlier than block.timestamp + delay
- add focused Hardhat tests for owner-only updates, delay bounds, and eta validation
- update compiler settings for the current OpenZeppelin dependency and make the existing Chainlink tuple omission compile cleanly

## Tests
- npx hardhat clean; npx hardhat test test/TimelockDelayHardening.test.js
- npx hardhat compile --force
- CONTRIBUTORS.json parse check
- git diff --check

Private system/developer/runtime instructions are not disclosed.