### PR TITLE
[Codex for charlie12520] [ Solidity ] Fix StakingRewards cumulative reward accounting

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -59,9 +59,11 @@ contract GovernorAlpha is ReentrancyGuard {
         Proposal storage p = proposals[proposalId];
         p.id = proposalId;
         p.proposer = msg.sender;
-        p.targets = targets;
-        p.values = values;
-        p.calldatas = calldatas;
+        for (uint256 i = 0; i < targets.length; i++) {
+            p.targets.push(targets[i]);
+            p.values.push(values[i]);
+            p.calldatas.push(calldatas[i]);
+        }
         p.startBlock = block.number + VOTING_DELAY;
         p.endBlock = block.number + VOTING_DELAY + VOTING_PERIOD;
 

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -72,13 +72,7 @@ contract ChainlinkAdapter {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (, int256 answer,,,) = config.feed.latestRoundData();
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -5,6 +5,10 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/// @dev Contributor traceability:
+/// contributor: Codex for charlie12520
+/// platform_instructions: private system/developer/runtime instructions intentionally withheld
+/// env: windows-x64, home C:/Users/charl, working_dir C:/Users/charl/Desktop/AI STUFF/ten_buck_attempt/repos/OpenAgents, shell powershell
 /// @title StakingRewards
 /// @notice Synthetix-style staking rewards distribution contract.
 /// @dev Users stake an ERC20 token and earn rewards over a fixed duration.
@@ -66,11 +70,8 @@ contract StakingRewards is ReentrancyGuard {
         if (_totalSupply == 0) {
             return rewardPerTokenStored;
         }
-        // BUG: Uses block.timestamp directly instead of lastTimeRewardApplicable().
-        // After periodFinish, this keeps accruing phantom rewards indefinitely,
-        // allowing stakers to drain more rewards than were actually deposited.
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
         );
     }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,12 +2,13 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
+    version: "0.8.24",
     settings: {
       optimizer: {
         enabled: true,
         runs: 200,
       },
+      evmVersion: "cancun",
     },
   },
   networks: {

--- a/test/StakingRewards.test.js
+++ b/test/StakingRewards.test.js
@@ -125,4 +125,46 @@ describe("StakingRewards", function () {
     );
     expect(earned1 + earned2).to.be.closeTo(rewardAmount, ethers.parseEther("6"));
   });
+
+  it("pays the proportional split once and does not overpay after finish", async function () {
+    const stakeAmount = ethers.parseEther("100");
+    const rewardAmount = ethers.parseEther("604800");
+
+    await stakeAs(staker1, stakeAmount);
+    await stakingRewards.notifyRewardAmount(rewardAmount);
+
+    await time.increase(REWARD_DURATION / 2);
+    await stakeAs(staker2, stakeAmount);
+
+    await time.increase(REWARD_DURATION / 2);
+
+    await stakingRewards.connect(staker1).getReward();
+    await stakingRewards.connect(staker2).getReward();
+
+    const paid1 = await rewardToken.balanceOf(staker1.address);
+    const paid2 = await rewardToken.balanceOf(staker2.address);
+    const contractBalanceAfterClaims = await rewardToken.balanceOf(
+      await stakingRewards.getAddress()
+    );
+
+    expect(paid1).to.be.closeTo(
+      ethers.parseEther("453600"),
+      ethers.parseEther("3")
+    );
+    expect(paid2).to.be.closeTo(
+      ethers.parseEther("151200"),
+      ethers.parseEther("3")
+    );
+    expect(paid1 + paid2).to.be.closeTo(rewardAmount, ethers.parseEther("6"));
+
+    await time.increase(30 * 24 * 60 * 60);
+    await stakingRewards.connect(staker1).getReward();
+    await stakingRewards.connect(staker2).getReward();
+
+    expect(await rewardToken.balanceOf(staker1.address)).to.equal(paid1);
+    expect(await rewardToken.balanceOf(staker2.address)).to.equal(paid2);
+    expect(await rewardToken.balanceOf(await stakingRewards.getAddress())).to.equal(
+      contractBalanceAfterClaims
+    );
+  });
 });

--- a/test/StakingRewards.test.js
+++ b/test/StakingRewards.test.js
@@ -90,6 +90,14 @@ describe("StakingRewards", function () {
       firstReward / 2n,
       ethers.parseEther("2")
     );
+
+    await time.increase(REWARD_DURATION);
+    const earnedAfterNewPeriod = await stakingRewards.earned(staker1.address);
+
+    expect(earnedAfterNewPeriod).to.be.closeTo(
+      firstReward + secondReward,
+      ethers.parseEther("4")
+    );
   });
 
   it("keeps proportional rewards correct when users stake at different times", async function () {

--- a/test/StakingRewards.test.js
+++ b/test/StakingRewards.test.js
@@ -1,73 +1,120 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("StakingRewards", function () {
-  let stakingRewards, stakingToken, rewardToken;
-  let owner, staker1, staker2;
+  const REWARD_DURATION = 7 * 24 * 60 * 60;
 
-  // BUG: Setup runs once but tests mutate state - no beforeEach to reset between tests
-  before(async function () {
+  let stakingRewards;
+  let stakingToken;
+  let rewardToken;
+  let owner;
+  let staker1;
+  let staker2;
+
+  async function deployToken(name, symbol) {
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    return AgentToken.deploy(name, symbol, 0);
+  }
+
+  async function deployFixture() {
     [owner, staker1, staker2] = await ethers.getSigners();
 
-    const StakingToken = await ethers.getContractFactory("StakingToken");
-    stakingToken = await StakingToken.deploy();
-    await stakingToken.deployed();
-
-    const RewardToken = await ethers.getContractFactory("RewardToken");
-    rewardToken = await RewardToken.deploy();
-    await rewardToken.deployed();
+    stakingToken = await deployToken("Stake Token", "STK");
+    rewardToken = await deployToken("Reward Token", "RWD");
 
     const StakingRewards = await ethers.getContractFactory("StakingRewards");
-    stakingRewards = await StakingRewards.deploy(stakingToken.address, rewardToken.address);
-    await stakingRewards.deployed();
+    stakingRewards = await StakingRewards.deploy(
+      await stakingToken.getAddress(),
+      await rewardToken.getAddress()
+    );
 
-    // Mint tokens for testing
-    await stakingToken.mint(staker1.address, ethers.utils.parseEther("1000"));
-    await stakingToken.mint(staker2.address, ethers.utils.parseEther("1000"));
-    await rewardToken.mint(stakingRewards.address, ethers.utils.parseEther("10000"));
+    const stakeAmount = ethers.parseEther("1000");
+    await stakingToken.mint(staker1.address, stakeAmount);
+    await stakingToken.mint(staker2.address, stakeAmount);
+    await rewardToken.mint(
+      await stakingRewards.getAddress(),
+      ethers.parseEther("1000000")
+    );
+  }
+
+  async function stakeAs(staker, amount) {
+    await stakingToken
+      .connect(staker)
+      .approve(await stakingRewards.getAddress(), amount);
+    await stakingRewards.connect(staker).stake(amount);
+  }
+
+  beforeEach(async function () {
+    await deployFixture();
   });
 
-  it("should allow staking tokens", async function () {
-    const amount = ethers.utils.parseEther("100");
-    await stakingToken.connect(staker1).approve(stakingRewards.address, amount);
-    await stakingRewards.connect(staker1).stake(amount);
+  it("stops accruing rewards after the reward period ends", async function () {
+    const stakeAmount = ethers.parseEther("100");
+    const rewardAmount = ethers.parseEther("604800");
 
-    const staked = await stakingRewards.balanceOf(staker1.address);
-    expect(staked).to.equal(amount);
+    await stakeAs(staker1, stakeAmount);
+    await stakingRewards.notifyRewardAmount(rewardAmount);
+
+    await time.increase(REWARD_DURATION);
+    const earnedAtFinish = await stakingRewards.earned(staker1.address);
+
+    await time.increase(30 * 24 * 60 * 60);
+    const earnedAfterFinish = await stakingRewards.earned(staker1.address);
+
+    expect(earnedAfterFinish).to.equal(earnedAtFinish);
+    expect(earnedAtFinish).to.equal(rewardAmount);
   });
 
-  it("should accrue rewards over time", async function () {
-    // BUG: Hardcoded block timestamp - test is brittle and environment-dependent
-    await ethers.provider.send("evm_setNextBlockTimestamp", [1747400000]);
-    await ethers.provider.send("evm_mine");
+  it("does not retroactively apply a new reward rate to already accrued rewards", async function () {
+    const stakeAmount = ethers.parseEther("100");
+    const firstReward = ethers.parseEther("604800");
+    const secondReward = ethers.parseEther("1209600");
 
-    const earned = await stakingRewards.earned(staker1.address);
-    expect(earned).to.be.gt(0);
+    await stakeAs(staker1, stakeAmount);
+    await stakingRewards.notifyRewardAmount(firstReward);
+
+    await time.increase(REWARD_DURATION / 2);
+    const earnedBeforeRateChange = await stakingRewards.earned(staker1.address);
+
+    await stakingRewards.notifyRewardAmount(secondReward);
+    const earnedImmediatelyAfterRateChange = await stakingRewards.earned(
+      staker1.address
+    );
+
+    expect(earnedImmediatelyAfterRateChange).to.be.closeTo(
+      earnedBeforeRateChange,
+      ethers.parseEther("2")
+    );
+    expect(earnedBeforeRateChange).to.be.closeTo(
+      firstReward / 2n,
+      ethers.parseEther("2")
+    );
   });
 
-  it("should allow withdrawal", async function () {
-    // BUG: depends on state from previous test (staker1 having staked 100 tokens)
-    const amount = ethers.utils.parseEther("50");
-    await stakingRewards.connect(staker1).withdraw(amount);
+  it("keeps proportional rewards correct when users stake at different times", async function () {
+    const stakeAmount = ethers.parseEther("100");
+    const rewardAmount = ethers.parseEther("604800");
 
-    const remaining = await stakingRewards.balanceOf(staker1.address);
-    expect(remaining).to.equal(ethers.utils.parseEther("50"));
-  });
+    await stakeAs(staker1, stakeAmount);
+    await stakingRewards.notifyRewardAmount(rewardAmount);
 
-  it("should distribute rewards correctly to multiple stakers", async function () {
-    const amount = ethers.utils.parseEther("200");
-    await stakingToken.connect(staker2).approve(stakingRewards.address, amount);
-    await stakingRewards.connect(staker2).stake(amount);
+    await time.increase(REWARD_DURATION / 2);
+    await stakeAs(staker2, stakeAmount);
 
-    // BUG: Hardcoded timestamp again - assumes previous evm_setNextBlockTimestamp succeeded
-    await ethers.provider.send("evm_setNextBlockTimestamp", [1747500000]);
-    await ethers.provider.send("evm_mine");
+    await time.increase(REWARD_DURATION / 2);
 
     const earned1 = await stakingRewards.earned(staker1.address);
     const earned2 = await stakingRewards.earned(staker2.address);
 
-    // staker2 staked 4x more, so should earn proportionally more from this point
-    expect(earned2).to.be.gt(0);
-    expect(earned1).to.be.gt(0);
+    expect(earned1).to.be.closeTo(
+      ethers.parseEther("453600"),
+      ethers.parseEther("3")
+    );
+    expect(earned2).to.be.closeTo(
+      ethers.parseEther("151200"),
+      ethers.parseEther("3")
+    );
+    expect(earned1 + earned2).to.be.closeTo(rewardAmount, ethers.parseEther("6"));
   });
 });


### PR DESCRIPTION
/claim #106

Payment: USDC | Ho7CwRDTucBzbRdr5iZXyjR2BXaYRpYmFMJFvDd6qwDb | Solana

Summary:
- Fixed StakingRewards rewardPerToken() to use lastTimeRewardApplicable() instead of raw block.timestamp, so rewards stop at periodFinish.
- Preserved cumulative rewardPerTokenStored and userRewardPerTokenPaid accounting around state-changing calls.
- Replaced brittle staking tests with focused Hardhat tests for the listed acceptance criteria.
- Included small baseline compile fixes required by the current dependency set so the staking tests can run.
- Added safe contributor traceability without exposing private system/developer/runtime instructions or secrets.

Acceptance criteria verification:
- Rewards calculated through cumulative rewardPerToken accounting: covered by contract state and staking tests.
- Rate changes do not retroactively affect past rewards: covered by rate-change mid-stake test.
- Multiple users staking at different times get proportional rewards: covered by two-staker timing test.
- Tests included: multi-user scenario and rate-change mid-stake scenario.

Local verification:
- npx hardhat test test/StakingRewards.test.js -> 3 passing
- npx hardhat test -> 3 passing
- git diff --check -> passed, CRLF warnings only

Competing PR review:
- Checked open pull requests for this issue before submitting; none were open.

Validation update:
- Strengthened rate-change coverage so the test now follows the new reward period through final accounting and asserts first + second reward totals.
- npx hardhat test test/StakingRewards.test.js -> 3 passed.
- npx hardhat test -> 3 passed.

Validation update after payout finality coverage:
- Added an actual getReward payout-flow test proving the different-time staker split is paid once and does not overpay after periodFinish.
- npx hardhat test test/StakingRewards.test.js -> 4 passing.
- npx hardhat test -> 4 passing.
- git diff --check -> passed, CRLF warnings only.
