### PR TITLE
fix: use SafeERC20 for unchecked transfer return values (#181)

### DIFF
--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PaymentEscrow is Ownable {
+    using SafeERC20 for IERC20;
     struct Escrow {
         address payer;
         address payee;
@@ -33,7 +35,9 @@ contract PaymentEscrow is Ownable {
         require(payee != address(0), "Invalid payee");
         require(amount > 0, "Amount must be > 0");
 
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        // FIX #181: Use SafeERC20 to handle non-standard tokens that return false
+        // instead of reverting on failed transfers
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
@@ -56,7 +60,8 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer || msg.sender == owner(), "Not authorized");
 
         escrow.released = true;
-        IERC20(escrow.token).transfer(escrow.payee, escrow.amount);
+        // FIX #181: Use safeTransfer — non-standard ERC20s may return false silently
+        IERC20(escrow.token).safeTransfer(escrow.payee, escrow.amount);
 
         emit EscrowReleased(escrowId, escrow.payee, escrow.amount);
     }
@@ -68,7 +73,8 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer, "Not payer");
 
         escrow.refunded = true;
-        IERC20(escrow.token).transfer(escrow.payer, escrow.amount);
+        // FIX #181: Use safeTransfer — non-standard ERC20s may return false silently
+        IERC20(escrow.token).safeTransfer(escrow.payer, escrow.amount);
 
         emit EscrowRefunded(escrowId, escrow.payer, escrow.amount);
     }

--- a/contracts/dex/Router.sol
+++ b/contracts/dex/Router.sol
@@ -51,7 +51,8 @@ contract Router {
     ) external returns (uint256 amountOut) {
         require(path.length >= 2, "Path too short");
 
-        IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        // FIX #181: Check return value — non-standard ERC20s may return false instead of reverting
+        require(IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn), "transferFrom failed");
 
         uint256 currentAmount = amountIn;
 
@@ -71,7 +72,8 @@ contract Router {
         amountOut = currentAmount;
 
         // Transfer final tokens to user
-        IERC20(path[path.length - 1]).transfer(msg.sender, amountOut);
+        // FIX #181: Check return value — non-standard ERC20s may return false instead of reverting
+        require(IERC20(path[path.length - 1]).transfer(msg.sender, amountOut), "transfer failed");
 
         emit MultiHopSwap(msg.sender, path, amountIn, amountOut);
     }


### PR DESCRIPTION
## Fix #181: Unchecked ERC20 Return Values

**Bug:** .transfer() and .transferFrom() return values ignored — non-standard ERC20s (e.g., USDT) that return false instead of reverting would silently fail.

**Fix:**
- PaymentEscrow: Added SafeERC20 library, replaced with safeTransfer()/safeTransferFrom()
- Router: Wrapped calls in require() to check return values

Fixes #181