### PR TITLE
feat: add EIP-712 gas sponsorship relay for agent transactions (#183)

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract AgentRegistry is Ownable {
+    // FIX #183: Trusted gas relay forwarder — enables gasless agent registration
+    address public trustedForwarder;
+
     struct Agent {
         address owner;
         string name;
@@ -18,28 +21,73 @@ contract AgentRegistry is Ownable {
     mapping(address => bytes32[]) public ownerAgents;
     bytes32[] public agentIds;
 
+    // FIX #172: Name uniqueness mapping to prevent frontrunning / name-squatting
+    mapping(string => bool) public registeredName;
+    // FIX #172: Per-address nonce for deterministic, collision-free agent IDs
+    mapping(address => uint256) public nonce;
+
     uint256 public registrationFee;
     uint256 public minReputation;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
     event ReputationUpdated(bytes32 indexed agentId, uint256 newReputation);
+    event TrustedForwarderUpdated(address indexed forwarder);
 
-    constructor(uint256 _registrationFee) Ownable(msg.sender) {
+    constructor(uint256 _registrationFee, address _trustedForwarder) Ownable(msg.sender) {
         registrationFee = _registrationFee;
         minReputation = 0;
+        trustedForwarder = _trustedForwarder;
+    }
+
+    // FIX #183: Allow owner to update the trusted forwarder (GasRelay contract)
+    function setTrustedForwarder(address _forwarder) external onlyOwner {
+        trustedForwarder = _forwarder;
+        emit TrustedForwarderUpdated(_forwarder);
+    }
+
+    // FIX #183: Internal helper — resolve actual sender from msg.sender or forwarder context
+    // Uses EIP-2771 pattern: when called via trustedForwarder, the original sender
+    // address is appended as the last 20 bytes of calldata.
+    function _msgSender() internal view returns (address) {
+        if (msg.sender == trustedForwarder && trustedForwarder != address(0)) {
+            return address(bytes20(msg.data[msg.data.length - 20:]));
+        }
+        return msg.sender;
+    }
+
+    // FIX #183: Internal helper — return msg.data stripping relay context if present
+    function _msgData() internal view returns (bytes calldata) {
+        if (msg.sender == trustedForwarder && trustedForwarder != address(0)) {
+            return msg.data[:msg.data.length - 20];
+        }
+        return msg.data;
     }
 
     function registerAgent(string calldata name, string calldata endpoint) external payable returns (bytes32) {
+        // FIX #183: Use resolved sender (supports gas relay via trustedForwarder)
+        address sender = _msgSender();
         require(msg.value >= registrationFee, "Insufficient fee");
         require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
 
-        bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp));
+        // FIX #172: Enforce unique agent names — prevents frontrunner from registering
+        // the same name before the legitimate sender
+        require(!registeredName[name], "Agent name already taken");
+
+        // FIX #172: Use sender nonce instead of block.timestamp — deterministic,
+        // non-frontrunnable agent IDs that only the sender can produce
+        // FIX #183: Uses resolved sender to support gas relay
+        uint256 senderNonce = nonce[sender];
+        bytes32 agentId = keccak256(abi.encodePacked(sender, senderNonce, name));
+        nonce[sender] = senderNonce + 1;
 
         require(agents[agentId].registeredAt == 0, "Agent exists");
 
+        // FIX #172: Mark name as taken atomically in the same tx
+        registeredName[name] = true;
+
         agents[agentId] = Agent({
-            owner: msg.sender,
+            owner: sender,
             name: name,
             endpoint: endpoint,
             reputation: 100,
@@ -48,15 +96,17 @@ contract AgentRegistry is Ownable {
             active: true
         });
 
-        ownerAgents[msg.sender].push(agentId);
+        ownerAgents[sender].push(agentId);
         agentIds.push(agentId);
 
-        emit AgentRegistered(agentId, msg.sender, name);
+        emit AgentRegistered(agentId, sender, name);
         return agentId;
     }
 
     function deactivateAgent(bytes32 agentId) external {
-        require(agents[agentId].owner == msg.sender, "Not agent owner");
+        // FIX #183: Use resolved sender to support gas relay
+        address sender = _msgSender();
+        require(agents[agentId].owner == sender, "Not agent owner");
         agents[agentId].active = false;
         emit AgentDeactivated(agentId);
     }

--- a/contracts/GasRelay.sol
+++ b/contracts/GasRelay.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title GasRelay
+/// @notice Meta-transaction relay for agent operations — enables gasless transactions.
+/// @dev Users sign typed data off-chain; a relayer submits the tx and pays gas.
+///      The relay verifies EIP-712 signatures and forwards calls to target contracts.
+contract GasRelay is EIP712, ReentrancyGuard {
+    using ECDSA for bytes32;
+
+    // Authorized relayers who can submit meta-tx on behalf of users
+    mapping(address => bool) public relayers;
+    address public owner;
+
+    // Replay protection: signer => nonce
+    mapping(address => uint256) public nonces;
+
+    // Typehash for the ForwardRequest struct
+    bytes32 private constant FORWARD_REQUEST_TYPEHASH =
+        keccak256("ForwardRequest(address from,address to,uint256 value,bytes data,uint256 nonce,uint256 deadline)");
+
+    event RelayerAuthorized(address indexed relayer, bool authorized);
+    event MetaTransactionExecuted(
+        address indexed from,
+        address indexed to,
+        bytes data,
+        uint256 nonce
+    );
+
+    struct ForwardRequest {
+        address from;    // The actual sender (signer)
+        address to;      // Target contract
+        uint256 value;   // ETH value to forward
+        bytes data;      // Calldata
+        uint256 nonce;   // Replay protection
+        uint256 deadline; // Expiration timestamp
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "GasRelay: not owner");
+        _;
+    }
+
+    constructor(address _owner)
+        EIP712("GasRelay", "1")
+    {
+        owner = _owner;
+    }
+
+    /// @notice Authorize or deauthorize a relayer address.
+    function setRelayer(address relayer, bool authorized) external onlyOwner {
+        relayers[relayer] = authorized;
+        emit RelayerAuthorized(relayer, authorized);
+    }
+
+    /// @notice Execute a meta-transaction on behalf of a user.
+    /// @param req The forward request containing user's intent.
+    /// @param signature EIP-712 signature from the user (req.from).
+    function executeMetaTransaction(
+        ForwardRequest calldata req,
+        bytes calldata signature
+    ) external payable nonReentrant returns (bytes memory) {
+        require(relayers[msg.sender], "GasRelay: not authorized relayer");
+        require(block.timestamp <= req.deadline, "GasRelay: request expired");
+        require(req.from != address(0), "GasRelay: invalid sender");
+
+        // Verify nonce matches to prevent replay
+        require(req.nonce == nonces[req.from], "GasRelay: invalid nonce");
+
+        // Verify EIP-712 signature
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    FORWARD_REQUEST_TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    keccak256(req.data),
+                    req.nonce,
+                    req.deadline
+                )
+            )
+        );
+
+        address signer = digest.recover(signature);
+        require(signer == req.from, "GasRelay: invalid signature");
+
+        // Increment nonce (replay protection)
+        nonces[req.from]++;
+
+        // Forward the call to the target contract
+        (bool success, bytes memory result) = req.to.call{value: req.value}(req.data);
+        require(success, "GasRelay: forwarded call failed");
+
+        emit MetaTransactionExecuted(req.from, req.to, req.data, req.nonce);
+        return result;
+    }
+
+    /// @notice Get the current nonce for a signer.
+    function getNonce(address signer) external view returns (uint256) {
+        return nonces[signer];
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
## Feat #183: Gas Sponsorship Relay

**Bug:** No gasless transaction support — agents need ETH to register.

**Fix:**
- Created GasRelay.sol — EIP-712 meta-transaction relay with signature verification, nonce replay protection, and authorized relayer system
- Added EIP-2771 trusted-forwarder pattern to AgentRegistry: _msgSender() resolves original sender from relay calldata

Fixes #183