### PR TITLE
fix: add access control and eta validation to Timelock (#201)

### DIFF
--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -8,6 +8,8 @@ pragma solidity ^0.8.20;
 contract Timelock {
     uint256 public constant GRACE_PERIOD = 14 days;
     uint256 public constant MAXIMUM_DELAY = 30 days;
+    // FIX #201: Minimum delay to prevent setting delay to 0
+    uint256 public constant MINIMUM_DELAY = 1 days;
 
     address public admin;
     address public pendingAdmin;
@@ -34,11 +36,9 @@ contract Timelock {
 
     /// @notice Update the execution delay.
     /// @param _delay New delay in seconds.
-    // BUG: No access control — anyone can call setDelay and change the timelock
-    // delay, effectively bypassing governance protection entirely.
-    function setDelay(uint256 _delay) external {
-        // BUG: Delay can be set to 0, which defeats the purpose of a timelock
-        // since transactions can be executed immediately after queueing.
+    // FIX #201: Add onlyAdmin modifier and minimum delay check
+    function setDelay(uint256 _delay) external onlyAdmin {
+        require(_delay >= MINIMUM_DELAY, "Timelock: delay below minimum");
         require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
         delay = _delay;
         emit NewDelay(_delay);
@@ -69,9 +69,9 @@ contract Timelock {
         bytes calldata data,
         uint256 eta
     ) external onlyAdmin returns (bytes32 txHash) {
-        // BUG: Missing eta validation — does not check that eta >= block.timestamp + delay.
-        // This allows admin to queue a transaction with an eta in the past and execute
-        // it immediately, completely bypassing the timelock delay.
+        // FIX #201: Validate eta is in the future — ensures timelock delay is enforced.
+        // Without this, admin could queue with past eta and execute immediately.
+        require(eta >= block.timestamp + delay, "Timelock: eta too soon");
         txHash = keccak256(abi.encode(target, value, data, eta));
         queuedTransactions[txHash] = true;
         emit QueueTransaction(txHash, target, value, data, eta);


### PR DESCRIPTION
## Fix #201: Timelock Expiry Bypass

**Bug:** setDelay() had no access control (anyone could change delay). queueTransaction() did not validate eta >= block.timestamp + delay, allowing immediate execution.

**Fix:**
- Added onlyAdmin modifier to setDelay()
- Added MINIMUM_DELAY = 1 days constant
- Added require(eta >= block.timestamp + delay) in queueTransaction()

Fixes #201