### PR TITLE
feat: add batchRegister to AgentRegistry for gas efficiency

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -21,6 +21,8 @@ contract AgentRegistry is Ownable {
     uint256 public registrationFee;
     uint256 public minReputation;
 
+    uint256 public constant MAX_BATCH_SIZE = 50;
+
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
     event ReputationUpdated(bytes32 indexed agentId, uint256 newReputation);
@@ -53,6 +55,49 @@ contract AgentRegistry is Ownable {
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
+    }
+
+    /// @notice Register multiple agents in a single transaction for gas efficiency
+    /// @param names Array of agent names (must not exceed MAX_BATCH_SIZE)
+    /// @param endpoints Array of agent endpoints (must match names length)
+    /// @return ids Array of registered agent IDs
+    function batchRegister(
+        string[] calldata names,
+        string[] calldata endpoints
+    ) external payable returns (bytes32[] memory ids) {
+        uint256 count = names.length;
+        require(count > 0, "Empty batch");
+        require(count <= MAX_BATCH_SIZE, "Batch too large");
+        require(count == endpoints.length, "Array length mismatch");
+        require(msg.value >= registrationFee * count, "Insufficient fee");
+
+        ids = new bytes32[](count);
+
+        for (uint256 i = 0; i < count; i++) {
+            require(bytes(names[i]).length > 0 && bytes(names[i]).length <= 64, "Invalid name");
+
+            bytes32 agentId = keccak256(abi.encodePacked(msg.sender, names[i], block.timestamp, i));
+
+            require(agents[agentId].registeredAt == 0, "Agent exists");
+
+            agents[agentId] = Agent({
+                owner: msg.sender,
+                name: names[i],
+                endpoint: endpoints[i],
+                reputation: 100,
+                tasksCompleted: 0,
+                registeredAt: block.timestamp,
+                active: true
+            });
+
+            ownerAgents[msg.sender].push(agentId);
+            agentIds.push(agentId);
+
+            emit AgentRegistered(agentId, msg.sender, names[i]);
+            ids[i] = agentId;
+        }
+
+        return ids;
     }
 
     function deactivateAgent(bytes32 agentId) external {

--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -73,11 +73,11 @@ contract ChainlinkAdapter {
         require(config.active, "Feed not active");
 
         (
-            uint80 /* roundId */,
+            ,
             int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            ,
+            ,
+            
         ) = config.feed.latestRoundData();
 
         // No validation of roundId, staleness, or negative price

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,28 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.28",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/AgentRegistry.test.js
+++ b/test/AgentRegistry.test.js
@@ -1,0 +1,204 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry - Batch Operations", function () {
+  let agentRegistry;
+  let owner, user1, user2;
+  const REGISTRATION_FEE = ethers.parseEther("0.01");
+
+  beforeEach(async function () {
+    [owner, user1, user2] = await ethers.getSigners();
+
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    agentRegistry = await AgentRegistry.deploy(REGISTRATION_FEE);
+    await agentRegistry.waitForDeployment();
+  });
+
+  // Helper to count registered agents by parsing events
+  async function getAgentCount() {
+    // agentIds is a public array, we can query it by index until it reverts
+    let count = 0;
+    try {
+      for (let i = 0; i < 200; i++) {
+        await agentRegistry.agentIds(i);
+        count++;
+      }
+    } catch (e) {
+      // Expected - array out of bounds
+    }
+    return count;
+  }
+
+  describe("Single registration (backward compatibility)", function () {
+    it("should register a single agent", async function () {
+      const tx = await agentRegistry.connect(user1).registerAgent("Agent1", "https://agent1.example.com", {
+        value: REGISTRATION_FEE,
+      });
+      const receipt = await tx.wait();
+
+      const events = receipt.logs.filter(
+        (log) => { try { return agentRegistry.interface.parseLog(log)?.name === "AgentRegistered"; } catch { return false; } }
+      );
+      expect(events.length).to.equal(1);
+
+      expect(await getAgentCount()).to.equal(1);
+    });
+  });
+
+  describe("batchRegister", function () {
+    it("should register a batch of 1 agent", async function () {
+      const names = ["SoloAgent"];
+      const endpoints = ["https://solo.example.com"];
+
+      const tx = await agentRegistry.connect(user1).batchRegister(names, endpoints, {
+        value: REGISTRATION_FEE,
+      });
+      const receipt = await tx.wait();
+
+      const events = receipt.logs.filter(
+        (log) => { try { return agentRegistry.interface.parseLog(log)?.name === "AgentRegistered"; } catch { return false; } }
+      );
+      expect(events.length).to.equal(1);
+
+      expect(await getAgentCount()).to.equal(1);
+
+      // Verify the agent data
+      const agentId = await agentRegistry.agentIds(0);
+      const agent = await agentRegistry.getAgent(agentId);
+      expect(agent.name).to.equal("SoloAgent");
+      expect(agent.endpoint).to.equal("https://solo.example.com");
+      expect(agent.owner).to.equal(user1.address);
+      expect(agent.active).to.be.true;
+      expect(agent.reputation).to.equal(100);
+    });
+
+    it("should register a batch of 50 agents", async function () {
+      const names = [];
+      const endpoints = [];
+      for (let i = 0; i < 50; i++) {
+        names.push(`Agent${i}`);
+        endpoints.push(`https://agent${i}.example.com`);
+      }
+
+      const totalFee = REGISTRATION_FEE * 50n;
+
+      const tx = await agentRegistry.connect(user1).batchRegister(names, endpoints, {
+        value: totalFee,
+      });
+      const receipt = await tx.wait();
+
+      const events = receipt.logs.filter(
+        (log) => { try { return agentRegistry.interface.parseLog(log)?.name === "AgentRegistered"; } catch { return false; } }
+      );
+      expect(events.length).to.equal(50);
+
+      expect(await getAgentCount()).to.equal(50);
+
+      // Verify a few agents
+      for (let i = 0; i < 50; i++) {
+        const agentId = await agentRegistry.agentIds(i);
+        const agent = await agentRegistry.getAgent(agentId);
+        expect(agent.name).to.equal(`Agent${i}`);
+        expect(agent.endpoint).to.equal(`https://agent${i}.example.com`);
+        expect(agent.owner).to.equal(user1.address);
+        expect(agent.active).to.be.true;
+      }
+    });
+
+    it("should revert on array length mismatch", async function () {
+      const names = ["Agent1", "Agent2"];
+      const endpoints = ["https://agent1.example.com"];
+
+      await expect(
+        agentRegistry.connect(user1).batchRegister(names, endpoints, {
+          value: REGISTRATION_FEE * 2n,
+        })
+      ).to.be.revertedWith("Array length mismatch");
+    });
+
+    it("should revert on empty batch", async function () {
+      await expect(
+        agentRegistry.connect(user1).batchRegister([], [], {
+          value: 0,
+        })
+      ).to.be.revertedWith("Empty batch");
+    });
+
+    it("should revert on batch exceeding MAX_BATCH_SIZE", async function () {
+      const names = [];
+      const endpoints = [];
+      for (let i = 0; i < 51; i++) {
+        names.push(`Agent${i}`);
+        endpoints.push(`https://agent${i}.example.com`);
+      }
+
+      await expect(
+        agentRegistry.connect(user1).batchRegister(names, endpoints, {
+          value: REGISTRATION_FEE * 51n,
+        })
+      ).to.be.revertedWith("Batch too large");
+    });
+
+    it("should revert on insufficient fee", async function () {
+      const names = ["Agent1", "Agent2"];
+      const endpoints = ["https://agent1.example.com", "https://agent2.example.com"];
+
+      await expect(
+        agentRegistry.connect(user1).batchRegister(names, endpoints, {
+          value: REGISTRATION_FEE,
+        })
+      ).to.be.revertedWith("Insufficient fee");
+    });
+
+    it("should collect total fee once", async function () {
+      const names = ["Agent1", "Agent2", "Agent3"];
+      const endpoints = ["https://a1.example.com", "https://a2.example.com", "https://a3.example.com"];
+      const totalFee = REGISTRATION_FEE * 3n;
+
+      const contractAddr = await agentRegistry.getAddress();
+      const balanceBefore = await ethers.provider.getBalance(contractAddr);
+
+      await agentRegistry.connect(user1).batchRegister(names, endpoints, {
+        value: totalFee,
+      });
+
+      const balanceAfter = await ethers.provider.getBalance(contractAddr);
+      expect(balanceAfter - balanceBefore).to.equal(totalFee);
+    });
+
+    it("should allow multiple users to batch register", async function () {
+      await agentRegistry.connect(user1).batchRegister(["A1", "A2"], ["e1", "e2"], {
+        value: REGISTRATION_FEE * 2n,
+      });
+
+      await agentRegistry.connect(user2).batchRegister(["B1", "B2", "B3"], ["e3", "e4", "e5"], {
+        value: REGISTRATION_FEE * 3n,
+      });
+
+      expect(await getAgentCount()).to.equal(5);
+    });
+
+    it("should return correct agent IDs", async function () {
+      const names = ["Agent1", "Agent2"];
+      const endpoints = ["https://a1.example.com", "https://a2.example.com"];
+
+      const tx = await agentRegistry.connect(user1).batchRegister(names, endpoints, {
+        value: REGISTRATION_FEE * 2n,
+      });
+      const receipt = await tx.wait();
+
+      const events = receipt.logs.filter(
+        (log) => { try { return agentRegistry.interface.parseLog(log)?.name === "AgentRegistered"; } catch { return false; } }
+      );
+
+      const agentIds = events.map((e) => agentRegistry.interface.parseLog(e).args.agentId);
+      expect(agentIds.length).to.equal(2);
+      expect(agentIds[0]).to.not.equal(agentIds[1]);
+
+      for (const id of agentIds) {
+        const agent = await agentRegistry.getAgent(id);
+        expect(agent.registeredAt).to.be.gt(0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `batchRegister(string[] names, string[] endpoints)` to `AgentRegistry.sol` for gas-efficient multi-agent registration in a single transaction.

### Implementation

- **Max batch size:** 50 agents per transaction
- **Single fee collection:** `msg.value >= registrationFee * count`
- **Individual events:** Emits `AgentRegistered` for each agent
- **Unique IDs:** Each agentId includes loop index in hash to prevent duplicates
- **Validation:** Array length mismatch, empty batch, oversized batch, insufficient fee all revert

### Backward Compatibility

The existing `registerAgent()` function is untouched. `batchRegister` is a new addition.

### Tests (10 passing)

| Test | Status |
|------|--------|
| Single registration backward compat | ✔ |
| Batch of 1 agent | ✔ |
| Batch of 50 agents (max) | ✔ |
| Array length mismatch revert | ✔ |
| Empty batch revert | ✔ |
| Oversized batch revert | ✔ |
| Insufficient fee revert | ✔ |
| Total fee collection verification | ✔ |
| Multi-user batch registration | ✔ |
| Return value (agent IDs) verification | ✔ |

### Additional Fixes

- Fixed `ChainlinkAdapter.sol` destructuring syntax for Solidity 0.8.20 compatibility
- Added multi-compiler Hardhat config (0.8.20 + 0.8.28) to support OZ v5.1 dependencies

### How to Run

```bash
npm install
npx hardhat test test/AgentRegistry.test.js
```

Closes #194