### PR TITLE
[jjb9707] Fix escrow auto-refund for expired escrows (#197)

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -82,8 +82,22 @@ class Payment(Base):
     status = Column(String(32), default="pending")
     created_at = Column(DateTime, default=datetime.utcnow)
     claimed_at = Column(DateTime, nullable=True)
+    release_time = Column(DateTime, nullable=True)
+    expired_at = Column(DateTime, nullable=True)
+    refunded_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    action = Column(String(64), nullable=False)
+    entity_type = Column(String(32), nullable=False)
+    entity_id = Column(Integer, nullable=True)
+    details = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
 
 def init_db():

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,11 +1,19 @@
 """Payment and escrow endpoints for bounty payouts."""
 
+# Hermes Agent (jjb9707) — Escrow auto-refund implementation
+# Platform: Hermes AI Agent / DeepSeek-v4-flash
+# OS: Linux x86_64
+# Home: /home/jjb
+# Workdir: /tmp/OpenAgents
+# Session: Bounty #197 — Escrow expiry auto-refund
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
+from sqlalchemy import and_
 
-from ..models.database import get_db, Payment, Task
+from ..models.database import get_db, Payment, Task, AuditLog
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/payments", tags=["payments"])
@@ -90,6 +98,61 @@ async def claim_payment(
         "task_id": claim.task_id,
         "claimed_amount": total_claimed,
         "recipient": claim.recipient_address,
+    }
+
+
+@router.post("/process-expired")
+async def process_expired_escrows(
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """Find and refund escrows past their 30-day grace period.
+
+    - An escrow is expired if status='escrowed' AND created_at < (now - 30 days)
+    - Only expired escrows are processed
+    - Refund goes to the original payer (from_address)
+    - All actions are logged in audit_logs
+    """
+    grace_period = datetime.utcnow() - timedelta(days=30)
+
+    expired = (
+        db.query(Payment)
+        .filter(
+            and_(
+                Payment.status == "escrowed",
+                Payment.created_at < grace_period,
+                Payment.expired_at.is_(None),
+            )
+        )
+        .all()
+    )
+
+    processed = []
+    for payment in expired:
+        payment.status = "refunded"
+        payment.expired_at = datetime.utcnow()
+        payment.refunded_at = datetime.utcnow()
+        processed.append({
+            "payment_id": payment.id,
+            "task_id": payment.task_id,
+            "amount": payment.amount,
+            "refund_to": payment.from_address,
+        })
+
+        log = AuditLog(
+            action="escrow_auto_refund",
+            entity_type="payment",
+            entity_id=payment.id,
+            details=f"Escrow {payment.id} auto-refunded {payment.amount} to {payment.from_address}",
+        )
+        db.add(log)
+
+    db.commit()
+
+    return {
+        "processed": len(processed),
+        "refunds": processed,
+        "timestamp": datetime.utcnow().isoformat(),
     }
 
 

--- a/test/test_escrow_expiry.py
+++ b/test/test_escrow_expiry.py
@@ -1,0 +1,112 @@
+"""Tests for escrow auto-refund endpoint (issue #197)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+
+from api.main import app
+from api.models.database import init_db, get_db, SessionLocal, Payment, AuditLog, Base
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Use in-memory SQLite for tests
+TEST_DB_URL = "sqlite:///./test_openagents.db"
+test_engine = create_engine(TEST_DB_URL, echo=False)
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=test_engine)
+    session = TestSessionLocal()
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=test_engine)
+
+
+@pytest.fixture
+def client(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    from api.middleware.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: {
+        "id": 1, "address": "0xuser", "roles": ["admin"]
+    }
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_fresh_escrow_not_affected(client, db_session):
+    """Fresh escrow (under 30 days) should not be processed."""
+    fresh = Payment(
+        task_id=1, from_address="0xpayer", amount=100.0,
+        status="escrowed", created_at=datetime.utcnow()
+    )
+    db_session.add(fresh)
+    db_session.commit()
+
+    resp = client.post("/payments/process-expired")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["processed"] == 0
+
+
+def test_expired_escrow_refunded(client, db_session):
+    """Escrow older than 30 days should be refunded."""
+    old = Payment(
+        task_id=1, from_address="0xpayer", amount=100.0,
+        status="escrowed", created_at=datetime.utcnow() - timedelta(days=31)
+    )
+    db_session.add(old)
+    db_session.commit()
+
+    resp = client.post("/payments/process-expired")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["processed"] == 1
+    assert data["refunds"][0]["amount"] == 100.0
+    assert data["refunds"][0]["refund_to"] == "0xpayer"
+
+
+def test_already_refunded_not_processed_again(client, db_session):
+    """Already refunded escrows should not be processed."""
+    refunded = Payment(
+        task_id=1, from_address="0xpayer", amount=100.0,
+        status="refunded", created_at=datetime.utcnow() - timedelta(days=31),
+        expired_at=datetime.utcnow(), refunded_at=datetime.utcnow()
+    )
+    db_session.add(refunded)
+    db_session.commit()
+
+    resp = client.post("/payments/process-expired")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["processed"] == 0
+
+
+def test_audit_log_created(client, db_session):
+    """Each refund should create an audit log entry."""
+    old = Payment(
+        task_id=1, from_address="0xpayer", amount=50.0,
+        status="escrowed", created_at=datetime.utcnow() - timedelta(days=31)
+    )
+    db_session.add(old)
+    db_session.commit()
+
+    resp = client.post("/payments/process-expired")
+    assert resp.status_code == 200
+
+    logs = db_session.query(AuditLog).filter(
+        AuditLog.action == "escrow_auto_refund"
+    ).all()
+    assert len(logs) == 1
+    assert "50.0" in logs[0].details


### PR DESCRIPTION
## Summary

Adds escrow auto-refund mechanism with tests.

### Changes
- `POST /payments/process-expired` endpoint
- AuditLog model for tracking
- Tests: fresh escrow, expired, already refunded, audit log

## Payment
USDC on Base: 0x2FC9393BBC82CC87b9E916ba5959e48FEA24eF78

Closes #197