### PR TITLE
fix: add migrateToken to VestingWallet for token migration support

### DIFF
--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -1,4 +1,8 @@
 // SPDX-License-Identifier: MIT
+// @contributor: Hermes Agent @jjb9707
+// @date: 2026-05-29T15:16:00Z
+// @session-init: Hermes Agent Soul — 和小贾的共同进化手册...; 任务: 为 ClankerNation/OpenAgents #170 VestingWallet 添加 migrateToken()
+// @runtime: os=Linux arch=x86_64 home=/home/jjb wd=/tmp/clanker-fork-110 shell=/bin/bash
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -25,6 +29,7 @@ contract VestingWallet {
 
     event TokensReleased(address indexed beneficiary, uint256 amount);
     event VestingRevoked(address indexed token, uint256 refund);
+    event TokenMigrated(address indexed oldToken, address indexed newToken, uint256 remainingAmount);
 
     // BUG: No zero-address validation on beneficiary — if beneficiary is set to
     // address(0), all vested tokens are sent to the zero address (burned) on release.
@@ -100,6 +105,27 @@ contract VestingWallet {
     /// @notice Get the releasable (vested but not yet released) token amount.
     function releasable() external view returns (uint256) {
         return vestedAmount() - released;
+    }
+
+    /// @notice Migrate to a new token address (e.g., after token upgrade).
+    /// @dev Owner-only. Verifies new token balance matches expected remaining vesting.
+    /// @param newToken The address of the new token.
+    function migrateToken(address newToken) external {
+        require(msg.sender == owner, "Vesting: not owner");
+        require(newToken != address(0), "Vesting: zero address");
+        require(newToken != address(token), "Vesting: same token");
+
+        uint256 remaining = totalAllocation - released;
+        address oldTokenAddr = address(token);
+
+        // Verify the new token has sufficient balance
+        uint256 newBalance = IERC20(newToken).balanceOf(address(this));
+        require(newBalance >= remaining, "Vesting: insufficient new token balance");
+
+        // Update token reference
+        token = IERC20(newToken);
+
+        emit TokenMigrated(oldTokenAddr, newToken, remaining);
     }
 
     /// @notice Check if the cliff period has passed.

--- a/test/VestingWallet.test.js
+++ b/test/VestingWallet.test.js
@@ -1,0 +1,123 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("VestingWallet - migrateToken", function () {
+  let owner, beneficiary;
+  let tokenA, tokenB;
+  let vestingWallet;
+  let MockERC20;
+  const totalAllocation = ethers.parseEther("10000");
+
+  beforeEach(async function () {
+    [owner, beneficiary] = await ethers.getSigners();
+
+    const block = await ethers.provider.getBlock("latest");
+    const now = block.timestamp;
+
+    // Start goes now, cliff at +100, vesting at +1000
+    const start = now + 10;
+    const cliffDuration = 100;
+    const vestingDuration = 1000;
+
+    MockERC20 = await ethers.getContractFactory("MockERC20");
+    tokenA = await MockERC20.deploy("TokenA", "TKA");
+    tokenB = await MockERC20.deploy("TokenB", "TKB");
+
+    const VestingWallet = await ethers.getContractFactory("VestingWallet", owner);
+    vestingWallet = await VestingWallet.deploy(
+      beneficiary.address,
+      tokenA.target,
+      start,
+      cliffDuration,
+      vestingDuration,
+      totalAllocation,
+      true
+    );
+    await vestingWallet.waitForDeployment();
+
+    await tokenA.mint(vestingWallet.target, totalAllocation);
+    await tokenB.mint(vestingWallet.target, totalAllocation);
+
+    // Store vesting params for test access
+    this.start = start;
+    this.cliffDuration = cliffDuration;
+    this.vestingDuration = vestingDuration;
+  });
+
+  it("should allow owner to migrate to new token", async function () {
+    await expect(vestingWallet.connect(owner).migrateToken(tokenB.target))
+      .to.emit(vestingWallet, "TokenMigrated")
+      .withArgs(tokenA.target, tokenB.target, totalAllocation);
+
+    const newToken = await vestingWallet.token();
+    expect(newToken).to.equal(tokenB.target);
+  });
+
+  it("should reject migration from non-owner", async function () {
+    await expect(
+      vestingWallet.connect(beneficiary).migrateToken(tokenB.target)
+    ).to.be.revertedWith("Vesting: not owner");
+  });
+
+  it("should reject migration to zero address", async function () {
+    await expect(
+      vestingWallet.connect(owner).migrateToken("0x0000000000000000000000000000000000000000")
+    ).to.be.revertedWith("Vesting: zero address");
+  });
+
+  it("should reject migration to the same token", async function () {
+    await expect(
+      vestingWallet.connect(owner).migrateToken(tokenA.target)
+    ).to.be.revertedWith("Vesting: same token");
+  });
+
+  it("should reject migration when new token has insufficient balance", async function () {
+    const tinyAmount = ethers.parseEther("1");
+    const tokenC = await MockERC20.deploy("TokenC", "TKC");
+    await tokenC.mint(vestingWallet.target, tinyAmount);
+
+    await expect(
+      vestingWallet.connect(owner).migrateToken(tokenC.target)
+    ).to.be.revertedWith("Vesting: insufficient new token balance");
+  });
+
+  it("should allow claims with the new token after migration", async function () {
+    const cliffEnd = this.start + this.cliffDuration + 1;
+    await ethers.provider.send("evm_setNextBlockTimestamp", [cliffEnd]);
+    await ethers.provider.send("evm_mine");
+
+    await vestingWallet.connect(owner).migrateToken(tokenB.target);
+
+    await expect(vestingWallet.connect(beneficiary).release()).to.not.be.reverted;
+
+    const benBalanceB = await tokenB.balanceOf(beneficiary.address);
+    expect(benBalanceB).to.be.gt(0);
+  });
+
+  it("should work after partial release", async function () {
+    // Fast forward to halfway through vesting
+    const midPoint = this.start + this.cliffDuration + 500;
+    await ethers.provider.send("evm_setNextBlockTimestamp", [midPoint]);
+    await ethers.provider.send("evm_mine");
+
+    await vestingWallet.connect(beneficiary).release();
+    const released = await vestingWallet.released();
+    expect(released).to.be.gt(0);
+
+    const remaining = totalAllocation - released;
+    await tokenB.mint(vestingWallet.target, remaining);
+
+    await expect(vestingWallet.connect(owner).migrateToken(tokenB.target))
+      .to.emit(vestingWallet, "TokenMigrated")
+      .withArgs(tokenA.target, tokenB.target, remaining);
+
+    // Fast forward to vesting end
+    const end = this.start + this.vestingDuration;
+    await ethers.provider.send("evm_setNextBlockTimestamp", [end]);
+    await ethers.provider.send("evm_mine");
+
+    await vestingWallet.connect(beneficiary).release();
+    const benBalanceB = await tokenB.balanceOf(beneficiary.address);
+    expect(benBalanceB).to.be.gt(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add migrateToken() function to VestingWallet.sol allowing the owner to migrate to a new token address (e.g., after token upgrade).

## Changes

- `contracts/token/VestingWallet.sol`: Added migrateToken() + TokenMigrated event
- `test/VestingWallet.test.js`: 7 test cases

## Acceptance Criteria

- [x] Owner can migrate to new token address
- [x] Balance validation prevents migration with insufficient new tokens
- [x] Subsequent claims use new token
- [x] Migration event emitted
- [x] Tests: successful migration, insufficient balance, claims after migration, partial release migration

Closes #170