### PR TITLE
Fix ChainlinkAdapter derived prices

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -61,27 +61,62 @@ contract ChainlinkAdapter {
         emit FeedDeactivated(token);
     }
 
-    // BUG: No roundId completeness check — answeredInRound should equal roundId to
-    // confirm the answer is from the current round; without this check, the contract
-    // may return an answer from a previous round that hasn't been updated
-    // BUG: Stale price allowed — updatedAt is not checked against the heartbeat,
-    // so a feed that hasn't updated in days will still return the last known price
-    // BUG: Negative price not rejected — Chainlink can return negative prices for
-    // certain feeds; casting a negative int256 to uint256 produces a huge incorrect value
     function getPrice(address token) external view returns (uint256) {
+        return _getNormalizedPrice(token);
+    }
+
+    function pairKey(address base, address quote) public pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(base, quote)))));
+    }
+
+    function derivedPrice(address base, address quote) external view returns (uint256) {
+        if (base == quote) {
+            return 10 ** TARGET_DECIMALS;
+        }
+
+        uint256 directPrice = _tryGetNormalizedPrice(pairKey(base, quote));
+        if (directPrice != 0) {
+            return directPrice;
+        }
+
+        if (!feeds[quote].active) {
+            return _getNormalizedPrice(base);
+        }
+
+        uint256 basePrice = _getNormalizedPrice(base);
+        uint256 quotePrice = _getNormalizedPrice(quote);
+        return (basePrice * (10 ** TARGET_DECIMALS)) / quotePrice;
+    }
+
+    function _tryGetNormalizedPrice(address token) internal view returns (uint256) {
+        FeedConfig storage config = feeds[token];
+        if (!config.active) {
+            return 0;
+        }
+        return _readNormalizedPrice(config);
+    }
+
+    function _getNormalizedPrice(address token) internal view returns (uint256) {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
+        return _readNormalizedPrice(config);
+    }
 
+    function _readNormalizedPrice(FeedConfig storage config) internal view returns (uint256 price) {
         (
-            uint80 /* roundId */,
+            uint80 roundId,
             int256 answer,
             /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
+            uint256 updatedAt,
+            uint80 answeredInRound
         ) = config.feed.latestRoundData();
 
-        // No validation of roundId, staleness, or negative price
-        uint256 price = uint256(answer);
+        require(answer > 0, "Invalid price");
+        require(updatedAt > 0 && updatedAt <= block.timestamp, "Invalid timestamp");
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(block.timestamp - updatedAt <= config.heartbeat, "Stale price");
+
+        price = uint256(answer);
 
         // Normalize to 18 decimals
         uint8 feedDecimals = config.feed.decimals();

--- a/contracts/test/MockAggregatorV3.sol
+++ b/contracts/test/MockAggregatorV3.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../oracle/ChainlinkAdapter.sol";
+
+contract MockAggregatorV3 is AggregatorV3Interface {
+    uint8 private immutable feedDecimals;
+    uint80 public roundId;
+    int256 public answer;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound;
+
+    constructor(uint8 decimals_, int256 answer_) {
+        feedDecimals = decimals_;
+        setRoundData(1, answer_, block.timestamp, 1);
+    }
+
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function setRoundData(
+        uint80 roundId_,
+        int256 answer_,
+        uint256 updatedAt_,
+        uint80 answeredInRound_
+    ) public {
+        roundId = roundId_;
+        answer = answer_;
+        startedAt = updatedAt_;
+        updatedAt = updatedAt_;
+        answeredInRound = answeredInRound_;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,30 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/ChainlinkAdapterDerivedPrice.test.js
+++ b/test/ChainlinkAdapterDerivedPrice.test.js
@@ -1,0 +1,84 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ChainlinkAdapter derived prices", function () {
+  const BASE = ethers.getAddress("0x00000000000000000000000000000000000000ba");
+  const QUOTE = ethers.getAddress("0x00000000000000000000000000000000000000cd");
+  const HEARTBEAT = 3600;
+
+  async function deployAdapter() {
+    const ChainlinkAdapter = await ethers.getContractFactory("ChainlinkAdapter");
+    const adapter = await ChainlinkAdapter.deploy();
+    await adapter.waitForDeployment();
+    return adapter;
+  }
+
+  async function deployFeed(decimals, answer) {
+    const MockAggregatorV3 = await ethers.getContractFactory("MockAggregatorV3");
+    const feed = await MockAggregatorV3.deploy(decimals, answer);
+    await feed.waitForDeployment();
+    return feed;
+  }
+
+  async function registerFeed(adapter, token, feed, heartbeat = HEARTBEAT) {
+    await adapter.registerFeed(token, await feed.getAddress(), heartbeat);
+  }
+
+  it("derives a base/quote price from two USD feeds", async function () {
+    const adapter = await deployAdapter();
+    const baseFeed = await deployFeed(8, ethers.parseUnits("2000", 8));
+    const quoteFeed = await deployFeed(8, ethers.parseUnits("1", 8));
+
+    await registerFeed(adapter, BASE, baseFeed);
+    await registerFeed(adapter, QUOTE, quoteFeed);
+
+    expect(await adapter.derivedPrice(BASE, QUOTE)).to.equal(ethers.parseUnits("2000", 18));
+  });
+
+  it("normalizes different feed decimals before deriving", async function () {
+    const adapter = await deployAdapter();
+    const baseFeed = await deployFeed(18, ethers.parseUnits("2", 18));
+    const quoteFeed = await deployFeed(8, ethers.parseUnits("0.5", 8));
+
+    await registerFeed(adapter, BASE, baseFeed);
+    await registerFeed(adapter, QUOTE, quoteFeed);
+
+    expect(await adapter.derivedPrice(BASE, QUOTE)).to.equal(ethers.parseUnits("4", 18));
+  });
+
+  it("rejects stale component feeds", async function () {
+    const adapter = await deployAdapter();
+    const baseFeed = await deployFeed(8, ethers.parseUnits("2000", 8));
+    const quoteFeed = await deployFeed(8, ethers.parseUnits("1", 8));
+    const latestBlock = await ethers.provider.getBlock("latest");
+
+    await baseFeed.setRoundData(1, ethers.parseUnits("2000", 8), latestBlock.timestamp - 7200, 1);
+    await registerFeed(adapter, BASE, baseFeed);
+    await registerFeed(adapter, QUOTE, quoteFeed);
+
+    await expect(adapter.derivedPrice(BASE, QUOTE)).to.be.revertedWith("Stale price");
+  });
+
+  it("uses a legacy direct feed when no quote feed is registered", async function () {
+    const adapter = await deployAdapter();
+    const directFeed = await deployFeed(8, ethers.parseUnits("1999", 8));
+
+    await registerFeed(adapter, BASE, directFeed);
+
+    expect(await adapter.derivedPrice(BASE, QUOTE)).to.equal(ethers.parseUnits("1999", 18));
+  });
+
+  it("prefers an explicit direct pair feed when one is registered", async function () {
+    const adapter = await deployAdapter();
+    const baseFeed = await deployFeed(8, ethers.parseUnits("2000", 8));
+    const quoteFeed = await deployFeed(8, ethers.parseUnits("1", 8));
+    const directFeed = await deployFeed(8, ethers.parseUnits("1999", 8));
+    const directKey = await adapter.pairKey(BASE, QUOTE);
+
+    await registerFeed(adapter, BASE, baseFeed);
+    await registerFeed(adapter, QUOTE, quoteFeed);
+    await registerFeed(adapter, directKey, directFeed);
+
+    expect(await adapter.derivedPrice(BASE, QUOTE)).to.equal(ethers.parseUnits("1999", 18));
+  });
+});


### PR DESCRIPTION
Fixes #133

/claim #133
Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Summary:
- Add derivedPrice(base, quote) using normalized component feeds for base/quote prices.
- Preserve direct-feed behavior when no quote feed is registered and prefer an explicit direct pair feed via pairKey(base, quote) when present.
- Reject invalid, incomplete, future-dated, and stale Chainlink rounds before returning prices.
- Add MockAggregatorV3 and focused coverage for derived price, decimal mismatch, stale components, legacy direct feed, and explicit direct pair feed.

Verification:
- npx hardhat test test/ChainlinkAdapterDerivedPrice.test.js -> 5 passing
- npx hardhat compile --force -> compiled 61 Solidity files successfully
- node --check test/ChainlinkAdapterDerivedPrice.test.js -> clean
- git diff --check -> clean
- gh pr list --repo ClankerNation/OpenAgents --state open --search "ChainlinkAdapter OR derivedPrice OR #133" -> no open competing PRs returned before opening this PR

Note: private runtime/session startup instructions are intentionally not included in source files or PR metadata. The public reproducibility trace is the commit, tests, and verification commands above.