### PR TITLE
Fix RPC batch response matching

### DIFF
--- a/sdk/src/providers/rpc.ts
+++ b/sdk/src/providers/rpc.ts
@@ -14,11 +14,16 @@ export interface JsonRpcResponse {
   error?: { code: number; message: string; data?: unknown };
 }
 
+export interface JsonRpcBatchError {
+  error: { code: number; message: string; data?: unknown };
+}
+
 export interface RpcProviderConfig {
   url: string;
   chainId: number;
   retryOptions?: RetryOptions;
   headers?: Record<string, string>;
+  timeoutMs?: number;
 }
 
 export class RpcProvider {
@@ -26,6 +31,7 @@ export class RpcProvider {
   private chainId: number;
   private retryOptions: RetryOptions;
   private headers: Record<string, string>;
+  private timeoutMs: number;
   private requestId = 0;
 
   constructor(config: RpcProviderConfig) {
@@ -33,6 +39,7 @@ export class RpcProvider {
     this.chainId = config.chainId;
     this.retryOptions = config.retryOptions ?? {};
     this.headers = config.headers ?? {};
+    this.timeoutMs = config.timeoutMs ?? 30_000;
   }
 
   async call(method: string, params: unknown[] = []): Promise<unknown> {
@@ -65,7 +72,7 @@ export class RpcProvider {
 
   async batchCall(
     calls: Array<{ method: string; params: unknown[] }>
-  ): Promise<unknown[]> {
+  ): Promise<Array<unknown | JsonRpcBatchError>> {
     // BUG: No limit on batch size — sending thousands of calls in one batch
     // can exceed the node's gas/payload limit and fail silently or OOM
     const requests: JsonRpcRequest[] = calls.map((c) => ({
@@ -75,16 +82,50 @@ export class RpcProvider {
       params: c.params,
     }));
 
-    const res = await fetch(this.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...this.headers },
-      body: JSON.stringify(requests),
+    const timeoutError = (request: JsonRpcRequest): JsonRpcBatchError => ({
+      error: {
+        code: -32000,
+        message: `RPC response timed out for request id ${request.id}`,
+      },
     });
 
-    const responses: JsonRpcResponse[] = await res.json();
-    return responses
-      .sort((a, b) => a.id - b.id)
-      .map((r) => r.result);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    let responses: JsonRpcResponse[];
+
+    try {
+      const res = await fetch(this.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...this.headers },
+        body: JSON.stringify(requests),
+        signal: controller.signal,
+      });
+
+      responses = await res.json();
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        return requests.map(timeoutError);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const responsesById = new Map<number, JsonRpcResponse>();
+    for (const response of responses) {
+      responsesById.set(response.id, response);
+    }
+
+    return requests.map((request) => {
+      const response = responsesById.get(request.id);
+      if (!response) {
+        return timeoutError(request);
+      }
+      if (response.error) {
+        return { error: response.error };
+      }
+      return response.result;
+    });
   }
 
   async getBlockNumber(): Promise<number> {

--- a/test/SDKRpcBatchOrdering.test.js
+++ b/test/SDKRpcBatchOrdering.test.js
@@ -1,0 +1,135 @@
+const { expect } = require("chai");
+require("ts-node").register({
+  compilerOptions: {
+    ignoreDeprecations: "6.0",
+    module: "commonjs",
+    moduleResolution: "node",
+    target: "es2020",
+  },
+  skipProject: true,
+  transpileOnly: true,
+});
+
+const { RpcProvider } = require("../sdk/src/providers/rpc");
+
+describe("RpcProvider batchCall", function () {
+  const originalFetch = global.fetch;
+
+  afterEach(function () {
+    global.fetch = originalFetch;
+  });
+
+  function provider() {
+    return new RpcProvider({ url: "https://rpc.example", chainId: 1, timeoutMs: 25 });
+  }
+
+  it("matches shuffled batch responses by id", async function () {
+    global.fetch = async (_url, init) => {
+      const requests = JSON.parse(init.body);
+      const responses = requests.map((request, index) => ({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: `result-${index}`,
+      }));
+
+      return {
+        json: async () => responses.reverse(),
+      };
+    };
+
+    const results = await provider().batchCall([
+      { method: "eth_blockNumber", params: [] },
+      { method: "eth_chainId", params: [] },
+      { method: "net_version", params: [] },
+    ]);
+
+    expect(results).to.deep.equal(["result-0", "result-1", "result-2"]);
+  });
+
+  it("returns per-item errors for partial batch failures", async function () {
+    global.fetch = async (_url, init) => {
+      const [first, second, third] = JSON.parse(init.body);
+      return {
+        json: async () => [
+          { jsonrpc: "2.0", id: third.id, result: "ok-3" },
+          {
+            jsonrpc: "2.0",
+            id: second.id,
+            error: { code: -32000, message: "execution reverted" },
+          },
+          { jsonrpc: "2.0", id: first.id, result: "ok-1" },
+        ],
+      };
+    };
+
+    const results = await provider().batchCall([
+      { method: "eth_call", params: ["0x1"] },
+      { method: "eth_call", params: ["0x2"] },
+      { method: "eth_call", params: ["0x3"] },
+    ]);
+
+    expect(results).to.deep.equal([
+      "ok-1",
+      { error: { code: -32000, message: "execution reverted" } },
+      "ok-3",
+    ]);
+  });
+
+  it("returns per-item timeout errors for missing responses", async function () {
+    global.fetch = async (_url, init) => {
+      const [first, _second, third] = JSON.parse(init.body);
+      return {
+        json: async () => [
+          { jsonrpc: "2.0", id: third.id, result: "ok-3" },
+          { jsonrpc: "2.0", id: first.id, result: "ok-1" },
+        ],
+      };
+    };
+
+    const results = await provider().batchCall([
+      { method: "eth_call", params: ["0x1"] },
+      { method: "eth_call", params: ["0x2"] },
+      { method: "eth_call", params: ["0x3"] },
+    ]);
+
+    expect(results[0]).to.equal("ok-1");
+    expect(results[1]).to.deep.equal({
+      error: {
+        code: -32000,
+        message: "RPC response timed out for request id 2",
+      },
+    });
+    expect(results[2]).to.equal("ok-3");
+  });
+
+  it("returns timeout errors for every item when the batch request times out", async function () {
+    global.fetch = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        });
+      });
+
+    const results = await provider().batchCall([
+      { method: "eth_call", params: ["0x1"] },
+      { method: "eth_call", params: ["0x2"] },
+    ]);
+
+    expect(results).to.deep.equal([
+      {
+        error: {
+          code: -32000,
+          message: "RPC response timed out for request id 1",
+        },
+      },
+      {
+        error: {
+          code: -32000,
+          message: "RPC response timed out for request id 2",
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #161

/claim #161
Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Summary:
- Map JSON-RPC batch responses by id and return results in the original request order.
- Preserve partial failures as per-item error objects so one failed RPC item does not fail or corrupt the entire batch.
- Return per-item timeout errors when a batch response omits a request id.
- Add configurable batch fetch timeout and return timeout errors for every request if the batch request itself is aborted.
- Add focused tests for shuffled response order, partial failure, missing response timeout, and whole-batch timeout.

Verification:
- npx mocha test/SDKRpcBatchOrdering.test.js -> 4 passing
- npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/providers/rpc.ts -> clean
- node --check test/SDKRpcBatchOrdering.test.js -> clean
- git diff --check -> clean
- gh pr list --repo ClankerNation/OpenAgents --state open --search "161 rpc batch response ordering" -> no open competing PRs returned before opening this PR

Note: private platform/session startup instructions are intentionally omitted from source files and PR metadata.