### PR TITLE
Fix dynamic ABI decoding

### DIFF
--- a/sdk/src/utils/encoding.ts
+++ b/sdk/src/utils/encoding.ts
@@ -2,11 +2,25 @@
  * ABI encoding/decoding utilities for EVM-compatible contract interactions.
  */
 
-export type AbiType = "uint256" | "address" | "bytes32" | "string" | "bool";
+export type AbiType =
+  | "uint256"
+  | "address"
+  | "bytes32"
+  | "string"
+  | "bytes"
+  | "bool"
+  | "tuple"
+  | `${string}[]`;
 
 export interface AbiParam {
   type: AbiType;
   value: string | number | bigint | boolean;
+  components?: AbiTypeDescriptor[];
+}
+
+export interface AbiTypeDescriptor {
+  type: AbiType;
+  components?: AbiTypeDescriptor[];
 }
 
 export function encodeUint256(value: bigint | number): string {
@@ -74,6 +88,129 @@ export function decodeAddress(slot: string): string {
 
 export function decodeBool(slot: string): boolean {
   return BigInt("0x" + slot) !== 0n;
+}
+
+function stripHexPrefix(hex: string): string {
+  return hex.startsWith("0x") ? hex.slice(2) : hex;
+}
+
+function readWord(data: string, byteOffset: number): string {
+  const hex = stripHexPrefix(data);
+  const start = byteOffset * 2;
+  return hex.slice(start, start + 64).padStart(64, "0");
+}
+
+function readUint(data: string, byteOffset: number): bigint {
+  return BigInt("0x" + readWord(data, byteOffset));
+}
+
+function normalizeDescriptor(type: AbiType | AbiTypeDescriptor): AbiTypeDescriptor {
+  return typeof type === "string" ? { type } : type;
+}
+
+function isDynamicType(type: AbiTypeDescriptor): boolean {
+  if (type.type === "string" || type.type === "bytes" || type.type.endsWith("[]")) {
+    return true;
+  }
+  if (type.type === "tuple") {
+    return type.components?.some(isDynamicType) ?? false;
+  }
+  return false;
+}
+
+function decodeStatic(type: AbiTypeDescriptor, data: string, byteOffset: number): unknown {
+  const word = readWord(data, byteOffset);
+
+  switch (type.type) {
+    case "uint256":
+      return BigInt("0x" + word);
+    case "address":
+      return "0x" + word.slice(24).toLowerCase();
+    case "bytes32":
+      return "0x" + word;
+    case "bool":
+      return BigInt("0x" + word) !== 0n;
+    case "tuple":
+      return decodeTuple(type, data, byteOffset, byteOffset);
+    default:
+      throw new Error(`Unsupported static ABI type: ${type.type}`);
+  }
+}
+
+function decodeBytesAt(data: string, byteOffset: number): Buffer {
+  const hex = stripHexPrefix(data);
+  const length = Number(readUint(data, byteOffset));
+  const start = (byteOffset + 32) * 2;
+  return Buffer.from(hex.slice(start, start + length * 2), "hex");
+}
+
+function decodeArray(type: AbiTypeDescriptor, data: string, slotOffset: number, baseOffset: number): unknown[] {
+  const elementType = type.type.slice(0, -2) as AbiType;
+  const elementDescriptor: AbiTypeDescriptor =
+    elementType === "tuple"
+      ? { type: elementType, components: type.components }
+      : { type: elementType };
+  const arrayOffset = Number(readUint(data, slotOffset));
+  const arrayStart = baseOffset + arrayOffset;
+  const length = Number(readUint(data, arrayStart));
+  const values: unknown[] = [];
+
+  for (let i = 0; i < length; i++) {
+    const elementSlot = arrayStart + 32 + i * 32;
+    values.push(decodeType(elementDescriptor, data, elementSlot, arrayStart));
+  }
+
+  return values;
+}
+
+function decodeTuple(type: AbiTypeDescriptor, data: string, slotOffset: number, baseOffset: number): unknown[] {
+  const components = type.components ?? [];
+  const tupleStart = isDynamicType(type) ? baseOffset + Number(readUint(data, slotOffset)) : slotOffset;
+
+  return components.map((component, index) =>
+    decodeType(component, data, tupleStart + index * 32, tupleStart)
+  );
+}
+
+function decodeType(type: AbiTypeDescriptor, data: string, slotOffset: number, baseOffset: number): unknown {
+  if (!isDynamicType(type)) {
+    return decodeStatic(type, data, slotOffset);
+  }
+
+  if (type.type === "string") {
+    return decodeBytesAt(data, baseOffset + Number(readUint(data, slotOffset))).toString("utf8");
+  }
+
+  if (type.type === "bytes") {
+    return decodeBytesAt(data, baseOffset + Number(readUint(data, slotOffset)));
+  }
+
+  if (type.type.endsWith("[]")) {
+    return decodeArray(type, data, slotOffset, baseOffset);
+  }
+
+  if (type.type === "tuple") {
+    return decodeTuple(type, data, slotOffset, baseOffset);
+  }
+
+  throw new Error(`Unsupported ABI type: ${type.type}`);
+}
+
+export function decodeParameter(type: AbiType | AbiTypeDescriptor, data: string): unknown {
+  const descriptor = normalizeDescriptor(type);
+  if (descriptor.type === "tuple" && isDynamicType(descriptor)) {
+    const hexLength = stripHexPrefix(data).length / 2;
+    const possibleOffset = Number(readUint(data, 0));
+    if (possibleOffset < hexLength && possibleOffset % 32 === 0) {
+      return decodeType(descriptor, data, 0, 0);
+    }
+    return decodeTuple(descriptor, data, 0, 0);
+  }
+  return decodeType(descriptor, data, 0, 0);
+}
+
+export function decodeParams(types: Array<AbiType | AbiTypeDescriptor>, data: string): unknown[] {
+  return types.map((type, index) => decodeType(normalizeDescriptor(type), data, index * 32, 0));
 }
 
 export function functionSelector(signature: string): string {

--- a/test/SDKAbiDynamicDecode.test.js
+++ b/test/SDKAbiDynamicDecode.test.js
@@ -1,0 +1,98 @@
+const { expect } = require("chai");
+require("ts-node").register({
+  compilerOptions: {
+    ignoreDeprecations: "6.0",
+    module: "commonjs",
+    moduleResolution: "node",
+    target: "es2020",
+  },
+  skipProject: true,
+  transpileOnly: true,
+});
+
+const { decodeParameter, decodeParams } = require("../sdk/src/utils/encoding");
+
+function word(value) {
+  return BigInt(value).toString(16).padStart(64, "0");
+}
+
+function utf8Hex(value) {
+  return Buffer.from(value, "utf8").toString("hex");
+}
+
+function dynamicBytes(valueHex) {
+  const clean = valueHex.startsWith("0x") ? valueHex.slice(2) : valueHex;
+  const paddedLength = Math.ceil(clean.length / 64) * 64;
+  return word(clean.length / 2) + clean.padEnd(paddedLength, "0");
+}
+
+describe("ABI dynamic decoding", function () {
+  it("decodes a complex return type with string, array, and uint", function () {
+    const encoded =
+      "0x" +
+      word(0x60) +
+      word(0xa0) +
+      word(7) +
+      dynamicBytes(utf8Hex("agent")) +
+      word(3) +
+      word(1) +
+      word(2) +
+      word(3);
+
+    const decoded = decodeParams(["string", "uint256[]", "uint256"], encoded);
+
+    expect(decoded).to.deep.equal(["agent", [1n, 2n, 3n], 7n]);
+  });
+
+  it("decodes bytes to a Buffer", function () {
+    const encoded = "0x" + word(0x20) + dynamicBytes("1234abcd");
+
+    const decoded = decodeParameter("bytes", encoded);
+
+    expect(Buffer.isBuffer(decoded)).to.equal(true);
+    expect(decoded.toString("hex")).to.equal("1234abcd");
+  });
+
+  it("decodes nested tuples recursively", function () {
+    const tuple = {
+      type: "tuple",
+      components: [
+        { type: "uint256" },
+        {
+          type: "tuple",
+          components: [{ type: "string" }, { type: "uint256[]" }],
+        },
+      ],
+    };
+    const encoded =
+      "0x" +
+      word(0x20) +
+      word(42) +
+      word(0x40) +
+      word(0x40) +
+      word(0x80) +
+      dynamicBytes(utf8Hex("nested")) +
+      word(2) +
+      word(8) +
+      word(13);
+
+    const decoded = decodeParameter(tuple, encoded);
+
+    expect(decoded).to.deep.equal([42n, ["nested", [8n, 13n]]]);
+  });
+
+  it("decodes dynamic arrays of dynamic values", function () {
+    const encoded =
+      "0x" +
+      word(0x20) +
+      word(2) +
+      word(0x60) +
+      word(0xa0) +
+      dynamicBytes(utf8Hex("alpha")) +
+      dynamicBytes(utf8Hex("beta"));
+
+    const decoded = decodeParameter("string[]", encoded);
+
+    expect(decoded).to.deep.equal(["alpha", "beta"]);
+  });
+});


### PR DESCRIPTION
Fixes #198

/claim #198
Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Summary:
- Add decodeParameter and decodeParams helpers for ABI return decoding.
- Decode string values through offset/length UTF-8 payloads.
- Decode bytes values as Buffer instances.
- Decode dynamic arrays, including arrays of dynamic values.
- Decode nested tuple descriptors recursively.
- Add focused tests for complex string + array + uint returns, bytes Buffer decoding, nested tuples, and string arrays.

Verification:
- npx mocha test/SDKAbiDynamicDecode.test.js -> 4 passing
- npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/utils/encoding.ts -> clean
- node --check test/SDKAbiDynamicDecode.test.js -> clean
- git diff --check -> clean
- gh pr list --repo ClankerNation/OpenAgents --state open --search "198 encoding decodeParameter dynamic types" -> no open competing PRs returned before opening this PR

Note: private platform/session startup instructions are intentionally omitted from source files and PR metadata.