### PR TITLE
sdk: add contract deployment helper

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,18 @@ export interface AgentConfig {
   routerAddress: string;
 }
 
+export interface DeploymentOptions {
+  confirmations?: number;
+}
+
+export interface DeploymentResult {
+  contract: ethers.BaseContract;
+  address: string;
+  txHash: string;
+  gasUsed: bigint;
+  receipt: ethers.TransactionReceipt;
+}
+
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
@@ -18,6 +30,43 @@ export class OpenAgentsSDK {
     this.config = config;
     this.provider = new ethers.JsonRpcProvider(config.rpcUrl);
     this.signer = new ethers.Wallet(config.privateKey, this.provider);
+  }
+
+  async deployContract(
+    abi: ethers.InterfaceAbi,
+    bytecode: ethers.BytesLike,
+    args: unknown[] = [],
+    options: DeploymentOptions = {}
+  ): Promise<DeploymentResult> {
+    const confirmations = options.confirmations ?? 1;
+    const factory = this.createContractFactory(abi, bytecode);
+    const contract = await factory.deploy(...args);
+    await contract.waitForDeployment();
+
+    const deploymentTx = contract.deploymentTransaction();
+    if (!deploymentTx) {
+      throw new Error("Deployment transaction unavailable");
+    }
+
+    const receipt = await deploymentTx.wait(confirmations);
+    if (!receipt) {
+      throw new Error("Deployment receipt unavailable");
+    }
+
+    return {
+      contract,
+      address: await contract.getAddress(),
+      txHash: deploymentTx.hash,
+      gasUsed: receipt.gasUsed,
+      receipt,
+    };
+  }
+
+  protected createContractFactory(
+    abi: ethers.InterfaceAbi,
+    bytecode: ethers.BytesLike
+  ): ethers.ContractFactory {
+    return new ethers.ContractFactory(abi, bytecode, this.signer);
   }
 
   async registerAgent(): Promise<string> {

--- a/test/SDKDeployContract.test.js
+++ b/test/SDKDeployContract.test.js
@@ -1,0 +1,95 @@
+process.env.TS_NODE_IGNORE_DIAGNOSTICS = "5102";
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+});
+
+require("ts-node/register/transpile-only");
+
+const { expect } = require("chai");
+const { OpenAgentsSDK } = require("../sdk/src/index.ts");
+
+const sdkConfig = {
+  name: "agent",
+  endpoint: "https://agent.example",
+  privateKey: "0x".padEnd(66, "1"),
+  rpcUrl: "http://127.0.0.1:8545",
+  registryAddress: "0x0000000000000000000000000000000000000001",
+  routerAddress: "0x0000000000000000000000000000000000000002",
+};
+
+describe("OpenAgentsSDK.deployContract", function () {
+  it("deploys with constructor args and returns deployment metadata", async function () {
+    const deployedAddress = "0x00000000000000000000000000000000000000aa";
+    const receipt = { gasUsed: 123456n };
+    const calls = { args: null, confirmations: null, waited: false };
+
+    class TestSDK extends OpenAgentsSDK {
+      createContractFactory(abi, bytecode) {
+        calls.abi = abi;
+        calls.bytecode = bytecode;
+        return {
+          deploy: async (...args) => {
+            calls.args = args;
+            return {
+              waitForDeployment: async () => {
+                calls.waited = true;
+              },
+              deploymentTransaction: () => ({
+                hash: "0xabc123",
+                wait: async (confirmations) => {
+                  calls.confirmations = confirmations;
+                  return receipt;
+                },
+              }),
+              getAddress: async () => deployedAddress,
+            };
+          },
+        };
+      }
+    }
+
+    const abi = ["constructor(uint256,string)"];
+    const bytecode = "0x60006000";
+    const sdk = new TestSDK(sdkConfig);
+
+    const result = await sdk.deployContract(abi, bytecode, [42n, "hello"], { confirmations: 3 });
+
+    expect(calls.abi).to.equal(abi);
+    expect(calls.bytecode).to.equal(bytecode);
+    expect(calls.args).to.deep.equal([42n, "hello"]);
+    expect(calls.waited).to.equal(true);
+    expect(calls.confirmations).to.equal(3);
+    expect(result.address).to.equal(deployedAddress);
+    expect(result.txHash).to.equal("0xabc123");
+    expect(result.gasUsed).to.equal(123456n);
+    expect(result.receipt).to.equal(receipt);
+  });
+
+  it("waits for one confirmation by default", async function () {
+    let confirmations;
+
+    class TestSDK extends OpenAgentsSDK {
+      createContractFactory() {
+        return {
+          deploy: async () => ({
+            waitForDeployment: async () => {},
+            deploymentTransaction: () => ({
+              hash: "0xdef456",
+              wait: async (count) => {
+                confirmations = count;
+                return { gasUsed: 1n };
+              },
+            }),
+            getAddress: async () => "0x00000000000000000000000000000000000000bb",
+          }),
+        };
+      }
+    }
+
+    const sdk = new TestSDK(sdkConfig);
+    await sdk.deployContract([], "0x6000");
+
+    expect(confirmations).to.equal(1);
+  });
+});


### PR DESCRIPTION
Fixes #191
/claim #191

## Summary
- adds OpenAgentsSDK.deployContract(abi, bytecode, args, options)
- uses ethers ContractFactory with the SDK signer and waits for deployment
- supports configurable confirmation count, defaulting to 1
- returns the deployed contract, address, transaction hash, gas used, and full receipt
- adds focused SDK tests for constructor args and confirmation waiting

## Verification
- `npx mocha test/SDKDeployContract.test.js` -> 2 passing
- `npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/index.ts`
- `node --check test/SDKDeployContract.test.js`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.