### PR TITLE
sdk: add conditional retry policy

### DIFF
--- a/sdk/src/utils/retry.ts
+++ b/sdk/src/utils/retry.ts
@@ -7,22 +7,28 @@ export interface RetryOptions {
   baseDelayMs?: number;
   maxDelayMs?: number;
   onRetry?: (attempt: number, error: Error) => void;
+  retryCondition?: (error: Error) => boolean;
+  backoffMultiplier?: (error: Error) => number;
 }
 
-const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "onRetry">> = {
+const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "onRetry" | "retryCondition" | "backoffMultiplier">> = {
   maxRetries: Infinity, // BUG: No cap — will retry forever by default
   baseDelayMs: 500,
   maxDelayMs: 30_000,
 };
 
 export class RetryHandler {
-  private options: Required<Omit<RetryOptions, "onRetry">>;
+  private options: Required<Omit<RetryOptions, "onRetry" | "retryCondition" | "backoffMultiplier">>;
   private onRetry?: (attempt: number, error: Error) => void;
+  private retryCondition: (error: Error) => boolean;
+  private backoffMultiplier: (error: Error) => number;
   private consecutiveFailures = 0;
 
   constructor(options: RetryOptions = {}) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.onRetry = options.onRetry;
+    this.retryCondition = options.retryCondition ?? isRetryable;
+    this.backoffMultiplier = options.backoffMultiplier ?? defaultBackoffMultiplier;
   }
 
   async execute<T>(fn: () => Promise<T>): Promise<T> {
@@ -31,17 +37,18 @@ export class RetryHandler {
     for (let attempt = 0; attempt <= this.options.maxRetries; attempt++) {
       try {
         const result = await fn();
-        // BUG: consecutiveFailures is never reset on success,
-        // so backoff keeps growing even after recovery
+        this.consecutiveFailures = 0;
         return result;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         this.consecutiveFailures++;
 
-        if (attempt < this.options.maxRetries) {
+        if (attempt < this.options.maxRetries && this.retryCondition(lastError)) {
           this.onRetry?.(attempt + 1, lastError);
-          const delay = this.calculateBackoff(attempt);
+          const delay = this.calculateBackoff(attempt, lastError);
           await this.sleep(delay);
+        } else {
+          throw lastError;
         }
       }
     }
@@ -49,12 +56,12 @@ export class RetryHandler {
     throw lastError ?? new Error("Retry failed with unknown error");
   }
 
-  private calculateBackoff(attempt: number): number {
+  private calculateBackoff(attempt: number, error: Error): number {
     // BUG: 2 ** attempt overflows to Infinity for large attempt values (attempt > ~1023),
     // and Math.min with Infinity returns maxDelayMs, but intermediate calc can cause issues
     const exponentialDelay = this.options.baseDelayMs * Math.pow(2, attempt);
     const jitter = Math.random() * this.options.baseDelayMs;
-    return Math.min(exponentialDelay + jitter, this.options.maxDelayMs);
+    return Math.min((exponentialDelay + jitter) * this.backoffMultiplier(error), this.options.maxDelayMs);
   }
 
   private sleep(ms: number): Promise<void> {
@@ -79,9 +86,37 @@ export async function withRetry<T>(
 }
 
 export function isRetryable(error: Error): boolean {
-  const retryableCodes = ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "429"];
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    if (status === 429) return true;
+    if (status >= 400 && status < 500) return false;
+    if (status >= 500 && status < 600) return true;
+  }
+
+  const retryableCodes = ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "ECONNABORTED", "429", "fetch failed", "network"];
   const message = error.message.toLowerCase();
   return retryableCodes.some(
     (code) => message.includes(code.toLowerCase())
   );
+}
+
+export function defaultBackoffMultiplier(error: Error): number {
+  const status = getErrorStatus(error);
+  if (status === 429) return 2;
+  if (status !== undefined && status >= 500) return 1.5;
+  return 1;
+}
+
+function getErrorStatus(error: Error): number | undefined {
+  const maybeStatus = (error as Error & { status?: unknown; statusCode?: unknown; code?: unknown }).status ??
+    (error as Error & { statusCode?: unknown }).statusCode ??
+    (error as Error & { code?: unknown }).code;
+
+  if (typeof maybeStatus === "number") return maybeStatus;
+  if (typeof maybeStatus === "string" && /^\d+$/.test(maybeStatus)) {
+    return Number(maybeStatus);
+  }
+
+  const match = error.message.match(/\b([1-5]\d\d)\b/);
+  return match ? Number(match[1]) : undefined;
 }

--- a/test/SDKRetryConditional.test.js
+++ b/test/SDKRetryConditional.test.js
@@ -1,0 +1,87 @@
+process.env.TS_NODE_IGNORE_DIAGNOSTICS = "5102";
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+});
+
+require("ts-node/register/transpile-only");
+
+const { expect } = require("chai");
+const { withRetry, isRetryable } = require("../sdk/src/utils/retry.ts");
+
+function httpError(status) {
+  const error = new Error(`HTTP ${status}`);
+  error.status = status;
+  return error;
+}
+
+describe("conditional retry", function () {
+  it("retries 5xx errors and calls onRetry", async function () {
+    let attempts = 0;
+    const retries = [];
+
+    const result = await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) throw httpError(500);
+        return "ok";
+      },
+      {
+        maxRetries: 3,
+        baseDelayMs: 0,
+        onRetry: (attempt, error) => retries.push([attempt, error.status]),
+      }
+    );
+
+    expect(result).to.equal("ok");
+    expect(attempts).to.equal(3);
+    expect(retries).to.deep.equal([[1, 500], [2, 500]]);
+  });
+
+  it("does not retry 400-class errors by default", async function () {
+    let attempts = 0;
+    let thrown;
+
+    try {
+      await withRetry(
+        async () => {
+          attempts += 1;
+          throw httpError(400);
+        },
+        { maxRetries: 3, baseDelayMs: 0 }
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown.message).to.equal("HTTP 400");
+    expect(attempts).to.equal(1);
+  });
+
+  it("allows custom retry conditions to override the default", async function () {
+    let attempts = 0;
+
+    const result = await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 2) throw httpError(400);
+        return "custom";
+      },
+      {
+        maxRetries: 2,
+        baseDelayMs: 0,
+        retryCondition: (error) => error.status === 400,
+      }
+    );
+
+    expect(result).to.equal("custom");
+    expect(attempts).to.equal(2);
+  });
+
+  it("classifies network and HTTP status errors", function () {
+    expect(isRetryable(Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" }))).to.equal(true);
+    expect(isRetryable(httpError(429))).to.equal(true);
+    expect(isRetryable(httpError(503))).to.equal(true);
+    expect(isRetryable(httpError(404))).to.equal(false);
+  });
+});


### PR DESCRIPTION
Fixes #137
/claim #137

## Summary
- adds `retryCondition(error)` to control which failures are retried
- defaults to retrying network failures, 429, and 5xx responses while failing 4xx immediately
- keeps `onRetry(attempt, error)` callbacks for logging
- adds per-error backoff multipliers through `backoffMultiplier(error)` plus defaults for 429/5xx
- resets consecutive failure count after a successful attempt
- adds focused tests for 500 retry, 400 fail-fast, custom condition override, and classifier behavior

## Verification
- `npx mocha test/SDKRetryConditional.test.js` -> 4 passing
- `npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/utils/retry.ts`
- `node --check test/SDKRetryConditional.test.js`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.