### PR TITLE
sdk: clean websocket handlers on reconnect

### DIFF
--- a/sdk/src/providers/websocket.ts
+++ b/sdk/src/providers/websocket.ts
@@ -4,6 +4,7 @@ export interface WsProviderConfig {
   url: string;
   reconnectIntervalMs?: number;
   maxReconnectAttempts?: number;
+  listenerWarningThreshold?: number;
 }
 
 interface PendingRequest {
@@ -19,6 +20,7 @@ export class WebSocketProvider extends EventEmitter {
   private subscriptions = new Map<string, (data: unknown) => void>();
   private reconnectInterval: number;
   private maxReconnectAttempts: number;
+  private listenerWarningThreshold: number;
   private reconnectCount = 0;
   private isConnected = false;
 
@@ -27,13 +29,19 @@ export class WebSocketProvider extends EventEmitter {
     this.url = config.url;
     this.reconnectInterval = config.reconnectIntervalMs ?? 3000;
     this.maxReconnectAttempts = config.maxReconnectAttempts ?? 10;
+    this.listenerWarningThreshold = config.listenerWarningThreshold ?? 10;
   }
 
   async connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url);
+      this.cleanupSocket();
 
-      this.ws.onopen = () => {
+      const socket = new WebSocket(this.url);
+      this.ws = socket;
+      this.warnIfListenerCountIsHigh();
+
+      socket.onopen = () => {
+        if (this.ws !== socket) return;
         this.isConnected = true;
         this.reconnectCount = 0;
         // BUG: No heartbeat/ping mechanism — connection can silently die
@@ -42,7 +50,8 @@ export class WebSocketProvider extends EventEmitter {
         resolve();
       };
 
-      this.ws.onmessage = (event) => {
+      socket.onmessage = (event) => {
+        if (this.ws !== socket) return;
         const data = JSON.parse(event.data as string);
         if (data.id && this.pendingRequests.has(data.id)) {
           const pending = this.pendingRequests.get(data.id)!;
@@ -54,7 +63,8 @@ export class WebSocketProvider extends EventEmitter {
         }
       };
 
-      this.ws.onclose = () => {
+      socket.onclose = () => {
+        if (this.ws !== socket) return;
         this.isConnected = false;
         // BUG: Messages sent while disconnected are silently dropped —
         // no queue to buffer and replay after reconnection
@@ -62,7 +72,8 @@ export class WebSocketProvider extends EventEmitter {
         this.attemptReconnect();
       };
 
-      this.ws.onerror = (err) => {
+      socket.onerror = (err) => {
+        if (this.ws !== socket) return;
         if (!this.isConnected) reject(new Error("WebSocket connection failed"));
         this.emit("error", err);
       };
@@ -108,9 +119,29 @@ export class WebSocketProvider extends EventEmitter {
   }
 
   disconnect(): void {
-    this.ws?.close();
+    const socket = this.ws;
+    this.cleanupSocket();
+    socket?.close();
     this.ws = null;
     this.isConnected = false;
     this.pendingRequests.clear();
+  }
+
+  private cleanupSocket(): void {
+    const socket = this.ws as (WebSocket & { removeAllListeners?: () => void }) | null;
+    if (!socket) return;
+
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+    socket.removeAllListeners?.();
+  }
+
+  private warnIfListenerCountIsHigh(): void {
+    const count = this.listenerCount("message");
+    if (count > this.listenerWarningThreshold) {
+      console.warn(`WebSocketProvider has ${count} message listeners`);
+    }
   }
 }

--- a/test/SDKWebSocketReconnect.test.js
+++ b/test/SDKWebSocketReconnect.test.js
@@ -1,0 +1,115 @@
+process.env.TS_NODE_IGNORE_DIAGNOSTICS = "5102";
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+});
+
+require("ts-node/register/transpile-only");
+
+const { expect } = require("chai");
+const { WebSocketProvider } = require("../sdk/src/providers/websocket.ts");
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("WebSocketProvider reconnect listeners", function () {
+  let OriginalWebSocket;
+  let sockets;
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.sent = [];
+      this.removed = 0;
+      sockets.push(this);
+    }
+
+    send(data) {
+      this.sent.push(data);
+    }
+
+    close() {
+      this.onclose?.();
+    }
+
+    removeAllListeners() {
+      this.removed += 1;
+    }
+
+    open() {
+      this.onopen?.();
+    }
+
+    message(data) {
+      this.onmessage?.({ data: JSON.stringify(data) });
+    }
+  }
+
+  beforeEach(function () {
+    OriginalWebSocket = global.WebSocket;
+    sockets = [];
+    global.WebSocket = FakeWebSocket;
+  });
+
+  afterEach(function () {
+    global.WebSocket = OriginalWebSocket;
+  });
+
+  it("handles each message once after repeated reconnects", async function () {
+    const provider = new WebSocketProvider({
+      url: "ws://example",
+      reconnectIntervalMs: 0,
+      maxReconnectAttempts: 12,
+    });
+
+    const initialConnect = provider.connect();
+    sockets[0].open();
+    await initialConnect;
+
+    for (let i = 0; i < 10; i++) {
+      sockets[i].close();
+      await tick();
+      sockets[i + 1].open();
+    }
+
+    let deliveries = 0;
+    provider.subscriptions.set("sub-1", () => {
+      deliveries += 1;
+    });
+
+    for (const socket of sockets) {
+      socket.message({
+        jsonrpc: "2.0",
+        method: "eth_subscription",
+        params: { subscription: "sub-1", result: "payload" },
+      });
+    }
+
+    expect(deliveries).to.equal(1);
+    for (const staleSocket of sockets.slice(0, -1)) {
+      expect(staleSocket.removed).to.equal(1);
+    }
+  });
+
+  it("warns when provider message listeners exceed the configured threshold", async function () {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+
+    try {
+      const provider = new WebSocketProvider({
+        url: "ws://example",
+        listenerWarningThreshold: 1,
+      });
+      provider.on("message", () => {});
+      provider.on("message", () => {});
+
+      const connecting = provider.connect();
+      sockets[0].open();
+      await connecting;
+
+      expect(warnings).to.deep.equal(["WebSocketProvider has 2 message listeners"]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});


### PR DESCRIPTION
Fixes #115
/claim #115

## Summary
- clears old WebSocket handlers before creating a replacement socket
- ignores stale socket callbacks after reconnect replacement
- prevents manual disconnect from scheduling reconnect through a stale close handler
- adds listener-count warning when provider message listeners exceed the configured threshold
- adds reconnect regression coverage over 10 reconnects, verifying a subscription message is delivered exactly once

## Verification
- `npx mocha test/SDKWebSocketReconnect.test.js` -> 2 passing
- `npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/providers/websocket.ts`
- `node --check test/SDKWebSocketReconnect.test.js`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.