### PR TITLE
sdk: paginate open task reads

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,10 +9,29 @@ export interface AgentConfig {
   routerAddress: string;
 }
 
+export interface GetOpenTasksOptions {
+  offset?: number;
+  limit?: number;
+  status?: number;
+  batchSize?: number;
+}
+
+export interface SDKTask {
+  id: number;
+  creator: string;
+  assignedAgent: string;
+  description: string;
+  reward: bigint;
+  deadline: bigint;
+  status: number;
+  result: string;
+}
+
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
   private config: AgentConfig;
+  private taskCountCache: { blockNumber: number; count: bigint } | null = null;
 
   constructor(config: AgentConfig) {
     this.config = config;
@@ -60,8 +79,47 @@ export class OpenAgentsSDK {
     await tx.wait();
   }
 
-  async getOpenTasks(): Promise<any[]> {
-    const router = new ethers.Contract(
+  async getOpenTasks(options: GetOpenTasksOptions = {}): Promise<SDKTask[]> {
+    const router = this.createRouterReader();
+    const offset = Math.max(0, options.offset ?? 0);
+    const limit = Math.max(0, options.limit ?? 50);
+    const batchSize = Math.min(Math.max(1, options.batchSize ?? 10), 10);
+    const statusFilter = options.status ?? 0;
+    const count = Number(await this.getCachedTaskCount(router));
+    const end = Math.min(count, offset + limit);
+    const tasks: SDKTask[] = [];
+
+    for (let start = offset; start < end; start += batchSize) {
+      const ids = Array.from(
+        { length: Math.min(batchSize, end - start) },
+        (_, index) => start + index
+      );
+      const batch = await Promise.all(ids.map(async (id) => ({
+        id,
+        task: await router.tasks(id),
+      })));
+
+      for (const { id, task } of batch) {
+        const status = Number(task[5]);
+        if (status !== statusFilter) continue;
+        tasks.push({
+          id,
+          creator: task[0],
+          assignedAgent: task[1],
+          description: task[2],
+          reward: task[3],
+          deadline: task[4],
+          status,
+          result: task[6],
+        });
+      }
+    }
+
+    return tasks;
+  }
+
+  protected createRouterReader(): ethers.Contract {
+    return new ethers.Contract(
       this.config.routerAddress,
       [
         "function taskCount() view returns (uint256)",
@@ -69,23 +127,20 @@ export class OpenAgentsSDK {
       ],
       this.provider
     );
+  }
 
-    const count = await router.taskCount();
-    const openTasks = [];
+  protected async getCurrentBlockNumber(): Promise<number> {
+    return this.provider.getBlockNumber();
+  }
 
-    for (let i = 0; i < count; i++) {
-      const task = await router.tasks(i);
-      if (task[5] === 0) {
-        openTasks.push({
-          id: i,
-          creator: task[0],
-          description: task[2],
-          reward: task[3],
-          deadline: task[4],
-        });
-      }
+  private async getCachedTaskCount(router: ethers.Contract): Promise<bigint> {
+    const blockNumber = await this.getCurrentBlockNumber();
+    if (this.taskCountCache?.blockNumber === blockNumber) {
+      return this.taskCountCache.count;
     }
 
-    return openTasks;
+    const count = await router.taskCount();
+    this.taskCountCache = { blockNumber, count };
+    return count;
   }
 }

--- a/test/SDKOpenTasksPagination.test.js
+++ b/test/SDKOpenTasksPagination.test.js
@@ -1,0 +1,99 @@
+process.env.TS_NODE_IGNORE_DIAGNOSTICS = "5102";
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+});
+
+require("ts-node/register/transpile-only");
+
+const { expect } = require("chai");
+const { OpenAgentsSDK } = require("../sdk/src/index.ts");
+
+const sdkConfig = {
+  name: "agent",
+  endpoint: "https://agent.example",
+  privateKey: "0x".padEnd(66, "1"),
+  rpcUrl: "http://127.0.0.1:8545",
+  registryAddress: "0x0000000000000000000000000000000000000001",
+  routerAddress: "0x0000000000000000000000000000000000000002",
+};
+
+function makeTask(id, status = 0) {
+  return [
+    `0x${String(id + 1).padStart(40, "0")}`,
+    `0x${String(id + 100).padStart(64, "0")}`,
+    `task-${id}`,
+    BigInt(id + 1),
+    BigInt(1000 + id),
+    status,
+    "0x",
+  ];
+}
+
+class TestSDK extends OpenAgentsSDK {
+  constructor(tasks) {
+    super(sdkConfig);
+    this.blockNumber = 1;
+    this.taskCountCalls = 0;
+    this.currentTasksCalls = 0;
+    this.maxConcurrentTasksCalls = 0;
+    this.tasksData = tasks;
+  }
+
+  createRouterReader() {
+    return {
+      taskCount: async () => {
+        this.taskCountCalls += 1;
+        return BigInt(this.tasksData.length);
+      },
+      tasks: async (id) => {
+        this.currentTasksCalls += 1;
+        this.maxConcurrentTasksCalls = Math.max(this.maxConcurrentTasksCalls, this.currentTasksCalls);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        this.currentTasksCalls -= 1;
+        return this.tasksData[id];
+      },
+    };
+  }
+
+  async getCurrentBlockNumber() {
+    return this.blockNumber;
+  }
+}
+
+describe("OpenAgentsSDK.getOpenTasks", function () {
+  it("paginates and fetches tasks with at most 10 concurrent calls", async function () {
+    const sdk = new TestSDK(Array.from({ length: 25 }, (_, id) => makeTask(id)));
+
+    const tasks = await sdk.getOpenTasks({ offset: 5, limit: 12 });
+
+    expect(tasks.map((task) => task.id)).to.deep.equal([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    expect(sdk.maxConcurrentTasksCalls).to.equal(10);
+  });
+
+  it("caches taskCount for one provider block", async function () {
+    const sdk = new TestSDK(Array.from({ length: 3 }, (_, id) => makeTask(id)));
+
+    await sdk.getOpenTasks({ limit: 1 });
+    await sdk.getOpenTasks({ limit: 1 });
+    expect(sdk.taskCountCalls).to.equal(1);
+
+    sdk.blockNumber = 2;
+    await sdk.getOpenTasks({ limit: 1 });
+    expect(sdk.taskCountCalls).to.equal(2);
+  });
+
+  it("filters by task status", async function () {
+    const sdk = new TestSDK([
+      makeTask(0, 0),
+      makeTask(1, 1),
+      makeTask(2, 0),
+      makeTask(3, 2),
+    ]);
+
+    const assigned = await sdk.getOpenTasks({ offset: 0, limit: 4, status: 1 });
+
+    expect(assigned.map((task) => task.id)).to.deep.equal([1]);
+    expect(assigned[0].status).to.equal(1);
+  });
+});


### PR DESCRIPTION
Fixes #113
/claim #113

## Summary
- adds `getOpenTasks({ offset, limit, status, batchSize })` options
- fetches task rows concurrently in batches capped at 10
- caches `taskCount` for the current provider block
- defaults to open-task status while allowing other status filters
- returns normalized SDK task objects including id, status, assigned agent, result, reward, and deadline
- adds focused tests for pagination, concurrency cap, one-block taskCount cache, and status filtering

## Verification
- `npx mocha test/SDKOpenTasksPagination.test.js` -> 3 passing
- `npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/index.ts`
- `node --check test/SDKOpenTasksPagination.test.js`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.