### PR TITLE
sdk: support EIP-1559 transaction signing

### DIFF
--- a/sdk/src/auth/wallet.ts
+++ b/sdk/src/auth/wallet.ts
@@ -1,5 +1,4 @@
-import { generateKeyPair, signMessage, keccak256 } from "../utils/crypto";
-import { encodeParams, AbiParam } from "../utils/encoding";
+import { ethers } from "ethers";
 import { RpcProvider } from "../providers/rpc";
 
 export interface WalletConfig {
@@ -13,8 +12,11 @@ export interface Transaction {
   data: string;
   gasLimit: bigint;
   gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
   nonce?: number;
   chainId?: number;
+  type?: 0 | 1 | 2;
 }
 
 export interface SignedTransaction {
@@ -34,42 +36,47 @@ export class Wallet {
     if (config.privateKey) {
       this.privateKey = config.privateKey;
     } else {
-      const keyPair = generateKeyPair();
-      this.privateKey = keyPair.privateKey;
+      this.privateKey = ethers.Wallet.createRandom().privateKey;
     }
     this.address = this.deriveAddress(this.privateKey);
     this.provider = config.provider;
   }
 
   private deriveAddress(privateKey: string): string {
-    const { ec as EC } = require("elliptic");
-    const curve = new EC("secp256k1");
-    const key = curve.keyFromPrivate(privateKey, "hex");
-    const pubKey = key.getPublic(false, "hex").slice(2); // remove 04 prefix
-    const hash = keccak256(Buffer.from(pubKey, "hex"));
-    return "0x" + hash.slice(-40);
+    return new ethers.Wallet(this.normalizePrivateKey(privateKey)).address;
   }
 
   async signTransaction(tx: Transaction): Promise<SignedTransaction> {
-    // BUG: No chain ID validation — transaction could be replayed on a different
-    // chain if chainId is missing or mismatched with the provider
     const nonce = tx.nonce ?? await this.getNonce();
-    const gasPrice = tx.gasPrice ?? BigInt(await this.provider.call("eth_gasPrice") as string);
+    const chainId = tx.chainId ?? this.provider.getChainId();
+    const type = tx.type ?? (tx.maxFeePerGas !== undefined ? 2 : 0);
+    const signer = new ethers.Wallet(this.normalizePrivateKey(this.privateKey));
 
-    const txData = encodeParams([
-      { type: "uint256", value: nonce } as AbiParam,
-      { type: "uint256", value: gasPrice } as AbiParam,
-      { type: "uint256", value: tx.gasLimit } as AbiParam,
-      { type: "address", value: tx.to } as AbiParam,
-      { type: "uint256", value: tx.value } as AbiParam,
-    ]);
+    const request: ethers.TransactionRequest = {
+      to: tx.to,
+      value: tx.value,
+      data: tx.data,
+      gasLimit: tx.gasLimit,
+      nonce,
+      chainId,
+      type,
+    };
 
-    const txHash = keccak256(txData);
-    const signature = signMessage(this.privateKey, txHash);
+    if (type === 2) {
+      if (tx.maxFeePerGas === undefined || tx.maxPriorityFeePerGas === undefined) {
+        throw new Error("EIP-1559 transactions require maxFeePerGas and maxPriorityFeePerGas");
+      }
+      request.maxFeePerGas = tx.maxFeePerGas;
+      request.maxPriorityFeePerGas = tx.maxPriorityFeePerGas;
+    } else {
+      request.gasPrice = tx.gasPrice ?? BigInt(await this.provider.call("eth_gasPrice") as string);
+    }
+
+    const raw = await signer.signTransaction(request);
 
     return {
-      raw: "0x" + txData.slice(2) + signature,
-      hash: "0x" + txHash,
+      raw,
+      hash: ethers.keccak256(raw),
     };
   }
 
@@ -98,5 +105,9 @@ export class Wallet {
 
   exportPrivateKey(): string {
     return this.privateKey;
+  }
+
+  private normalizePrivateKey(privateKey: string): string {
+    return privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`;
   }
 }

--- a/test/SDKWalletEip1559.test.js
+++ b/test/SDKWalletEip1559.test.js
@@ -1,0 +1,91 @@
+process.env.TS_NODE_IGNORE_DIAGNOSTICS = "5102";
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+});
+
+require("ts-node/register/transpile-only");
+
+const { expect } = require("chai");
+const { ethers } = require("ethers");
+const { Wallet } = require("../sdk/src/auth/wallet.ts");
+
+const privateKey = "0x59c6995e998f97a5a0044966f0945384e6e88c7a84172c5c2d7d8619b6fc0b60";
+
+class ProviderStub {
+  constructor() {
+    this.calls = [];
+  }
+
+  async call(method) {
+    this.calls.push(method);
+    if (method === "eth_gasPrice") return "0x3b9aca00";
+    if (method === "eth_getTransactionCount") return "0x0";
+    throw new Error(`unexpected call: ${method}`);
+  }
+
+  getChainId() {
+    return 31337;
+  }
+
+  async getBalance() {
+    return 0n;
+  }
+}
+
+describe("Wallet.signTransaction", function () {
+  const baseTx = {
+    to: "0x000000000000000000000000000000000000dEaD",
+    value: 123n,
+    data: "0x",
+    gasLimit: 21000n,
+    nonce: 7,
+    chainId: 31337,
+  };
+
+  it("signs EIP-1559 type-2 transactions and matches ethers output", async function () {
+    const provider = new ProviderStub();
+    const wallet = new Wallet({ privateKey, provider });
+    const tx = {
+      ...baseTx,
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+    };
+
+    const signed = await wallet.signTransaction(tx);
+    const expectedRaw = await new ethers.Wallet(privateKey).signTransaction({ ...tx, type: 2 });
+
+    expect(signed.raw).to.equal(expectedRaw);
+    expect(signed.hash).to.equal(ethers.keccak256(expectedRaw));
+    expect(signed.raw.startsWith("0x02")).to.equal(true);
+    expect(provider.calls).to.not.include("eth_gasPrice");
+  });
+
+  it("keeps legacy signing when gasPrice is explicitly supplied", async function () {
+    const provider = new ProviderStub();
+    const wallet = new Wallet({ privateKey, provider });
+    const tx = {
+      ...baseTx,
+      gasPrice: 1_000_000_000n,
+    };
+
+    const signed = await wallet.signTransaction(tx);
+    const expectedRaw = await new ethers.Wallet(privateKey).signTransaction({ ...tx, type: 0 });
+
+    expect(signed.raw).to.equal(expectedRaw);
+    expect(signed.hash).to.equal(ethers.keccak256(expectedRaw));
+    expect(signed.raw.startsWith("0x02")).to.equal(false);
+  });
+
+  it("auto-detects type 2 when maxFeePerGas is present", async function () {
+    const wallet = new Wallet({ privateKey, provider: new ProviderStub() });
+
+    const signed = await wallet.signTransaction({
+      ...baseTx,
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+    });
+
+    expect(ethers.Transaction.from(signed.raw).type).to.equal(2);
+  });
+});


### PR DESCRIPTION
Fixes #154
/claim #154

## Summary
- adds `type`, `maxFeePerGas`, and `maxPriorityFeePerGas` to SDK transaction signing
- auto-detects type 2 when `maxFeePerGas` is present
- preserves legacy transaction signing when `gasPrice` is supplied
- uses ethers transaction signing so raw tx and hash match canonical ethers output
- removes the wallet signing path dependency on the local manual ABI/signature encoder
- adds focused tests for EIP-1559, legacy, and auto-detection

## Verification
- `npx mocha test/SDKWalletEip1559.test.js` -> 3 passing
- `npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node sdk/src/auth/wallet.ts`
- `node --check test/SDKWalletEip1559.test.js`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.