### PR TITLE
api: add request ID middleware

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,51 @@
+import contextvars
+import logging
+import uuid
+from datetime import datetime
+from typing import Optional
+
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
+
+REQUEST_ID_HEADER = "X-Request-ID"
+request_id_context: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id",
+    default="-",
+)
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_context.get()
+        return True
+
+
+request_id_filter = RequestIdFilter()
+logging.getLogger().addFilter(request_id_filter)
+logger = logging.getLogger("openagents.api")
+logger.addFilter(request_id_filter)
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+
+@app.middleware("http")
+async def request_id_middleware(request, call_next):
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
+    token = request_id_context.set(request_id)
+    request.state.request_id = request_id
+
+    try:
+        logger.info("request started")
+        response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        logger.info("request completed")
+        return response
+    finally:
+        request_id_context.reset(token)
 
 
 class AgentResponse(BaseModel):

--- a/api/tests/test_request_id.py
+++ b/api/tests/test_request_id.py
@@ -1,0 +1,51 @@
+import logging
+import re
+
+from fastapi.testclient import TestClient
+
+from api.main import REQUEST_ID_HEADER, app
+
+
+client = TestClient(app)
+
+
+def test_response_has_generated_request_id_header():
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    request_id = response.headers[REQUEST_ID_HEADER]
+    assert re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        request_id,
+    )
+
+
+def test_client_request_id_is_preserved():
+    response = client.get("/health", headers={REQUEST_ID_HEADER: "trace-123"})
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "trace-123"
+
+
+def test_generated_ids_are_unique_per_request():
+    first = client.get("/health").headers[REQUEST_ID_HEADER]
+    second = client.get("/health").headers[REQUEST_ID_HEADER]
+
+    assert first != second
+
+
+def test_request_id_is_present_on_error_response():
+    response = client.get("/agents/missing-agent", headers={REQUEST_ID_HEADER: "error-trace"})
+
+    assert response.status_code == 404
+    assert response.headers[REQUEST_ID_HEADER] == "error-trace"
+
+
+def test_logs_include_request_id(caplog):
+    with caplog.at_level(logging.INFO, logger="openagents.api"):
+        response = client.get("/health", headers={REQUEST_ID_HEADER: "log-trace"})
+
+    assert response.status_code == 200
+    records = [record for record in caplog.records if record.name == "openagents.api"]
+    assert records
+    assert all(record.request_id == "log-trace" for record in records)


### PR DESCRIPTION
Fixes #178
/claim #178

## Summary
- adds FastAPI request ID middleware in `api/main.py`
- preserves client-provided `X-Request-ID` values for distributed tracing
- generates UUID request IDs when the client does not provide one
- sets `X-Request-ID` on successful and error responses
- stores the active request ID in request state and a context variable
- attaches request IDs to OpenAgents API log records through a logging filter
- adds focused tests for header presence, client pass-through, uniqueness, error responses, and log correlation

## Verification
- `python -m pip install -r api/requirements.txt pytest`
- `python -m pytest api/tests/test_request_id.py -q` -> 5 passed
- `python -m py_compile api/main.py api/tests/test_request_id.py`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.