### PR TITLE
api: add task update websocket

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,6 +1,8 @@
 """Task management endpoints for bounty assignments."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+import asyncio
+
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
@@ -11,6 +13,7 @@ from ..middleware.auth import get_current_user
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled"}
+HEARTBEAT_INTERVAL_SECONDS = 30
 
 
 class TaskCreate(BaseModel):
@@ -23,6 +26,76 @@ class TaskCreate(BaseModel):
 
 class TaskStatusUpdate(BaseModel):
     status: str  # BUG: Not validated against VALID_STATUSES enum — any string accepted
+
+
+class TaskWebSocketManager:
+    def __init__(self):
+        self.clients: dict[WebSocket, set[int]] = {}
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.clients[websocket] = set()
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self.clients.pop(websocket, None)
+
+    def subscribe(self, websocket: WebSocket, task_id: int) -> None:
+        self.clients.setdefault(websocket, set()).add(task_id)
+
+    def unsubscribe(self, websocket: WebSocket, task_id: int) -> None:
+        self.clients.setdefault(websocket, set()).discard(task_id)
+
+    async def broadcast(self, task_id: int, payload: dict) -> None:
+        stale: list[WebSocket] = []
+        for websocket, task_ids in list(self.clients.items()):
+            if task_id not in task_ids:
+                continue
+            try:
+                await websocket.send_json(payload)
+            except RuntimeError:
+                stale.append(websocket)
+
+        for websocket in stale:
+            self.disconnect(websocket)
+
+
+task_ws_manager = TaskWebSocketManager()
+
+
+async def broadcast_task_update(task_id: int, status: str) -> None:
+    await task_ws_manager.broadcast(
+        task_id,
+        {"type": "task_update", "task_id": task_id, "status": status},
+    )
+
+
+@router.websocket("/ws")
+async def task_updates_ws(websocket: WebSocket):
+    await task_ws_manager.connect(websocket)
+    try:
+        while True:
+            try:
+                message = await asyncio.wait_for(
+                    websocket.receive_json(),
+                    timeout=HEARTBEAT_INTERVAL_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                await websocket.send_json({"type": "heartbeat"})
+                continue
+
+            action = message.get("action")
+            task_id = int(message.get("task_id", 0))
+
+            if action == "subscribe":
+                task_ws_manager.subscribe(websocket, task_id)
+                await websocket.send_json({"type": "subscribed", "task_id": task_id})
+            elif action == "unsubscribe":
+                task_ws_manager.unsubscribe(websocket, task_id)
+                await websocket.send_json({"type": "unsubscribed", "task_id": task_id})
+            else:
+                await websocket.send_json({"type": "error", "message": "Unknown action"})
+    except WebSocketDisconnect:
+        task_ws_manager.disconnect(websocket)
 
 
 @router.post("/")
@@ -40,6 +113,7 @@ async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depen
     db.add(new_task)
     db.commit()
     db.refresh(new_task)
+    await broadcast_task_update(new_task.id, new_task.status)
     return {"id": new_task.id, "status": new_task.status}
 
 
@@ -88,6 +162,7 @@ async def update_task_status(
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
+    await broadcast_task_update(task.id, task.status)
     return {"id": task.id, "status": task.status}
 
 
@@ -102,4 +177,5 @@ async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(g
         raise HTTPException(status_code=400, detail="Cannot cancel an active task")
     task.status = "cancelled"
     db.commit()
+    await broadcast_task_update(task.id, task.status)
     return {"id": task.id, "status": "cancelled"}

--- a/api/tests/test_task_websocket.py
+++ b/api/tests/test_task_websocket.py
@@ -1,0 +1,67 @@
+import asyncio
+import os
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+import api.routes.tasks as tasks
+
+
+def make_client():
+    app = FastAPI()
+    app.include_router(tasks.router)
+    return TestClient(app)
+
+
+def setup_function():
+    tasks.task_ws_manager.clients.clear()
+
+
+def test_websocket_subscribe_and_receive_task_update():
+    client = make_client()
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.send_json({"action": "subscribe", "task_id": 42})
+        assert websocket.receive_json() == {"type": "subscribed", "task_id": 42}
+
+        asyncio.run(tasks.broadcast_task_update(42, "assigned"))
+
+        assert websocket.receive_json() == {
+            "type": "task_update",
+            "task_id": 42,
+            "status": "assigned",
+        }
+
+
+def test_unsubscribe_removes_client_from_task_broadcasts():
+    client = make_client()
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.send_json({"action": "subscribe", "task_id": 7})
+        assert websocket.receive_json() == {"type": "subscribed", "task_id": 7}
+        websocket.send_json({"action": "unsubscribe", "task_id": 7})
+        assert websocket.receive_json() == {"type": "unsubscribed", "task_id": 7}
+
+        assert tasks.task_ws_manager.clients
+        assert 7 not in next(iter(tasks.task_ws_manager.clients.values()))
+
+
+def test_heartbeat_keeps_connection_alive(monkeypatch):
+    monkeypatch.setattr(tasks, "HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    client = make_client()
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        assert websocket.receive_json() == {"type": "heartbeat"}
+
+
+def test_disconnected_client_is_cleaned_up():
+    client = make_client()
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.send_json({"action": "subscribe", "task_id": 9})
+        assert websocket.receive_json() == {"type": "subscribed", "task_id": 9}
+        assert len(tasks.task_ws_manager.clients) == 1
+
+    assert tasks.task_ws_manager.clients == {}


### PR DESCRIPTION
Fixes #188
/claim #188

## Summary
- adds `ws /tasks/ws` for real-time task update subscriptions
- supports subscribe/unsubscribe messages by task ID
- broadcasts task status updates from create, status update, and cancel paths
- sends heartbeat messages when the connection is idle
- cleans up disconnected clients from the subscription manager
- adds focused websocket tests for subscribe/update delivery, unsubscribe cleanup, heartbeat, and disconnect cleanup

## Verification
- `python -m pytest api/tests/test_task_websocket.py -q` -> 4 passed
- `python -m py_compile api/routes/tasks.py api/tests/test_task_websocket.py`
- `git diff --check`

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.