### PR TITLE
registry: use counter based agent IDs

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -20,6 +20,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public nextAgentId = 1;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -34,7 +35,7 @@ contract AgentRegistry is Ownable {
         require(msg.value >= registrationFee, "Insufficient fee");
         require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
 
-        bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp));
+        bytes32 agentId = bytes32(nextAgentId++);
 
         require(agents[agentId].registeredAt == 0, "Agent exists");
 

--- a/test/AgentRegistryCounterIds.test.js
+++ b/test/AgentRegistryCounterIds.test.js
@@ -1,0 +1,27 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry counter IDs", function () {
+  it("gives two same-name registrations unique IDs", async function () {
+    const [firstOwner, secondOwner] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory("AgentRegistry");
+    const registry = await Registry.deploy(0);
+
+    const first = await registry.connect(firstOwner).registerAgent("same-name", "https://one.example");
+    const second = await registry.connect(secondOwner).registerAgent("same-name", "https://two.example");
+
+    const firstReceipt = await first.wait();
+    const secondReceipt = await second.wait();
+    const firstEvent = firstReceipt.logs
+      .map((log) => registry.interface.parseLog(log))
+      .find((log) => log.name === "AgentRegistered");
+    const secondEvent = secondReceipt.logs
+      .map((log) => registry.interface.parseLog(log))
+      .find((log) => log.name === "AgentRegistered");
+
+    expect(firstEvent.args.agentId).to.not.equal(secondEvent.args.agentId);
+    expect(firstEvent.args.agentId).to.equal(ethers.zeroPadValue("0x01", 32));
+    expect(secondEvent.args.agentId).to.equal(ethers.zeroPadValue("0x02", 32));
+    expect(await registry.nextAgentId()).to.equal(3);
+  });
+});


### PR DESCRIPTION
Fixes #172
/claim #172

## Summary
- replaces timestamp/name-derived AgentRegistry IDs with a monotonic counter
- keeps the existing `registerAgent(name, endpoint)` flow unchanged for honest users
- keeps the existing collision guard
- adds focused coverage proving two same-name registrations get distinct IDs

## Verification
- `npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc contracts/AgentRegistry.sol`
- `node --check test/AgentRegistryCounterIds.test.js`
- `git diff --check`

Note: I did not report a full Hardhat run here because current main still has a Solidity parse failure in an unrelated oracle contract. The modified AgentRegistry contract compiles directly with solcjs.

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.