### PR TITLE
token: refresh permit domain separator by chain

### DIFF
--- a/contracts/token/AgentToken.sol
+++ b/contracts/token/AgentToken.sol
@@ -15,7 +15,10 @@ contract AgentToken is ERC20, ERC20Burnable {
     bytes32 public constant PERMIT_TYPEHASH = keccak256(
         "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
     );
-    bytes32 public immutable DOMAIN_SEPARATOR;
+    bytes32 private immutable _HASHED_NAME;
+    bytes32 private immutable _HASHED_VERSION;
+    uint256 private immutable _CACHED_CHAIN_ID;
+    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
     mapping(address => uint256) public nonces;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
@@ -27,13 +30,19 @@ contract AgentToken is ERC20, ERC20Burnable {
     ) ERC20(name_, symbol_) {
         owner = msg.sender;
         _mint(msg.sender, initialSupply);
-        DOMAIN_SEPARATOR = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256(bytes(name_)),
-            keccak256(bytes("1")),
-            block.chainid,
-            address(this)
-        ));
+        _HASHED_NAME = keccak256(bytes(name_));
+        _HASHED_VERSION = keccak256(bytes("1"));
+        _CACHED_CHAIN_ID = block.chainid;
+        _CACHED_DOMAIN_SEPARATOR = _buildDomainSeparator(block.chainid);
+    }
+
+    /// @notice EIP-712 domain separator for the current chain.
+    /// @dev Recomputes after a fork so permits signed on the old chain ID do not replay.
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        if (block.chainid == _CACHED_CHAIN_ID) {
+            return _CACHED_DOMAIN_SEPARATOR;
+        }
+        return _buildDomainSeparator(block.chainid);
     }
 
     /// @notice Mint new tokens to a recipient.
@@ -82,10 +91,20 @@ contract AgentToken is ERC20, ERC20Burnable {
             deadline
         ));
 
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
         address recoveredAddress = ecrecover(digest, v, r, s);
         require(recoveredAddress != address(0) && recoveredAddress == _owner, "AgentToken: invalid signature");
 
         _approve(_owner, spender, value);
+    }
+
+    function _buildDomainSeparator(uint256 chainId) internal view returns (bytes32) {
+        return keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            _HASHED_NAME,
+            _HASHED_VERSION,
+            chainId,
+            address(this)
+        ));
     }
 }

--- a/test/AgentTokenDomainSeparator.test.js
+++ b/test/AgentTokenDomainSeparator.test.js
@@ -1,0 +1,107 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(process.cwd(), importPath),
+    path.join(process.cwd(), "node_modules", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileAgentToken() {
+  const sourcePath = "contracts/token/AgentToken.sol";
+  const harnessPath = "contracts/test/AgentTokenDomainHarness.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [sourcePath]: { content: fs.readFileSync(sourcePath, "utf8") },
+      [harnessPath]: {
+        content: `
+          // SPDX-License-Identifier: MIT
+          pragma solidity ^0.8.20;
+          import "../token/AgentToken.sol";
+
+          contract AgentTokenDomainHarness is AgentToken {
+              constructor() AgentToken("Agent Token", "AGENT", 1000) {}
+
+              function domainSeparatorForChainId(uint256 chainId) external view returns (bytes32) {
+                  return _buildDomainSeparator(chainId);
+              }
+          }
+        `,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  const contract = output.contracts[harnessPath].AgentTokenDomainHarness;
+  return {
+    abi: contract.abi,
+    bytecode: `0x${contract.evm.bytecode.object}`,
+  };
+}
+
+async function deployAgentToken() {
+  const compiled = compileAgentToken();
+  const [owner] = await ethers.getSigners();
+  const factory = new ethers.ContractFactory(compiled.abi, compiled.bytecode, owner);
+  return factory.deploy();
+}
+
+function expectedDomainSeparator(tokenAddress, chainId) {
+  return ethers.TypedDataEncoder.hashDomain({
+    name: "Agent Token",
+    version: "1",
+    chainId,
+    verifyingContract: tokenAddress,
+  });
+}
+
+describe("AgentToken DOMAIN_SEPARATOR", function () {
+  it("returns the EIP-712 separator for the active chain ID", async function () {
+    const token = await deployAgentToken();
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+
+    expect(await token.DOMAIN_SEPARATOR()).to.equal(
+      expectedDomainSeparator(await token.getAddress(), chainId)
+    );
+  });
+
+  it("builds different separators for different fork chain IDs", async function () {
+    const token = await deployAgentToken();
+    const tokenAddress = await token.getAddress();
+    const firstSeparator = await token.domainSeparatorForChainId(31337);
+    const secondSeparator = await token.domainSeparatorForChainId(31338);
+
+    expect(firstSeparator).to.not.equal(secondSeparator);
+    expect(firstSeparator).to.equal(
+      expectedDomainSeparator(tokenAddress, 31337n)
+    );
+    expect(secondSeparator).to.equal(
+      expectedDomainSeparator(tokenAddress, 31338n)
+    );
+  });
+});


### PR DESCRIPTION
Fixes #162
/claim #162

## Summary
- replaces the immutable public domain separator with cached EIP-712 domain data
- keeps a cached separator for the deployment chain ID
- recomputes the separator through `DOMAIN_SEPARATOR()` whenever `block.chainid` differs from the cached chain ID
- updates permit digest construction to use the dynamic `DOMAIN_SEPARATOR()` view
- adds a focused Hardhat `--no-compile` test that compiles only AgentToken plus a harness and verifies separators for different fork chain IDs

## Verification
- `npx hardhat test --no-compile test/AgentTokenDomainSeparator.test.js` -> 2 passing
- `npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-token contracts/token/AgentToken.sol`
- `node --check test/AgentTokenDomainSeparator.test.js`
- `git diff --check`

Note: I used Hardhat with `--no-compile` because current main still has an unrelated Solidity parse failure outside AgentToken. The modified token contract is compiled directly with solcjs and deployed in the focused test.

Payment: BTC | `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh` | Bitcoin

Security note: no private prompt/session initialization text is included in source, comments, or metadata. The requested startup-instructions traceability block was omitted because it would expose private session instructions.