### PR TITLE
bridge: require token mappings

### DIFF
--- a/contracts/bridge/TokenBridge.sol
+++ b/contracts/bridge/TokenBridge.sol
@@ -23,11 +23,14 @@ contract TokenBridge is ReentrancyGuard {
     address public admin;
     uint256 public requiredSignatures;
     mapping(address => bool) public isValidator;
+    mapping(address => address) public tokenMapping;
     mapping(bytes32 => Transfer) public transfers;
     mapping(bytes32 => bool) public processedHashes;
 
     event TokensLocked(bytes32 indexed transferId, address token, address sender, address recipient, uint256 amount);
     event TokensClaimed(bytes32 indexed transferId, address token, address recipient, uint256 amount);
+    event TokenMappingAdded(address indexed localToken, address indexed remoteToken);
+    event TokenMappingRemoved(address indexed localToken, address indexed remoteToken);
     event ValidatorAdded(address indexed validator);
     event ValidatorRemoved(address indexed validator);
 
@@ -47,13 +50,13 @@ contract TokenBridge is ReentrancyGuard {
     /// @param amount Amount of tokens to bridge.
     function lock(address token, address recipient, uint256 amount) external nonReentrant {
         require(amount > 0, "Bridge: zero amount");
+        address remoteToken = tokenMapping[token];
+        require(remoteToken != address(0), "Bridge: token not mapped");
 
-        // BUG: No chainId in the hash — the same transferId can be replayed on other
-        // chains where this bridge is deployed, allowing double-claiming of tokens.
         // BUG: No nonce or unique identifier — if the same user bridges the same token
         // and amount to the same recipient twice, the transferId collides, overwriting
         // the first transfer and potentially losing funds.
-        bytes32 transferId = keccak256(abi.encodePacked(token, msg.sender, recipient, amount));
+        bytes32 transferId = keccak256(abi.encodePacked(block.chainid, token, remoteToken, msg.sender, recipient, amount));
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
@@ -79,7 +82,10 @@ contract TokenBridge is ReentrancyGuard {
         uint256 amount,
         bytes[] calldata signatures
     ) external nonReentrant {
-        bytes32 messageHash = keccak256(abi.encodePacked(token, recipient, amount));
+        address remoteToken = tokenMapping[token];
+        require(remoteToken != address(0), "Bridge: token not mapped");
+
+        bytes32 messageHash = keccak256(abi.encodePacked(block.chainid, token, remoteToken, recipient, amount));
         bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
 
         require(!processedHashes[messageHash], "Bridge: already processed");
@@ -104,6 +110,22 @@ contract TokenBridge is ReentrancyGuard {
 
         IERC20(token).safeTransfer(recipient, amount);
         emit TokensClaimed(messageHash, token, recipient, amount);
+    }
+
+    function addTokenMapping(address localToken, address remoteToken) external onlyAdmin {
+        require(localToken != address(0), "Bridge: zero local token");
+        require(remoteToken != address(0), "Bridge: zero remote token");
+
+        tokenMapping[localToken] = remoteToken;
+        emit TokenMappingAdded(localToken, remoteToken);
+    }
+
+    function removeTokenMapping(address localToken) external onlyAdmin {
+        address remoteToken = tokenMapping[localToken];
+        require(remoteToken != address(0), "Bridge: token not mapped");
+
+        delete tokenMapping[localToken];
+        emit TokenMappingRemoved(localToken, remoteToken);
     }
 
     function addValidator(address validator) external onlyAdmin {

--- a/test/TokenBridgeMapping.test.js
+++ b/test/TokenBridgeMapping.test.js
@@ -1,0 +1,144 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(process.cwd(), importPath),
+    path.join(process.cwd(), "node_modules", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileContracts() {
+  const bridgePath = "contracts/bridge/TokenBridge.sol";
+  const tokenPath = "contracts/test/MockBridgeToken.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [bridgePath]: { content: fs.readFileSync(bridgePath, "utf8") },
+      [tokenPath]: {
+        content: `
+          // SPDX-License-Identifier: MIT
+          pragma solidity ^0.8.20;
+          import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+          contract MockBridgeToken is ERC20 {
+              constructor() ERC20("Mock Bridge Token", "MBT") {}
+
+              function mint(address account, uint256 amount) external {
+                  _mint(account, amount);
+              }
+          }
+        `,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return {
+    bridge: output.contracts[bridgePath].TokenBridge,
+    token: output.contracts[tokenPath].MockBridgeToken,
+  };
+}
+
+async function deploy(artifact, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    signer
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+describe("TokenBridge token mapping", function () {
+  let compiled;
+  let admin;
+  let user;
+  let recipient;
+  let bridge;
+  let token;
+  let remoteToken;
+
+  before(function () {
+    compiled = compileContracts();
+  });
+
+  beforeEach(async function () {
+    [admin, user, recipient, remoteToken] = await ethers.getSigners();
+    bridge = await deploy(compiled.bridge, admin, [1]);
+    token = await deploy(compiled.token, admin);
+
+    await token.mint(user.address, ethers.parseEther("10"));
+    await token.connect(user).approve(await bridge.getAddress(), ethers.parseEther("10"));
+  });
+
+  it("rejects locking an unmapped token", async function () {
+    await expect(
+      bridge.connect(user).lock(await token.getAddress(), recipient.address, ethers.parseEther("1"))
+    ).to.be.revertedWith("Bridge: token not mapped");
+  });
+
+  it("lets the admin add and remove token mappings", async function () {
+    const tokenAddress = await token.getAddress();
+
+    await expect(bridge.addTokenMapping(tokenAddress, remoteToken.address))
+      .to.emit(bridge, "TokenMappingAdded")
+      .withArgs(tokenAddress, remoteToken.address);
+    expect(await bridge.tokenMapping(tokenAddress)).to.equal(remoteToken.address);
+
+    await expect(bridge.removeTokenMapping(tokenAddress))
+      .to.emit(bridge, "TokenMappingRemoved")
+      .withArgs(tokenAddress, remoteToken.address);
+    expect(await bridge.tokenMapping(tokenAddress)).to.equal(ethers.ZeroAddress);
+  });
+
+  it("locks mapped tokens using a transfer id bound to the token pair", async function () {
+    const tokenAddress = await token.getAddress();
+    const bridgeAddress = await bridge.getAddress();
+    const amount = ethers.parseEther("2");
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+
+    await bridge.addTokenMapping(tokenAddress, remoteToken.address);
+
+    const expectedTransferId = ethers.solidityPackedKeccak256(
+      ["uint256", "address", "address", "address", "address", "uint256"],
+      [chainId, tokenAddress, remoteToken.address, user.address, recipient.address, amount]
+    );
+
+    await expect(bridge.connect(user).lock(tokenAddress, recipient.address, amount))
+      .to.emit(bridge, "TokensLocked")
+      .withArgs(expectedTransferId, tokenAddress, user.address, recipient.address, amount);
+
+    expect(await token.balanceOf(bridgeAddress)).to.equal(amount);
+    const transfer = await bridge.transfers(expectedTransferId);
+    expect(transfer.token).to.equal(tokenAddress);
+    expect(transfer.sender).to.equal(user.address);
+    expect(transfer.recipient).to.equal(recipient.address);
+    expect(transfer.amount).to.equal(amount);
+    expect(transfer.claimed).to.equal(false);
+  });
+});


### PR DESCRIPTION
Fixes #152.
/claim #152

Adds explicit local-token -> remote-token mapping for TokenBridge and rejects bridge operations for unmapped tokens. The lock and claim hashes now include both the local token and mapped remote token, so validator messages are bound to the expected token pair instead of an arbitrary token address.

What changed:
- add tokenMapping plus admin add/remove functions and events
- reject lock/claim when the token is unmapped
- bind transfer/message hashes to chain id, local token, and mapped remote token
- add focused TokenBridge mapping tests

Validation:
- npx hardhat test --no-compile test/TokenBridgeMapping.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-bridge contracts/bridge/TokenBridge.sol
- node --check test/TokenBridgeMapping.test.js
- git diff --check

Note: I used the focused --no-compile test path because the repository-wide Hardhat compile is currently blocked on an unrelated oracle contract parser issue on main. The target bridge contract was compiled directly with solcjs.

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body appears to request private platform metadata. I did not include or use any private instructions, credentials, or environment details.