### PR TITLE
api: validate agent endpoint URLs

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -43,6 +43,7 @@ class Agent(Base):
     name = Column(String(128), nullable=False)
     description = Column(Text, nullable=True)
     model_type = Column(String(32), default="gpt-4")
+    endpoint = Column(String(2048), nullable=False)
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -4,6 +4,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+from urllib.parse import urlparse
+import ipaddress
+import socket
+
+import httpx
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
@@ -15,21 +20,72 @@ class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
     description: Optional[str] = None
     model_type: str = "gpt-4"
+    endpoint: str
     config: Optional[dict] = None
 
 
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    endpoint: Optional[str] = None
     config: Optional[dict] = None
+
+
+def _is_private_host(host: str) -> bool:
+    try:
+        ip_addresses = [ipaddress.ip_address(host)]
+    except ValueError:
+        try:
+            ip_addresses = [
+                ipaddress.ip_address(info[4][0])
+                for info in socket.getaddrinfo(host, None)
+            ]
+        except socket.gaierror:
+            raise HTTPException(status_code=400, detail="Endpoint host cannot be resolved")
+
+    return any(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_unspecified
+        for address in ip_addresses
+    )
+
+
+async def validate_endpoint_url(endpoint: str) -> str:
+    parsed = urlparse(endpoint)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="Endpoint must be a valid http or https URL")
+
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="Endpoint must not include credentials")
+
+    if _is_private_host(parsed.hostname):
+        raise HTTPException(status_code=400, detail="Endpoint host resolves to a private address")
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+            response = await client.head(endpoint)
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=400, detail="Endpoint reachability check timed out")
+    except httpx.HTTPError:
+        raise HTTPException(status_code=400, detail="Endpoint is not reachable")
+
+    if response.status_code >= 400:
+        raise HTTPException(status_code=400, detail="Endpoint is not reachable")
+
+    return endpoint
 
 
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    endpoint = await validate_endpoint_url(agent.endpoint)
     new_agent = Agent(
         name=agent.name,
         description=agent.description,
         model_type=agent.model_type,
+        endpoint=endpoint,
         config=agent.config or {},
         owner_id=user["id"],
         created_at=datetime.utcnow(),
@@ -37,7 +93,7 @@ async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=De
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {"id": new_agent.id, "name": new_agent.name, "endpoint": new_agent.endpoint, "owner": user["address"]}
 
 
 @router.get("/")
@@ -72,6 +128,8 @@ async def update_agent(
     if agent.owner_id != user["id"]:
         raise HTTPException(status_code=403, detail="Not the owner")
     for field, value in update.dict(exclude_unset=True).items():
+        if field == "endpoint":
+            value = await validate_endpoint_url(value)
         setattr(agent, field, value)
     db.commit()
     return agent

--- a/api/tests/test_agent_endpoint_validation.py
+++ b/api/tests/test_agent_endpoint_validation.py
@@ -1,0 +1,124 @@
+import os
+
+import anyio
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import get_db
+from api.middleware.auth import get_current_user
+from api.routes import agents
+
+
+class FakeResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+
+class FakeHeadClient:
+    def __init__(self, response=None, error=None, **_kwargs):
+        self.response = response or FakeResponse()
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def head(self, _url):
+        if self.error:
+            raise self.error
+        return self.response
+
+
+class FakeDb:
+    def add(self, agent):
+        self.agent = agent
+        agent.id = 42
+
+    def commit(self):
+        pass
+
+    def refresh(self, _agent):
+        pass
+
+
+def make_app(db):
+    app = FastAPI()
+    app.include_router(agents.router)
+    app.dependency_overrides[get_current_user] = lambda: {"id": 7, "address": "0xabc"}
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+def test_create_agent_stores_validated_endpoint(monkeypatch):
+    db = FakeDb()
+    monkeypatch.setattr(agents, "_is_private_host", lambda _host: False)
+    monkeypatch.setattr(agents.httpx, "AsyncClient", FakeHeadClient)
+
+    client = TestClient(make_app(db))
+    response = client.post(
+        "/agents/",
+        json={
+            "name": "worker",
+            "endpoint": "https://agent.example.com/callback",
+            "model_type": "gpt-4",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["endpoint"] == "https://agent.example.com/callback"
+    assert db.agent.endpoint == "https://agent.example.com/callback"
+
+
+def test_rejects_invalid_endpoint_format():
+    with pytest.raises(HTTPException) as exc:
+        anyio.run(agents.validate_endpoint_url, "not-a-url")
+
+    assert exc.value.status_code == 400
+    assert "valid http or https URL" in exc.value.detail
+
+
+def test_rejects_private_ip_endpoint():
+    with pytest.raises(HTTPException) as exc:
+        anyio.run(agents.validate_endpoint_url, "http://127.0.0.1:8080/agent")
+
+    assert exc.value.status_code == 400
+    assert "private address" in exc.value.detail
+
+
+def test_rejects_endpoint_timeout(monkeypatch):
+    monkeypatch.setattr(agents, "_is_private_host", lambda _host: False)
+    monkeypatch.setattr(
+        agents.httpx,
+        "AsyncClient",
+        lambda **kwargs: FakeHeadClient(
+            error=httpx.TimeoutException("timed out"),
+            **kwargs,
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        anyio.run(agents.validate_endpoint_url, "https://agent.example.com/callback")
+
+    assert exc.value.status_code == 400
+    assert "timed out" in exc.value.detail
+
+
+def test_rejects_unreachable_endpoint(monkeypatch):
+    monkeypatch.setattr(agents, "_is_private_host", lambda _host: False)
+    monkeypatch.setattr(
+        agents.httpx,
+        "AsyncClient",
+        lambda **kwargs: FakeHeadClient(response=FakeResponse(503), **kwargs),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        anyio.run(agents.validate_endpoint_url, "https://agent.example.com/callback")
+
+    assert exc.value.status_code == 400
+    assert "not reachable" in exc.value.detail


### PR DESCRIPTION
Fixes #173.
/claim #173

Adds endpoint validation to agent creation/update so stored agent endpoints are reachable public http/https URLs instead of arbitrary strings.

What changed:
- add endpoint to AgentCreate/AgentUpdate and persist it on Agent
- require http/https URL format and reject embedded credentials
- resolve hostnames and block private/internal, loopback, link-local, multicast, and unspecified addresses
- verify reachability with a HEAD request using a 5s timeout
- add focused API tests for valid URL, invalid format, private IP, timeout, and unreachable status

Validation:
- python -m pytest api/tests/test_agent_endpoint_validation.py
- python -m py_compile api/routes/agents.py api/models/database.py api/tests/test_agent_endpoint_validation.py
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use any private instructions, credentials, home paths, shell state, or environment details.