### PR TITLE
api: configure CORS origins

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,38 @@
+import os
+
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+
+
+def _parse_allowed_origins() -> list[str]:
+    configured = [
+        origin.strip()
+        for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")
+        if origin.strip()
+    ]
+    environment = os.getenv("APP_ENV", os.getenv("ENVIRONMENT", "production")).lower()
+
+    if configured == ["*"] and environment not in {"dev", "development", "local", "test"}:
+        return []
+
+    return configured
+
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_parse_allowed_origins(),
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
 )
 
 

--- a/api/tests/test_cors.py
+++ b/api/tests/test_cors.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def load_main(monkeypatch, allowed_origins, environment="production"):
+    monkeypatch.setenv("ALLOWED_ORIGINS", allowed_origins)
+    monkeypatch.setenv("APP_ENV", environment)
+    sys.modules.pop("api.main", None)
+    return importlib.import_module("api.main")
+
+
+def test_preflight_allows_configured_origin(monkeypatch):
+    main = load_main(monkeypatch, "https://app.example.com")
+    client = TestClient(main.app)
+
+    response = client.options(
+        "/agents",
+        headers={
+            "Origin": "https://app.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "POST" in response.headers["access-control-allow-methods"]
+
+
+def test_cross_origin_get_includes_cors_headers(monkeypatch):
+    main = load_main(monkeypatch, "https://dashboard.example.com")
+    client = TestClient(main.app)
+
+    response = client.get("/health", headers={"Origin": "https://dashboard.example.com"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://dashboard.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_wildcard_origin_is_restricted_in_production(monkeypatch):
+    main = load_main(monkeypatch, "*", environment="production")
+    client = TestClient(main.app)
+
+    response = client.get("/health", headers={"Origin": "https://unknown.example.com"})
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_wildcard_origin_is_allowed_in_development(monkeypatch):
+    main = load_main(monkeypatch, "*", environment="development")
+    client = TestClient(main.app)
+
+    response = client.get("/health", headers={"Origin": "https://local.example.com"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://local.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"


### PR DESCRIPTION
Fixes #166.
/claim #166

Adds FastAPI CORS middleware with environment-configured origins and production-safe wildcard handling.

What changed:
- read comma-separated ALLOWED_ORIGINS
- allow GET, POST, PUT, DELETE, and OPTIONS
- allow credentials for authenticated frontend requests
- permit wildcard only when APP_ENV/ENVIRONMENT is development-like
- add preflight, cross-origin GET, production wildcard restriction, and development wildcard tests

Validation:
- python -m pytest api/tests/test_cors.py
- python -m py_compile api/main.py api/tests/test_cors.py
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.