### PR TITLE
rates: emit parameter update details

### DIFF
--- a/contracts/lending/InterestRateModel.sol
+++ b/contracts/lending/InterestRateModel.sol
@@ -5,6 +5,13 @@ pragma solidity ^0.8.20;
 /// @notice Variable interest rate model based on pool utilization
 /// @dev Rate increases with utilization, with a kink at the optimal point
 contract InterestRateModel {
+    struct Parameters {
+        uint256 baseRate;
+        uint256 multiplier;
+        uint256 jumpMultiplier;
+        uint256 kink;
+    }
+
     // BUG: No bounds on base rate — admin can set baseRate to any value including
     // extremely high values that make borrowing effectively impossible, or zero
     // which means lenders earn nothing at low utilization
@@ -18,7 +25,7 @@ contract InterestRateModel {
 
     address public admin;
 
-    event RateParamsUpdated(uint256 baseRate, uint256 multiplier, uint256 jumpMultiplier, uint256 kink);
+    event RateParametersUpdated(Parameters oldParameters, Parameters newParameters);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -44,11 +51,21 @@ contract InterestRateModel {
         uint256 _jumpMultiplier,
         uint256 _kink
     ) external onlyAdmin {
+        Parameters memory oldParameters = getParameters();
         baseRate = _baseRate;
         multiplier = _multiplier;
         jumpMultiplier = _jumpMultiplier;
         kink = _kink;
-        emit RateParamsUpdated(_baseRate, _multiplier, _jumpMultiplier, _kink);
+        emit RateParametersUpdated(oldParameters, getParameters());
+    }
+
+    function getParameters() public view returns (Parameters memory) {
+        return Parameters({
+            baseRate: baseRate,
+            multiplier: multiplier,
+            jumpMultiplier: jumpMultiplier,
+            kink: kink
+        });
     }
 
     function getUtilization(uint256 totalBorrowed, uint256 totalDeposits) public pure returns (uint256) {

--- a/test/InterestRateModelParameters.test.js
+++ b/test/InterestRateModelParameters.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const solc = require("solc");
+
+function compileInterestRateModel() {
+  const sourcePath = "contracts/lending/InterestRateModel.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [sourcePath]: { content: fs.readFileSync(sourcePath, "utf8") },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return output.contracts[sourcePath].InterestRateModel;
+}
+
+async function deployModel(args) {
+  const [admin] = await ethers.getSigners();
+  const artifact = compileInterestRateModel();
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    admin
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+describe("InterestRateModel parameters", function () {
+  it("returns all current parameters", async function () {
+    const model = await deployModel([1, 2, 3, 4]);
+
+    const params = await model.getParameters();
+
+    expect(params.baseRate).to.equal(1);
+    expect(params.multiplier).to.equal(2);
+    expect(params.jumpMultiplier).to.equal(3);
+    expect(params.kink).to.equal(4);
+  });
+
+  it("emits old and new parameters on update", async function () {
+    const model = await deployModel([10, 20, 30, 40]);
+
+    await expect(model.updateParams(11, 21, 31, 41))
+      .to.emit(model, "RateParametersUpdated")
+      .withArgs([10, 20, 30, 40], [11, 21, 31, 41]);
+
+    const params = await model.getParameters();
+    expect(params.baseRate).to.equal(11);
+    expect(params.multiplier).to.equal(21);
+    expect(params.jumpMultiplier).to.equal(31);
+    expect(params.kink).to.equal(41);
+  });
+});


### PR DESCRIPTION
Fixes #193.
/claim #193

Updates InterestRateModel parameter changes so off-chain monitoring can see both the previous and new configuration.

What changed:
- replace the old new-values-only event with RateParametersUpdated(oldParameters, newParameters)
- add a Parameters struct and getParameters() view
- emit old/new parameter snapshots on updateParams
- add focused tests for getter output and update event payload

Validation:
- npx hardhat test --no-compile test/InterestRateModelParameters.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-rates contracts/lending/InterestRateModel.sol
- node --check test/InterestRateModelParameters.test.js
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.