### PR TITLE
lottery: add prize claim deadline

### DIFF
--- a/contracts/lottery/PrizeSplit.sol
+++ b/contracts/lottery/PrizeSplit.sol
@@ -8,10 +8,12 @@ contract PrizeSplit {
     address public admin;
     uint256 public totalPrize;
     uint256 public roundId;
+    uint256 public constant CLAIM_PERIOD = 90 days;
 
     struct Round {
         address[] winners;
         uint256 prizePool;
+        uint256 reclaimAfter;
         bool finalized;
         mapping(address => uint256) shares;
         mapping(address => bool) claimed;
@@ -22,6 +24,7 @@ contract PrizeSplit {
     event RoundFunded(uint256 indexed roundId, uint256 amount);
     event RoundFinalized(uint256 indexed roundId, uint256 winnerCount);
     event PrizeClaimed(address indexed winner, uint256 amount, uint256 indexed roundId);
+    event UnclaimedPrizesReclaimed(uint256 indexed roundId, uint256 amount);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -39,12 +42,11 @@ contract PrizeSplit {
         emit RoundFunded(roundId, msg.value);
     }
 
-    // BUG: No zero-winner check — if winners array is empty, the function
-    // succeeds silently and the prize pool becomes permanently locked
     function finalizeRound(uint256 _roundId, address[] calldata winners) external onlyAdmin {
         Round storage round = rounds[_roundId];
         require(!round.finalized, "Already finalized");
         require(round.prizePool > 0, "No prize pool");
+        require(winners.length > 0, "No winners");
 
         // BUG: Rounding error loses dust — integer division truncates remainder,
         // so (prizePool % winners.length) wei is permanently locked in the contract
@@ -55,12 +57,11 @@ contract PrizeSplit {
             round.shares[winners[i]] = sharePerWinner;
         }
 
+        round.reclaimAfter = block.timestamp + CLAIM_PERIOD;
         round.finalized = true;
         emit RoundFinalized(_roundId, winners.length);
     }
 
-    // BUG: Reentrancy — state (claimed flag) is set after the external call,
-    // allowing a malicious contract to re-enter claimPrize and drain funds
     function claimPrize(uint256 _roundId) external {
         Round storage round = rounds[_roundId];
         require(round.finalized, "Not finalized");
@@ -69,13 +70,37 @@ contract PrizeSplit {
 
         uint256 amount = round.shares[msg.sender];
 
+        round.claimed[msg.sender] = true;
+        totalPrize -= amount;
+
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "Transfer failed");
 
-        // State updated after external call — reentrancy window
-        round.claimed[msg.sender] = true;
-
         emit PrizeClaimed(msg.sender, amount, _roundId);
+    }
+
+    function reclaimUnclaimed(uint256 _roundId) external onlyAdmin {
+        Round storage round = rounds[_roundId];
+        require(round.finalized, "Not finalized");
+        require(block.timestamp >= round.reclaimAfter, "Claim period active");
+
+        uint256 amount;
+        for (uint256 i = 0; i < round.winners.length; i++) {
+            address winner = round.winners[i];
+            if (!round.claimed[winner]) {
+                uint256 share = round.shares[winner];
+                round.claimed[winner] = true;
+                amount += share;
+            }
+        }
+
+        require(amount > 0, "No unclaimed prizes");
+        totalPrize -= amount;
+
+        (bool sent, ) = admin.call{value: amount}("");
+        require(sent, "Treasury transfer failed");
+
+        emit UnclaimedPrizesReclaimed(_roundId, amount);
     }
 
     function getShare(uint256 _roundId, address winner) external view returns (uint256) {
@@ -84,5 +109,9 @@ contract PrizeSplit {
 
     function isClaimed(uint256 _roundId, address winner) external view returns (bool) {
         return rounds[_roundId].claimed[winner];
+    }
+
+    function getReclaimAfter(uint256 _roundId) external view returns (uint256) {
+        return rounds[_roundId].reclaimAfter;
     }
 }

--- a/test/PrizeSplitPullClaims.test.js
+++ b/test/PrizeSplitPullClaims.test.js
@@ -1,0 +1,121 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const solc = require("solc");
+
+function compileContracts() {
+  const prizeSplitPath = "contracts/lottery/PrizeSplit.sol";
+  const rejectWinnerPath = "contracts/test/RejectEthWinner.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [prizeSplitPath]: { content: fs.readFileSync(prizeSplitPath, "utf8") },
+      [rejectWinnerPath]: {
+        content: `
+          // SPDX-License-Identifier: MIT
+          pragma solidity ^0.8.20;
+
+          contract RejectEthWinner {
+              function claim(address prizeSplit, uint256 roundId) external {
+                  (bool ok, ) = prizeSplit.call(
+                      abi.encodeWithSignature("claimPrize(uint256)", roundId)
+                  );
+                  require(ok, "claim failed");
+              }
+          }
+        `,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return {
+    prizeSplit: output.contracts[prizeSplitPath].PrizeSplit,
+    rejectWinner: output.contracts[rejectWinnerPath].RejectEthWinner,
+  };
+}
+
+async function deploy(artifact, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    signer
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function increaseTime(seconds) {
+  await ethers.provider.send("evm_increaseTime", [seconds]);
+  await ethers.provider.send("evm_mine");
+}
+
+describe("PrizeSplit pull claims", function () {
+  let compiled;
+  let admin;
+  let winner;
+  let other;
+  let prizeSplit;
+  let rejectWinner;
+
+  before(function () {
+    compiled = compileContracts();
+  });
+
+  beforeEach(async function () {
+    [admin, winner, other] = await ethers.getSigners();
+    prizeSplit = await deploy(compiled.prizeSplit, admin);
+    rejectWinner = await deploy(compiled.rejectWinner, admin);
+  });
+
+  async function fundAndFinalize(winners, value = ethers.parseEther("2")) {
+    await prizeSplit.fundRound({ value });
+    await prizeSplit.finalizeRound(1, winners);
+  }
+
+  it("lets other winners claim even when a contract winner rejects ETH", async function () {
+    await fundAndFinalize([await rejectWinner.getAddress(), winner.address]);
+
+    await expect(
+      rejectWinner.claim(await prizeSplit.getAddress(), 1)
+    ).to.be.revertedWith("claim failed");
+
+    await expect(prizeSplit.connect(winner).claimPrize(1))
+      .to.emit(prizeSplit, "PrizeClaimed")
+      .withArgs(winner.address, ethers.parseEther("1"), 1);
+    expect(await prizeSplit.isClaimed(1, winner.address)).to.equal(true);
+    expect(await prizeSplit.isClaimed(1, await rejectWinner.getAddress())).to.equal(false);
+  });
+
+  it("prevents treasury reclaim before the claim deadline", async function () {
+    await fundAndFinalize([winner.address, other.address]);
+
+    await expect(prizeSplit.reclaimUnclaimed(1))
+      .to.be.revertedWith("Claim period active");
+  });
+
+  it("reclaims unclaimed prizes after 90 days", async function () {
+    await fundAndFinalize([winner.address, other.address]);
+    await prizeSplit.connect(winner).claimPrize(1);
+
+    await increaseTime(90 * 24 * 60 * 60);
+
+    await expect(prizeSplit.reclaimUnclaimed(1))
+      .to.emit(prizeSplit, "UnclaimedPrizesReclaimed")
+      .withArgs(1, ethers.parseEther("1"));
+    expect(await prizeSplit.isClaimed(1, other.address)).to.equal(true);
+  });
+});


### PR DESCRIPTION
Fixes #189.
/claim #189

Hardens PrizeSplit claims so a rejecting contract winner cannot affect other winners and unclaimed prizes can be recovered after the claim period.

What changed:
- keep claims pull-based and move claimed/accounting updates before the external ETH transfer
- add a 90-day CLAIM_PERIOD and per-round reclaimAfter timestamp
- add admin reclaimUnclaimed() for expired unclaimed shares
- add zero-winner validation and reclaim deadline getter
- add focused tests for rejecting contract winner, active deadline, and treasury reclaim after 90 days

Validation:
- npx hardhat test --no-compile test/PrizeSplitPullClaims.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-prize contracts/lottery/PrizeSplit.sol
- node --check test/PrizeSplitPullClaims.test.js
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.