### PR TITLE
escrow: store received token amount

### DIFF
--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract PaymentEscrow is Ownable {
+    using SafeERC20 for IERC20;
+
     struct Escrow {
         address payer;
         address payee;
@@ -33,20 +36,24 @@ contract PaymentEscrow is Ownable {
         require(payee != address(0), "Invalid payee");
         require(amount > 0, "Amount must be > 0");
 
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20 escrowToken = IERC20(token);
+        uint256 balanceBefore = escrowToken.balanceOf(address(this));
+        escrowToken.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 receivedAmount = escrowToken.balanceOf(address(this)) - balanceBefore;
+        require(receivedAmount > 0, "No tokens received");
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
             payer: msg.sender,
             payee: payee,
             token: token,
-            amount: amount,
+            amount: receivedAmount,
             releaseTime: block.timestamp + lockDuration,
             released: false,
             refunded: false
         });
 
-        emit EscrowCreated(escrowId, msg.sender, amount);
+        emit EscrowCreated(escrowId, msg.sender, receivedAmount);
         return escrowId;
     }
 
@@ -56,7 +63,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer || msg.sender == owner(), "Not authorized");
 
         escrow.released = true;
-        IERC20(escrow.token).transfer(escrow.payee, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payee, escrow.amount);
 
         emit EscrowReleased(escrowId, escrow.payee, escrow.amount);
     }
@@ -68,7 +75,7 @@ contract PaymentEscrow is Ownable {
         require(msg.sender == escrow.payer, "Not payer");
 
         escrow.refunded = true;
-        IERC20(escrow.token).transfer(escrow.payer, escrow.amount);
+        IERC20(escrow.token).safeTransfer(escrow.payer, escrow.amount);
 
         emit EscrowRefunded(escrowId, escrow.payer, escrow.amount);
     }

--- a/test/PaymentEscrowReceivedAmount.test.js
+++ b/test/PaymentEscrowReceivedAmount.test.js
@@ -1,0 +1,155 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(process.cwd(), importPath),
+    path.join(process.cwd(), "node_modules", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileContracts() {
+  const escrowPath = "contracts/PaymentEscrow.sol";
+  const tokenPath = "contracts/test/FeeOnTransferToken.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [escrowPath]: { content: fs.readFileSync(escrowPath, "utf8") },
+      [tokenPath]: {
+        content: `
+          // SPDX-License-Identifier: MIT
+          pragma solidity ^0.8.20;
+          import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+          contract FeeOnTransferToken is ERC20 {
+              uint256 public feeBps;
+
+              constructor(uint256 _feeBps) ERC20("Fee Token", "FEE") {
+                  feeBps = _feeBps;
+              }
+
+              function mint(address account, uint256 amount) external {
+                  _mint(account, amount);
+              }
+
+              function _update(address from, address to, uint256 amount) internal override {
+                  if (from != address(0) && to != address(0) && feeBps > 0) {
+                      uint256 fee = amount * feeBps / 10000;
+                      super._update(from, to, amount - fee);
+                      super._update(from, address(0), fee);
+                  } else {
+                      super._update(from, to, amount);
+                  }
+              }
+          }
+        `,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return {
+    escrow: output.contracts[escrowPath].PaymentEscrow,
+    token: output.contracts[tokenPath].FeeOnTransferToken,
+  };
+}
+
+async function deploy(artifact, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    signer
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+describe("PaymentEscrow received amount accounting", function () {
+  let compiled;
+  let payer;
+  let payee;
+  let escrow;
+
+  before(function () {
+    compiled = compileContracts();
+  });
+
+  beforeEach(async function () {
+    [payer, payee] = await ethers.getSigners();
+    escrow = await deploy(compiled.escrow, payer);
+  });
+
+  async function deployToken(feeBps) {
+    const token = await deploy(compiled.token, payer, [feeBps]);
+    await token.mint(payer.address, ethers.parseEther("100"));
+    await token.approve(await escrow.getAddress(), ethers.parseEther("100"));
+    return token;
+  }
+
+  it("rejects zero amount escrows", async function () {
+    const token = await deployToken(0);
+
+    await expect(
+      escrow.createEscrow(payee.address, await token.getAddress(), 0, 0)
+    ).to.be.revertedWith("Amount must be > 0");
+  });
+
+  it("stores the full amount for standard ERC20 transfers", async function () {
+    const token = await deployToken(0);
+    const amount = ethers.parseEther("10");
+
+    await expect(escrow.createEscrow(payee.address, await token.getAddress(), amount, 0))
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0, payer.address, amount);
+
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(amount);
+  });
+
+  it("stores only the actual received amount for fee-on-transfer tokens", async function () {
+    const token = await deployToken(1000);
+    const amount = ethers.parseEther("10");
+    const received = ethers.parseEther("9");
+
+    await expect(escrow.createEscrow(payee.address, await token.getAddress(), amount, 0))
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0, payer.address, received);
+
+    const stored = await escrow.escrows(0);
+    expect(stored.amount).to.equal(received);
+    expect(await token.balanceOf(await escrow.getAddress())).to.equal(received);
+  });
+
+  it("releases the stored received amount", async function () {
+    const token = await deployToken(1000);
+    await escrow.createEscrow(payee.address, await token.getAddress(), ethers.parseEther("10"), 0);
+
+    await escrow.releaseEscrow(0);
+
+    expect(await token.balanceOf(payee.address)).to.equal(ethers.parseEther("8.1"));
+  });
+});


### PR DESCRIPTION
Fixes #179.
/claim #179

Updates PaymentEscrow to account for the actual token amount received, so fee-on-transfer tokens cannot overstate escrow value.

What changed:
- use SafeERC20 for transferFrom, release, and refund
- keep zero amount rejection
- measure token balance before/after deposit
- store and emit the received amount instead of the requested input amount
- add focused tests for zero amount, standard ERC20, fee-on-transfer accounting, and release of the stored amount

Validation:
- npx hardhat test --no-compile test/PaymentEscrowReceivedAmount.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-escrow contracts/PaymentEscrow.sol
- node --check test/PaymentEscrowReceivedAmount.test.js
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.