### PR TITLE
lottery: add cancellation refunds

### DIFF
--- a/contracts/lottery/RandomLottery.sol
+++ b/contracts/lottery/RandomLottery.sol
@@ -9,13 +9,19 @@ contract RandomLottery {
     uint256 public ticketPrice;
     uint256 public roundEnd;
     uint256 public currentRound;
+    uint256 public minimumParticipants;
+    bool public cancelled;
 
     address[] public players;
     mapping(uint256 => address) public roundWinners;
+    mapping(uint256 => mapping(address => uint256)) public contributions;
+    mapping(uint256 => mapping(address => bool)) public refunded;
 
     event TicketPurchased(address indexed player, uint256 round);
     event RoundStarted(uint256 indexed round, uint256 endTime);
     event WinnerSelected(address indexed winner, uint256 prize, uint256 round);
+    event LotteryCancelled(uint256 indexed round);
+    event TicketRefunded(address indexed player, uint256 indexed round, uint256 amount);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "Not owner");
@@ -25,6 +31,7 @@ contract RandomLottery {
     constructor(uint256 _ticketPrice) {
         owner = msg.sender;
         ticketPrice = _ticketPrice;
+        minimumParticipants = 2;
     }
 
     function startRound(uint256 duration) external onlyOwner {
@@ -32,18 +39,23 @@ contract RandomLottery {
         delete players;
         currentRound++;
         roundEnd = block.timestamp + duration;
+        cancelled = false;
         emit RoundStarted(currentRound, roundEnd);
     }
 
     function buyTicket() external payable {
         require(block.timestamp < roundEnd, "Round ended");
+        require(!cancelled, "Lottery cancelled");
         require(msg.value == ticketPrice, "Wrong ticket price");
         players.push(msg.sender);
+        contributions[currentRound][msg.sender] += msg.value;
         emit TicketPurchased(msg.sender, currentRound);
     }
 
     function drawWinner() external onlyOwner {
         require(block.timestamp >= roundEnd, "Round not ended");
+        require(!cancelled, "Lottery cancelled");
+        require(players.length >= minimumParticipants, "Not enough participants");
 
         // BUG: prevrandao is manipulable by validators — validators can influence
         // the randomness value, making the lottery outcome predictable/riggable
@@ -65,6 +77,38 @@ contract RandomLottery {
         require(sent, "Transfer failed");
 
         emit WinnerSelected(winner, prize, currentRound);
+    }
+
+    function cancelLottery() external onlyOwner {
+        require(roundEnd != 0, "No active round");
+        require(block.timestamp >= roundEnd, "Round not ended");
+        require(roundWinners[currentRound] == address(0), "Winner already selected");
+        require(players.length < minimumParticipants, "Minimum met");
+
+        cancelled = true;
+        roundEnd = 0;
+        emit LotteryCancelled(currentRound);
+    }
+
+    function refund(uint256 round) external {
+        require(cancelled && round == currentRound, "Lottery not cancelled");
+        require(!refunded[round][msg.sender], "Already refunded");
+
+        uint256 amount = contributions[round][msg.sender];
+        require(amount > 0, "No refund");
+
+        refunded[round][msg.sender] = true;
+        contributions[round][msg.sender] = 0;
+
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        require(sent, "Refund failed");
+
+        emit TicketRefunded(msg.sender, round, amount);
+    }
+
+    function setMinimumParticipants(uint256 minimum) external onlyOwner {
+        require(minimum > 0, "Invalid minimum");
+        minimumParticipants = minimum;
     }
 
     function getPlayers() external view returns (address[] memory) {

--- a/test/RandomLotteryRefunds.test.js
+++ b/test/RandomLotteryRefunds.test.js
@@ -1,0 +1,98 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const solc = require("solc");
+
+function compileLottery() {
+  const sourcePath = "contracts/lottery/RandomLottery.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [sourcePath]: { content: fs.readFileSync(sourcePath, "utf8") },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return output.contracts[sourcePath].RandomLottery;
+}
+
+async function deployLottery(ticketPrice) {
+  const [owner] = await ethers.getSigners();
+  const artifact = compileLottery();
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    owner
+  );
+  const contract = await factory.deploy(ticketPrice);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function increaseTime(seconds) {
+  await ethers.provider.send("evm_increaseTime", [seconds]);
+  await ethers.provider.send("evm_mine");
+}
+
+describe("RandomLottery refunds", function () {
+  let owner;
+  let player;
+  let other;
+  let lottery;
+  const ticketPrice = ethers.parseEther("1");
+
+  beforeEach(async function () {
+    [owner, player, other] = await ethers.getSigners();
+    lottery = await deployLottery(ticketPrice);
+    await lottery.startRound(60);
+  });
+
+  it("cancels after the deadline when minimum participants are not met", async function () {
+    await lottery.connect(player).buyTicket({ value: ticketPrice });
+    await increaseTime(61);
+
+    await expect(lottery.cancelLottery())
+      .to.emit(lottery, "LotteryCancelled")
+      .withArgs(1);
+
+    expect(await lottery.cancelled()).to.equal(true);
+  });
+
+  it("refunds each participant exactly once after cancellation", async function () {
+    await lottery.connect(player).buyTicket({ value: ticketPrice });
+    await increaseTime(61);
+    await lottery.cancelLottery();
+
+    await expect(lottery.connect(player).refund(1))
+      .to.emit(lottery, "TicketRefunded")
+      .withArgs(player.address, 1, ticketPrice);
+    await expect(lottery.connect(player).refund(1))
+      .to.be.revertedWith("Already refunded");
+    expect(await ethers.provider.getBalance(await lottery.getAddress())).to.equal(0);
+  });
+
+  it("does not allow refunds while the round is active or completed", async function () {
+    await lottery.connect(player).buyTicket({ value: ticketPrice });
+    await expect(lottery.connect(player).refund(1))
+      .to.be.revertedWith("Lottery not cancelled");
+
+    await lottery.connect(other).buyTicket({ value: ticketPrice });
+    await increaseTime(61);
+    await lottery.drawWinner();
+
+    await expect(lottery.connect(player).refund(1))
+      .to.be.revertedWith("Lottery not cancelled");
+  });
+});


### PR DESCRIPTION
Fixes #176.
/claim #176

Adds cancellation and exact participant refunds for RandomLottery rounds that miss the minimum participant count after the deadline.

What changed:
- track minimumParticipants, cancelled state, and per-round contributions
- allow owner cancellation after deadline when minimum participants are not met
- add participant refund(round) with double-refund protection
- block refunds for active/completed lotteries
- add focused tests for cancellation, exact refund, double-refund prevention, and active/completed refund rejection

Validation:
- npx hardhat test --no-compile test/RandomLotteryRefunds.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-lottery contracts/lottery/RandomLottery.sol
- node --check test/RandomLotteryRefunds.test.js
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.