### PR TITLE
registry: add batch registration

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -20,6 +20,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public constant MAX_BATCH_REGISTER = 50;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -32,14 +33,37 @@ contract AgentRegistry is Ownable {
 
     function registerAgent(string calldata name, string calldata endpoint) external payable returns (bytes32) {
         require(msg.value >= registrationFee, "Insufficient fee");
+        return _registerAgent(msg.sender, name, endpoint, 0);
+    }
+
+    function batchRegister(
+        string[] calldata names,
+        string[] calldata endpoints
+    ) external payable returns (bytes32[] memory registeredAgentIds) {
+        require(names.length == endpoints.length, "Length mismatch");
+        require(names.length > 0 && names.length <= MAX_BATCH_REGISTER, "Invalid batch size");
+        require(msg.value >= registrationFee * names.length, "Insufficient fee");
+
+        registeredAgentIds = new bytes32[](names.length);
+        for (uint256 i = 0; i < names.length; i++) {
+            registeredAgentIds[i] = _registerAgent(msg.sender, names[i], endpoints[i], i);
+        }
+    }
+
+    function _registerAgent(
+        address agentOwner,
+        string calldata name,
+        string calldata endpoint,
+        uint256 salt
+    ) internal returns (bytes32) {
         require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
 
-        bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp));
+        bytes32 agentId = keccak256(abi.encodePacked(agentOwner, name, endpoint, block.timestamp, salt));
 
         require(agents[agentId].registeredAt == 0, "Agent exists");
 
         agents[agentId] = Agent({
-            owner: msg.sender,
+            owner: agentOwner,
             name: name,
             endpoint: endpoint,
             reputation: 100,
@@ -48,10 +72,10 @@ contract AgentRegistry is Ownable {
             active: true
         });
 
-        ownerAgents[msg.sender].push(agentId);
+        ownerAgents[agentOwner].push(agentId);
         agentIds.push(agentId);
 
-        emit AgentRegistered(agentId, msg.sender, name);
+        emit AgentRegistered(agentId, agentOwner, name);
         return agentId;
     }
 
@@ -77,6 +101,10 @@ contract AgentRegistry is Ownable {
 
     function getAgent(bytes32 agentId) external view returns (Agent memory) {
         return agents[agentId];
+    }
+
+    function getAgentIds() external view returns (bytes32[] memory) {
+        return agentIds;
     }
 
     function getActiveAgentCount() external view returns (uint256 count) {

--- a/test/AgentRegistryBatchRegister.test.js
+++ b/test/AgentRegistryBatchRegister.test.js
@@ -1,0 +1,118 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(process.cwd(), importPath),
+    path.join(process.cwd(), "node_modules", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileAgentRegistry() {
+  const sourcePath = "contracts/AgentRegistry.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [sourcePath]: { content: fs.readFileSync(sourcePath, "utf8") },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return output.contracts[sourcePath].AgentRegistry;
+}
+
+async function deployRegistry(registrationFee) {
+  const [owner] = await ethers.getSigners();
+  const artifact = compileAgentRegistry();
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    owner
+  );
+  const contract = await factory.deploy(registrationFee);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+describe("AgentRegistry batchRegister", function () {
+  let user;
+  let registry;
+  const registrationFee = ethers.parseEther("0.01");
+
+  beforeEach(async function () {
+    [, user] = await ethers.getSigners();
+    registry = await deployRegistry(registrationFee);
+  });
+
+  it("registers a batch of one", async function () {
+    await expect(
+      registry.connect(user).batchRegister(["one"], ["https://one.example"], {
+        value: registrationFee,
+      })
+    ).to.emit(registry, "AgentRegistered");
+
+    const ids = await registry.getAgentIds();
+    expect(ids).to.have.length(1);
+    const agent = await registry.getAgent(ids[0]);
+    expect(agent.owner).to.equal(user.address);
+    expect(agent.name).to.equal("one");
+  });
+
+  it("registers a batch of 50 agents with unique IDs", async function () {
+    const names = [];
+    const endpoints = [];
+    for (let i = 0; i < 50; i++) {
+      names.push(`agent-${i}`);
+      endpoints.push(`https://agent-${i}.example`);
+    }
+
+    await registry.connect(user).batchRegister(names, endpoints, {
+      value: registrationFee * 50n,
+    });
+
+    const ids = await registry.getAgentIds();
+    expect(ids).to.have.length(50);
+    expect(new Set(ids).size).to.equal(50);
+
+    const lastAgent = await registry.getAgent(ids[49]);
+    expect(lastAgent.name).to.equal("agent-49");
+    expect(lastAgent.endpoint).to.equal("https://agent-49.example");
+  });
+
+  it("reverts on length mismatch", async function () {
+    await expect(
+      registry.connect(user).batchRegister(["one"], [], { value: registrationFee })
+    ).to.be.revertedWith("Length mismatch");
+  });
+
+  it("requires the aggregate registration fee", async function () {
+    await expect(
+      registry.connect(user).batchRegister(["one", "two"], ["a", "b"], {
+        value: registrationFee,
+      })
+    ).to.be.revertedWith("Insufficient fee");
+  });
+});


### PR DESCRIPTION
Fixes #182.
/claim #182

Adds bounded batch registration for AgentRegistry so platforms can onboard up to 50 agents in one transaction while still emitting individual AgentRegistered events.

What changed:
- add MAX_BATCH_REGISTER = 50
- add batchRegister(names, endpoints) with length and size validation
- require aggregate registration fee once: registrationFee * count
- share single-agent and batch logic through an internal _registerAgent helper
- include endpoint and batch index in the ID salt so same-block batch entries remain unique
- add getAgentIds() helper for inspection/tests
- add focused tests for batch of 1, batch of 50, length mismatch, and aggregate fee

Validation:
- npx hardhat test --no-compile test/AgentRegistryBatchRegister.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-registry-batch contracts/AgentRegistry.sol
- node --check test/AgentRegistryBatchRegister.test.js
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.