### PR TITLE
router: add sponsored task execution

### DIFF
--- a/contracts/TaskRouter.sol
+++ b/contracts/TaskRouter.sol
@@ -5,6 +5,7 @@ import "./AgentRegistry.sol";
 
 contract TaskRouter {
     AgentRegistry public registry;
+    address private sponsoredExecutor;
 
     enum TaskStatus { Open, Assigned, Completed, Disputed, Cancelled }
 
@@ -21,11 +22,16 @@ contract TaskRouter {
     mapping(uint256 => Task) public tasks;
     uint256 public taskCount;
     uint256 public platformFee; // basis points
+    mapping(address => uint256) public agentNonces;
+    mapping(address => uint256) public agentStake;
 
     event TaskCreated(uint256 indexed taskId, address indexed creator, uint256 reward);
     event TaskAssigned(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskCompleted(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskDisputed(uint256 indexed taskId);
+    event StakeDeposited(address indexed agent, uint256 amount);
+    event StakeWithdrawn(address indexed agent, uint256 amount);
+    event SponsoredExecution(address indexed agent, address indexed relayer, uint256 nonce, uint256 reimbursement);
 
     constructor(address _registry, uint256 _platformFee) {
         registry = AgentRegistry(_registry);
@@ -71,7 +77,8 @@ contract TaskRouter {
         require(task.status == TaskStatus.Assigned, "Not assigned");
 
         AgentRegistry.Agent memory agent = registry.getAgent(task.assignedAgent);
-        require(agent.owner == msg.sender, "Not assigned agent owner");
+        address executor = sponsoredExecutor == address(0) ? msg.sender : sponsoredExecutor;
+        require(agent.owner == executor, "Not assigned agent owner");
 
         task.result = result;
         task.status = TaskStatus.Completed;
@@ -79,10 +86,87 @@ contract TaskRouter {
         uint256 fee = task.reward * platformFee / 10000;
         uint256 payout = task.reward - fee;
 
-        (bool success, ) = msg.sender.call{value: payout}("");
+        (bool success, ) = executor.call{value: payout}("");
         require(success, "Payout failed");
 
         emit TaskCompleted(taskId, task.assignedAgent);
+    }
+
+    function depositStake() external payable {
+        require(msg.value > 0, "Stake required");
+        agentStake[msg.sender] += msg.value;
+        emit StakeDeposited(msg.sender, msg.value);
+    }
+
+    function withdrawStake(uint256 amount) external {
+        require(agentStake[msg.sender] >= amount, "Insufficient stake");
+        agentStake[msg.sender] -= amount;
+
+        (bool success, ) = msg.sender.call{value: amount}("");
+        require(success, "Withdraw failed");
+
+        emit StakeWithdrawn(msg.sender, amount);
+    }
+
+    function executeOnBehalf(
+        address agent,
+        bytes calldata callData,
+        bytes calldata signature
+    ) external returns (bytes memory result) {
+        require(agent != address(0), "Invalid agent");
+        require(sponsoredExecutor == address(0), "Nested sponsorship");
+
+        uint256 startGas = gasleft();
+        uint256 nonce = agentNonces[agent];
+        bytes32 digest = _sponsoredDigest(agent, callData, nonce);
+        require(_recoverSigner(digest, signature) == agent, "Invalid signature");
+
+        agentNonces[agent] = nonce + 1;
+        sponsoredExecutor = agent;
+
+        bool success;
+        (success, result) = address(this).call(callData);
+        sponsoredExecutor = address(0);
+        require(success, "Sponsored call failed");
+
+        uint256 reimbursement = (startGas - gasleft() + 21000) * tx.gasprice;
+        require(agentStake[agent] >= reimbursement, "Insufficient stake");
+        agentStake[agent] -= reimbursement;
+
+        (bool paid, ) = msg.sender.call{value: reimbursement}("");
+        require(paid, "Reimbursement failed");
+
+        emit SponsoredExecution(agent, msg.sender, nonce, reimbursement);
+    }
+
+    function sponsoredDigest(
+        address agent,
+        bytes calldata callData,
+        uint256 nonce
+    ) external view returns (bytes32) {
+        return _sponsoredDigest(agent, callData, nonce);
+    }
+
+    function _sponsoredDigest(
+        address agent,
+        bytes calldata callData,
+        uint256 nonce
+    ) internal view returns (bytes32) {
+        bytes32 messageHash = keccak256(abi.encodePacked(block.chainid, address(this), agent, nonce, callData));
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+    }
+
+    function _recoverSigner(bytes32 digest, bytes calldata signature) internal pure returns (address) {
+        require(signature.length == 65, "Invalid signature length");
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+        return ecrecover(digest, v, r, s);
     }
 
     function cancelTask(uint256 taskId) external {

--- a/test/TaskRouterGasSponsorship.test.js
+++ b/test/TaskRouterGasSponsorship.test.js
@@ -1,0 +1,145 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(process.cwd(), importPath),
+    path.join(process.cwd(), "node_modules", importPath),
+    path.join(process.cwd(), "contracts", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileContracts() {
+  const registryPath = "contracts/AgentRegistry.sol";
+  const routerPath = "contracts/TaskRouter.sol";
+  const input = {
+    language: "Solidity",
+    sources: {
+      [registryPath]: { content: fs.readFileSync(registryPath, "utf8") },
+      [routerPath]: { content: fs.readFileSync(routerPath, "utf8") },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return {
+    registry: output.contracts[registryPath].AgentRegistry,
+    router: output.contracts[routerPath].TaskRouter,
+  };
+}
+
+async function deploy(artifact, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    `0x${artifact.evm.bytecode.object}`,
+    signer
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function signSponsored(router, agent, callData) {
+  const nonce = await router.agentNonces(agent.address);
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  const messageHash = ethers.solidityPackedKeccak256(
+    ["uint256", "address", "address", "uint256", "bytes"],
+    [chainId, await router.getAddress(), agent.address, nonce, callData]
+  );
+  return agent.signMessage(ethers.getBytes(messageHash));
+}
+
+describe("TaskRouter gas sponsorship", function () {
+  let compiled;
+  let creator;
+  let agent;
+  let relayer;
+  let registry;
+  let router;
+  let agentId;
+
+  before(function () {
+    compiled = compileContracts();
+  });
+
+  beforeEach(async function () {
+    [creator, agent, relayer] = await ethers.getSigners();
+    registry = await deploy(compiled.registry, creator, [0]);
+    router = await deploy(compiled.router, creator, [await registry.getAddress(), 0]);
+
+    const receipt = await (await registry.connect(agent).registerAgent("agent", "https://agent.example")).wait();
+    agentId = receipt.logs
+      .map((log) => {
+        try {
+          return registry.interface.parseLog(log);
+        } catch (_error) {
+          return null;
+        }
+      })
+      .find((log) => log && log.name === "AgentRegistered").args.agentId;
+
+    await router.connect(creator).createTask("do work", (await timeNow()) + 3600, {
+      value: ethers.parseEther("1"),
+    });
+    await router.connect(agent).assignTask(0, agentId);
+  });
+
+  it("executes an agent-signed task completion through a relayer", async function () {
+    await router.connect(agent).depositStake({ value: ethers.parseEther("0.1") });
+    const callData = router.interface.encodeFunctionData("completeTask", [0, "0x1234"]);
+    const signature = await signSponsored(router, agent, callData);
+
+    await expect(router.connect(relayer).executeOnBehalf(agent.address, callData, signature))
+      .to.emit(router, "SponsoredExecution");
+
+    const task = await router.tasks(0);
+    expect(task.status).to.equal(2);
+    expect(await router.agentNonces(agent.address)).to.equal(1);
+    expect(await router.agentStake(agent.address)).to.be.lessThan(ethers.parseEther("0.1"));
+  });
+
+  it("rejects replayed sponsored executions", async function () {
+    await router.connect(agent).depositStake({ value: ethers.parseEther("0.1") });
+    const callData = router.interface.encodeFunctionData("completeTask", [0, "0x1234"]);
+    const signature = await signSponsored(router, agent, callData);
+
+    await router.connect(relayer).executeOnBehalf(agent.address, callData, signature);
+    await expect(router.connect(relayer).executeOnBehalf(agent.address, callData, signature))
+      .to.be.revertedWith("Invalid signature");
+  });
+
+  it("reverts if the agent stake cannot reimburse the relayer", async function () {
+    const callData = router.interface.encodeFunctionData("completeTask", [0, "0x1234"]);
+    const signature = await signSponsored(router, agent, callData);
+
+    await expect(router.connect(relayer).executeOnBehalf(agent.address, callData, signature))
+      .to.be.revertedWith("Insufficient stake");
+  });
+});
+
+async function timeNow() {
+  const block = await ethers.provider.getBlock("latest");
+  return block.timestamp;
+}


### PR DESCRIPTION
Fixes #190.
/claim #190

Adds gas-sponsored execution for TaskRouter so a relayer can submit an agent-signed task action and be reimbursed from the agent stake.

What changed:
- add agentNonces and agentStake tracking
- add depositStake and withdrawStake
- add executeOnBehalf(agent, callData, signature) with signed calldata verification
- bind signatures to chain id, TaskRouter address, agent, nonce, and calldata
- add replay protection through per-agent nonces
- reimburse the relayer from the agent stake after successful sponsored execution
- allow completeTask to recognize the signed sponsored executor while preserving direct calls
- add focused tests for sponsored completion, replay rejection, and insufficient stake

Validation:
- npx hardhat test --no-compile test/TaskRouterGasSponsorship.test.js
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-taskrouter contracts/TaskRouter.sol
- node --check test/TaskRouterGasSponsorship.test.js
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.