### PR TITLE
api: add admin audit log

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, event,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -84,6 +84,27 @@ class Payment(Base):
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    action = Column(String(128), nullable=False, index=True)
+    actor = Column(String(128), nullable=False, index=True)
+    target = Column(String(256), nullable=False, index=True)
+    before = Column(JSON, nullable=True)
+    after = Column(JSON, nullable=True)
+    ip = Column(String(64), nullable=True)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+
+def _prevent_audit_mutation(_mapper, _connection, _target):
+    raise ValueError("AuditLog records are immutable")
+
+
+event.listen(AuditLog, "before_update", _prevent_audit_mutation)
+event.listen(AuditLog, "before_delete", _prevent_audit_mutation)
 
 
 def init_db():

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,0 +1,83 @@
+"""Admin audit log endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
+
+from ..middleware.auth import require_role
+from ..models.database import AuditLog, get_db
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+admin_required = require_role("admin")
+
+
+def create_audit_log(
+    db: Session,
+    *,
+    action: str,
+    actor: str,
+    target: str,
+    before: Optional[dict] = None,
+    after: Optional[dict] = None,
+    ip: Optional[str] = None,
+) -> AuditLog:
+    audit_log = AuditLog(
+        action=action,
+        actor=actor,
+        target=target,
+        before=before,
+        after=after,
+        ip=ip,
+    )
+    db.add(audit_log)
+    db.commit()
+    db.refresh(audit_log)
+    return audit_log
+
+
+def audit_admin_action(
+    db: Session,
+    request: Request,
+    *,
+    action: str,
+    actor: str,
+    target: str,
+    before: Optional[dict] = None,
+    after: Optional[dict] = None,
+) -> AuditLog:
+    client_ip = request.client.host if request.client else None
+    return create_audit_log(
+        db,
+        action=action,
+        actor=actor,
+        target=target,
+        before=before,
+        after=after,
+        ip=client_ip,
+    )
+
+
+@router.get("/audit-log")
+async def list_audit_log(
+    actor: Optional[str] = None,
+    action: Optional[str] = None,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=500),
+    _admin=Depends(admin_required),
+    db: Session = Depends(get_db),
+):
+    query = db.query(AuditLog)
+    if actor:
+        query = query.filter(AuditLog.actor == actor)
+    if action:
+        query = query.filter(AuditLog.action == action)
+    if since:
+        query = query.filter(AuditLog.timestamp >= since)
+    if until:
+        query = query.filter(AuditLog.timestamp <= until)
+
+    return query.order_by(AuditLog.timestamp.desc()).offset(skip).limit(limit).all()

--- a/api/tests/test_admin_audit_log.py
+++ b/api/tests/test_admin_audit_log.py
@@ -1,0 +1,88 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import AuditLog, Base, get_db
+from api.routes.admin import admin_required, create_audit_log, router
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client(db_session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[admin_required] = lambda: {"id": 1, "roles": ["admin"]}
+    return TestClient(app)
+
+
+def test_create_audit_log(db_session):
+    entry = create_audit_log(
+        db_session,
+        action="set_fee",
+        actor="admin-1",
+        target="registration_fee",
+        before={"fee": 1},
+        after={"fee": 2},
+        ip="203.0.113.10",
+    )
+
+    stored = db_session.query(AuditLog).filter(AuditLog.id == entry.id).one()
+    assert stored.action == "set_fee"
+    assert stored.actor == "admin-1"
+    assert stored.before == {"fee": 1}
+    assert stored.after == {"fee": 2}
+    assert stored.ip == "203.0.113.10"
+
+
+def test_query_audit_log_filters(client, db_session):
+    create_audit_log(db_session, action="set_fee", actor="admin-1", target="fee")
+    create_audit_log(db_session, action="delete_user", actor="admin-2", target="user:9")
+
+    response = client.get("/admin/audit-log", params={"actor": "admin-1", "action": "set_fee"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["actor"] == "admin-1"
+    assert payload[0]["action"] == "set_fee"
+
+
+def test_audit_log_records_are_immutable(db_session):
+    entry = create_audit_log(
+        db_session,
+        action="set_fee",
+        actor="admin-1",
+        target="registration_fee",
+    )
+
+    entry.action = "tamper"
+    with pytest.raises(ValueError, match="immutable"):
+        db_session.commit()
+
+    db_session.rollback()
+    db_session.delete(entry)
+    with pytest.raises(ValueError, match="immutable"):
+        db_session.commit()


### PR DESCRIPTION
Fixes #192.
/claim #192

Adds immutable admin audit records and a query endpoint for accountability around admin write actions.

What changed:
- add AuditLog SQLAlchemy model with action, actor, target, before/after values, timestamp, and IP
- add SQLAlchemy mutation guards so AuditLog rows cannot be updated or deleted
- add create_audit_log and audit_admin_action helpers for admin write endpoints
- add GET /admin/audit-log with actor, action, since, until, skip, and limit filters
- add focused tests for log creation, query filtering, and immutability

Validation:
- python -m pytest api/tests/test_admin_audit_log.py
- python -m py_compile api/models/database.py api/routes/admin.py api/tests/test_admin_audit_log.py
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.