### PR TITLE
api: harden jwt authentication

### DIFF
--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -2,40 +2,52 @@
 
 import jwt
 import os
+import uuid
+from fastapi import APIRouter
 from fastapi import Request, HTTPException, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from datetime import datetime, timedelta
 from typing import Optional
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    environment = os.getenv("APP_ENV", os.getenv("ENVIRONMENT", "development")).lower()
+    if environment in {"prod", "production"}:
+        raise RuntimeError("JWT_SECRET is required in production")
+    JWT_SECRET = "openagents-development-secret-change-me"
+
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
+revoked_tokens: set[str] = set()
 
 security = HTTPBearer()
+router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
+    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access", "jti": str(uuid.uuid4())})
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def create_refresh_token(data: dict) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
+    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh", "jti": str(uuid.uuid4())})
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def decode_token(token: str) -> dict:
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
+        header = jwt.get_unverified_header(token)
+        if header.get("alg") != JWT_ALGORITHM:
+            raise jwt.InvalidTokenError("Invalid algorithm")
+
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        if payload.get("jti") in revoked_tokens:
+            raise HTTPException(status_code=401, detail="Token has been revoked")
         return payload
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
@@ -81,3 +93,30 @@ def generate_login_tokens(user_id: str, address: str, roles: list = None) -> dic
         "refresh_token": create_refresh_token(data),
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     }
+
+
+@router.post("/refresh")
+async def refresh_access_token(refresh_token: str):
+    payload = decode_token(refresh_token)
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+
+    data = {
+        "sub": payload.get("sub"),
+        "address": payload.get("address"),
+        "roles": payload.get("roles", []),
+    }
+    if not data["sub"]:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+
+    return {
+        "token": create_access_token(data),
+        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    }
+
+
+@router.post("/revoke")
+async def revoke_current_token(user=Depends(get_current_user), credentials: HTTPAuthorizationCredentials = Depends(security)):
+    payload = decode_token(credentials.credentials)
+    revoked_tokens.add(payload["jti"])
+    return {"revoked": True, "user_id": user["id"]}

--- a/api/tests/test_auth_hardening.py
+++ b/api/tests/test_auth_hardening.py
@@ -1,0 +1,83 @@
+import importlib
+import os
+import sys
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def load_auth(monkeypatch, secret="test-secret-with-enough-entropy-123", environment="development"):
+    if secret is None:
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+    else:
+        monkeypatch.setenv("JWT_SECRET", secret)
+    monkeypatch.setenv("APP_ENV", environment)
+    sys.modules.pop("api.middleware.auth", None)
+    return importlib.import_module("api.middleware.auth")
+
+
+def test_rejects_none_algorithm_tokens(monkeypatch):
+    auth = load_auth(monkeypatch)
+    unsigned = jwt.encode(
+        {"sub": "1", "address": "0xabc", "type": "access"},
+        key="",
+        algorithm="none",
+    )
+
+    with pytest.raises(Exception) as exc:
+        auth.decode_token(unsigned)
+
+    assert getattr(exc.value, "status_code", None) == 401
+
+
+def test_missing_secret_uses_development_fallback(monkeypatch):
+    auth = load_auth(monkeypatch, secret=None, environment="development")
+
+    token = auth.create_access_token({"sub": "1", "address": "0xabc"})
+    payload = auth.decode_token(token)
+
+    assert payload["sub"] == "1"
+
+
+def test_missing_secret_errors_in_production(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.setenv("APP_ENV", "production")
+    sys.modules.pop("api.middleware.auth", None)
+
+    with pytest.raises(RuntimeError, match="JWT_SECRET"):
+        importlib.import_module("api.middleware.auth")
+
+
+def test_revoked_token_fails(monkeypatch):
+    auth = load_auth(monkeypatch)
+    token = auth.create_access_token({"sub": "1", "address": "0xabc"})
+    payload = auth.decode_token(token)
+    auth.revoked_tokens.add(payload["jti"])
+
+    with pytest.raises(Exception) as exc:
+        auth.decode_token(token)
+
+    assert getattr(exc.value, "status_code", None) == 401
+    assert "revoked" in exc.value.detail
+
+
+def test_refresh_endpoint_returns_new_access_token(monkeypatch):
+    auth = load_auth(monkeypatch)
+    app = FastAPI()
+    app.include_router(auth.router)
+    client = TestClient(app)
+    refresh_token = auth.create_refresh_token({
+        "sub": "1",
+        "address": "0xabc",
+        "roles": ["agent"],
+    })
+
+    response = client.post("/auth/refresh", params={"refresh_token": refresh_token})
+
+    assert response.status_code == 200
+    payload = auth.decode_token(response.json()["token"])
+    assert payload["type"] == "access"
+    assert payload["sub"] == "1"
+    assert payload["roles"] == ["agent"]


### PR DESCRIPTION
Fixes #100.
/claim #100

Hardens JWT authentication by rejecting unsigned/none-alg tokens, avoiding import-time crashes in development, adding token revocation, and exposing refresh/revoke endpoints.

What changed:
- pin JWT decoding to HS256 only
- explicitly reject tokens whose header alg is not HS256
- use a development-only fallback JWT secret while requiring JWT_SECRET in production
- add jti values to access and refresh tokens
- add revoked token tracking and enforce it during decode
- add POST /auth/refresh and POST /auth/revoke endpoints
- add focused tests for none-alg rejection, missing secret fallback, production secret failure, revoked token failure, and refresh

Validation:
- python -m pytest api/tests/test_auth_hardening.py
- python -m py_compile api/middleware/auth.py api/tests/test_auth_hardening.py
- git diff --check

Payment address: bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh

Security note: the issue body asks for private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.