### PR TITLE
oracle: harden TWAP window

### DIFF
--- a/contracts/oracle/TWAPOracle.sol
+++ b/contracts/oracle/TWAPOracle.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.20;
 contract TWAPOracle {
     struct Observation {
         uint256 timestamp;
+        uint256 blockNumber;
         uint256 priceCumulative;
         uint256 spotPrice;
     }
@@ -16,13 +17,12 @@ contract TWAPOracle {
 
     Observation[] public observations;
     uint256 public constant PRECISION = 1e18;
+    uint256 public constant MIN_WINDOW_SIZE = 30 minutes;
+    uint256 public constant MAX_STALENESS = 2 hours;
 
-    // BUG: Observation window too short (1 block / 12 seconds) — TWAP computed over
-    // a single block provides no meaningful time-weighting and is trivially manipulable
-    // via flash loans within the same block
-    uint256 public windowSize = 12; // seconds — effectively 1 block
+    uint256 public windowSize = MIN_WINDOW_SIZE;
 
-    event ObservationRecorded(uint256 timestamp, uint256 spotPrice, uint256 priceCumulative);
+    event ObservationRecorded(uint256 timestamp, uint256 blockNumber, uint256 spotPrice, uint256 priceCumulative);
     event WindowUpdated(uint256 newWindow);
 
     modifier onlyAdmin() {
@@ -43,29 +43,28 @@ contract TWAPOracle {
 
         if (observations.length > 0) {
             Observation storage last = observations[observations.length - 1];
+            require(block.number > last.blockNumber, "Observation already recorded this block");
+
             uint256 elapsed = block.timestamp - last.timestamp;
             lastCumulative = last.priceCumulative + (last.spotPrice * elapsed);
             lastTimestamp = block.timestamp;
         }
 
-        // BUG: Price can be manipulated in same block — no check that block.timestamp
-        // has advanced since last observation, so multiple observations per block are
-        // allowed, letting an attacker overwrite the price within a single transaction
         observations.push(Observation({
             timestamp: lastTimestamp,
+            blockNumber: block.number,
             priceCumulative: lastCumulative,
             spotPrice: spotPrice
         }));
 
-        emit ObservationRecorded(lastTimestamp, spotPrice, lastCumulative);
+        emit ObservationRecorded(lastTimestamp, block.number, spotPrice, lastCumulative);
     }
 
-    // BUG: No staleness check — if no observation has been recorded for hours/days,
-    // the TWAP still returns an outdated price without warning, misleading consumers
     function getTWAP() external view returns (uint256) {
         require(observations.length >= 2, "Not enough observations");
 
         Observation storage latest = observations[observations.length - 1];
+        require(block.timestamp - latest.timestamp <= MAX_STALENESS, "Stale price");
 
         // Find the oldest observation within the window
         uint256 targetTime = latest.timestamp - windowSize;
@@ -80,6 +79,7 @@ contract TWAPOracle {
 
         Observation storage old = observations[oldIndex];
         uint256 timeElapsed = latest.timestamp - old.timestamp;
+        require(timeElapsed >= windowSize, "Insufficient window");
 
         if (timeElapsed == 0) {
             return latest.spotPrice;
@@ -94,6 +94,7 @@ contract TWAPOracle {
     }
 
     function setWindowSize(uint256 _windowSize) external onlyAdmin {
+        require(_windowSize >= MIN_WINDOW_SIZE, "Window too short");
         windowSize = _windowSize;
         emit WindowUpdated(_windowSize);
     }

--- a/test/TWAPOracleWindow.test.js
+++ b/test/TWAPOracleWindow.test.js
@@ -1,0 +1,100 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const solc = require("solc");
+
+function compileTWAPOracle() {
+  const source = fs.readFileSync("contracts/oracle/TWAPOracle.sol", "utf8");
+  const input = {
+    language: "Solidity",
+    sources: { "TWAPOracle.sol": { content: source } },
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = output.errors || [];
+  const fatal = errors.filter((error) => error.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(fatal.map((error) => error.formattedMessage).join("\n"));
+  }
+  return output.contracts["TWAPOracle.sol"].TWAPOracle;
+}
+
+async function deployTWAPOracle() {
+  const [owner] = await ethers.getSigners();
+  const compiled = compileTWAPOracle();
+  const factory = new ethers.ContractFactory(compiled.abi, compiled.evm.bytecode.object, owner);
+  const oracle = await factory.deploy(owner.address);
+  await oracle.waitForDeployment();
+  return oracle;
+}
+
+describe("TWAPOracle window hardening", function () {
+  it("enforces a 30 minute minimum window", async function () {
+    const oracle = await deployTWAPOracle();
+
+    await expect(oracle.setWindowSize(60)).to.be.revertedWith("Window too short");
+    await oracle.setWindowSize(30 * 60);
+
+    expect(await oracle.windowSize()).to.equal(30n * 60n);
+    expect(await oracle.MIN_WINDOW_SIZE()).to.equal(30n * 60n);
+  });
+
+  it("rejects multiple observations mined in the same block", async function () {
+    const oracle = await deployTWAPOracle();
+
+    try {
+      await ethers.provider.send("evm_setAutomine", [false]);
+      const first = await oracle.recordObservation(100);
+      const second = await oracle.recordObservation(200);
+      await ethers.provider.send("evm_mine", []);
+
+      await first.wait();
+      await second.wait().then(
+        () => {
+          throw new Error("second same-block observation did not revert");
+        },
+        (error) => {
+          expect(error.message).to.include("transaction execution reverted");
+        },
+      );
+    } finally {
+      await ethers.provider.send("evm_setAutomine", [true]);
+    }
+    expect(await oracle.getObservationCount()).to.equal(1n);
+  });
+
+  it("computes TWAP from cumulative prices after the full window", async function () {
+    const oracle = await deployTWAPOracle();
+
+    await oracle.recordObservation(100);
+    await ethers.provider.send("evm_increaseTime", [30 * 60]);
+    await oracle.recordObservation(200);
+
+    expect(await oracle.getTWAP()).to.equal(100n);
+  });
+
+  it("reverts when the latest observation is stale", async function () {
+    const oracle = await deployTWAPOracle();
+
+    await oracle.recordObservation(100);
+    await ethers.provider.send("evm_increaseTime", [30 * 60]);
+    await oracle.recordObservation(200);
+    await ethers.provider.send("evm_increaseTime", [2 * 60 * 60 + 1]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(oracle.getTWAP()).to.be.revertedWith("Stale price");
+  });
+
+  it("requires observations to cover the configured window", async function () {
+    const oracle = await deployTWAPOracle();
+
+    await oracle.recordObservation(100);
+    await ethers.provider.send("evm_increaseTime", [10 * 60]);
+    await oracle.recordObservation(200);
+
+    await expect(oracle.getTWAP()).to.be.revertedWith("Insufficient window");
+  });
+});


### PR DESCRIPTION
Fixes #88
/claim #88

Summary:
- set TWAPOracle's default and minimum window to 30 minutes
- record the observation block number and reject multiple observations in the same block
- reject stale TWAP reads when the latest observation is older than MAX_STALENESS
- require the selected observations to cover the configured window before returning a TWAP
- preserve cumulative price accounting from elapsed time between observations
- add focused tests for minimum window, same-block manipulation, cumulative TWAP, stale reads, and insufficient window coverage

Verification:
- npx hardhat test --no-compile test/TWAPOracleWindow.test.js -> 5 passing
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-twap contracts/oracle/TWAPOracle.sol
- node --check test/TWAPOracleWindow.test.js
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
