### PR TITLE
dex: add AMM indexer events

### DIFF
--- a/contracts/dex/AMMPool.sol
+++ b/contracts/dex/AMMPool.sol
@@ -23,7 +23,10 @@ contract AMMPool {
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB);
-    event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event Mint(address indexed sender, uint256 amountA, uint256 amountB);
+    event Burn(address indexed sender, uint256 amountA, uint256 amountB, address indexed to);
+    event Swap(address indexed user, address indexed tokenIn, uint256 amountIn, uint256 amountOut);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) {
         tokenA = IERC20(_tokenA);
@@ -53,6 +56,8 @@ contract AMMPool {
         totalLiquidity += lpTokens;
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
+        emit Mint(msg.sender, amountA, amountB);
+        emit Sync(reserveA, reserveB);
     }
 
     function removeLiquidity(uint256 lpTokens) external {
@@ -70,6 +75,8 @@ contract AMMPool {
         require(tokenB.transfer(msg.sender, amountB), "Transfer B failed");
 
         emit LiquidityRemoved(msg.sender, amountA, amountB);
+        emit Burn(msg.sender, amountA, amountB, msg.sender);
+        emit Sync(reserveA, reserveB);
     }
 
     // BUG: Swap has no deadline parameter — transaction can sit in mempool and execute
@@ -103,6 +110,7 @@ contract AMMPool {
         }
 
         emit Swap(msg.sender, tokenIn, amountIn, amountOut);
+        emit Sync(reserveA, reserveB);
     }
 
     function _sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/test/AMMPoolEvents.test.js
+++ b/test/AMMPoolEvents.test.js
@@ -1,0 +1,141 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const solc = require("solc");
+
+const mockErc20Source = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+`;
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "AMMPool.sol": { content: fs.readFileSync("contracts/dex/AMMPool.sol", "utf8") },
+      "MockERC20.sol": { content: mockErc20Source },
+    },
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const fatal = (output.errors || []).filter((error) => error.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(fatal.map((error) => error.formattedMessage).join("\n"));
+  }
+  return {
+    pool: output.contracts["AMMPool.sol"].AMMPool,
+    token: output.contracts["MockERC20.sol"].MockERC20,
+  };
+}
+
+async function deployFactory(compiled, signer, ...args) {
+  const factory = new ethers.ContractFactory(compiled.abi, compiled.evm.bytecode.object, signer);
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+describe("AMMPool indexer events", function () {
+  async function fixture() {
+    const [user] = await ethers.getSigners();
+    const compiled = compileContracts();
+    const tokenA = await deployFactory(compiled.token, user, "Token A", "TKA");
+    const tokenB = await deployFactory(compiled.token, user, "Token B", "TKB");
+    const pool = await deployFactory(compiled.pool, user, await tokenA.getAddress(), await tokenB.getAddress());
+
+    await tokenA.mint(user.address, 10_000n);
+    await tokenB.mint(user.address, 10_000n);
+    await tokenA.approve(await pool.getAddress(), 10_000n);
+    await tokenB.approve(await pool.getAddress(), 10_000n);
+
+    return { pool, tokenA, tokenB, user };
+  }
+
+  it("indexes Swap user and tokenIn fields", async function () {
+    const { pool } = await fixture();
+    const swap = pool.interface.getEvent("Swap");
+
+    expect(swap.inputs[0].name).to.equal("user");
+    expect(swap.inputs[0].indexed).to.equal(true);
+    expect(swap.inputs[1].name).to.equal("tokenIn");
+    expect(swap.inputs[1].indexed).to.equal(true);
+  });
+
+  it("emits Mint, Burn, Swap, and Sync with updated reserves", async function () {
+    const { pool, tokenA, user } = await fixture();
+    const tokenAAddress = await tokenA.getAddress();
+
+    await expect(pool.addLiquidity(1_000n, 1_000n))
+      .to.emit(pool, "Mint")
+      .withArgs(user.address, 1_000n, 1_000n)
+      .and.to.emit(pool, "Sync")
+      .withArgs(1_000n, 1_000n);
+
+    const swap = await pool.swap(tokenAAddress, 100n, 0);
+    const receipt = await swap.wait();
+    const swapLog = receipt.logs
+      .map((log) => {
+        try {
+          return pool.interface.parseLog(log);
+        } catch (_) {
+          return null;
+        }
+      })
+      .find((log) => log && log.name === "Swap");
+
+    expect(swapLog.args.user).to.equal(user.address);
+    expect(swapLog.args.tokenIn).to.equal(tokenAAddress);
+    expect(swapLog.args.amountIn).to.equal(100n);
+    expect(swapLog.args.amountOut).to.be.gt(0n);
+
+    const [reserveA, reserveB] = await pool.getReserves();
+    const burnAmountA = (reserveA * 100n) / 1_000n;
+    const burnAmountB = (reserveB * 100n) / 1_000n;
+    await expect(pool.removeLiquidity(100n))
+      .to.emit(pool, "Burn")
+      .withArgs(user.address, burnAmountA, burnAmountB, user.address)
+      .and.to.emit(pool, "Sync")
+      .withArgs(reserveA - burnAmountA, reserveB - burnAmountB);
+  });
+});


### PR DESCRIPTION
Fixes #165
/claim #165

Summary:
- index Swap user and tokenIn for efficient off-chain filtering
- add Mint and Burn events for liquidity changes
- add Sync reserve events after addLiquidity, removeLiquidity, and swap
- add focused tests that inspect Swap indexed ABI fields and verify Mint/Burn/Swap/Sync emissions through real pool interactions

Verification:
- npx hardhat test --no-compile test/AMMPoolEvents.test.js -> 2 passing
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-amm contracts/dex/AMMPool.sol
- node --check test/AMMPoolEvents.test.js
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata and contributor records containing private instructions. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
