### PR TITLE
governor: store proposal vote snapshot

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -16,6 +16,7 @@ contract GovernorAlpha is ReentrancyGuard {
         address[] targets;
         uint256[] values;
         bytes[] calldatas;
+        uint256 snapshotBlock;
         uint256 startBlock;
         uint256 endBlock;
         uint256 forVotes;
@@ -62,6 +63,7 @@ contract GovernorAlpha is ReentrancyGuard {
         p.targets = targets;
         p.values = values;
         p.calldatas = calldatas;
+        p.snapshotBlock = block.number;
         p.startBlock = block.number + VOTING_DELAY;
         p.endBlock = block.number + VOTING_DELAY + VOTING_PERIOD;
 
@@ -79,7 +81,7 @@ contract GovernorAlpha is ReentrancyGuard {
         require(!p.hasVoted[tx.origin], "Governor: already voted");
         p.hasVoted[tx.origin] = true;
 
-        uint256 weight = token.getPastVotes(tx.origin, p.startBlock);
+        uint256 weight = getVotingPower(tx.origin, proposalId);
         if (support) {
             p.forVotes += weight;
         } else {
@@ -87,6 +89,15 @@ contract GovernorAlpha is ReentrancyGuard {
         }
 
         emit VoteCast(tx.origin, proposalId, support, weight);
+    }
+
+    /// @notice Return voting power fixed at proposal creation.
+    /// @param account Voter address to inspect.
+    /// @param proposalId Proposal whose snapshot should be used.
+    function getVotingPower(address account, uint256 proposalId) public view returns (uint256) {
+        Proposal storage p = proposals[proposalId];
+        require(p.id != 0, "Governor: unknown proposal");
+        return token.getPastVotes(account, p.snapshotBlock);
     }
 
     /// @notice Execute a succeeded proposal.

--- a/test/GovernorAlphaSnapshot.test.js
+++ b/test/GovernorAlphaSnapshot.test.js
@@ -1,0 +1,131 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+const votesTokenSource = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+contract MockVotesToken is ERC20Votes {
+    constructor() ERC20("Mock Votes", "MVOTE") EIP712("Mock Votes", "1") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+`;
+
+function findImport(importPath) {
+  const candidates = [
+    path.join("node_modules", importPath),
+    path.join(process.cwd(), importPath),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "GovernorAlpha.sol": { content: fs.readFileSync("contracts/governance/GovernorAlpha.sol", "utf8") },
+      "MockVotesToken.sol": { content: votesTokenSource },
+    },
+    settings: {
+      viaIR: true,
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const fatal = (output.errors || []).filter((error) => error.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(fatal.map((error) => error.formattedMessage).join("\n"));
+  }
+  return {
+    governor: output.contracts["GovernorAlpha.sol"].GovernorAlpha,
+    token: output.contracts["MockVotesToken.sol"].MockVotesToken,
+  };
+}
+
+async function deployFactory(compiled, signer, ...args) {
+  const factory = new ethers.ContractFactory(compiled.abi, compiled.evm.bytecode.object, signer);
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function mineBlocks(count) {
+  for (let i = 0; i < count; i++) {
+    await ethers.provider.send("evm_mine", []);
+  }
+}
+
+describe("GovernorAlpha proposal snapshots", function () {
+  async function fixture() {
+    const [proposer, lateBuyer, recipient] = await ethers.getSigners();
+    const compiled = compileContracts();
+    const token = await deployFactory(compiled.token, proposer);
+    const governor = await deployFactory(compiled.governor, proposer, await token.getAddress());
+
+    const threshold = await governor.PROPOSAL_THRESHOLD();
+    await token.mint(proposer.address, threshold);
+    await token.connect(proposer).delegate(proposer.address);
+    await mineBlocks(1);
+
+    return { governor, token, proposer, lateBuyer, recipient, threshold };
+  }
+
+  async function createProposal(governor, target) {
+    const tx = await governor.propose([target], [0], ["0x"]);
+    const receipt = await tx.wait();
+    const event = receipt.logs
+      .map((log) => {
+        try {
+          return governor.interface.parseLog(log);
+        } catch (_) {
+          return null;
+        }
+      })
+      .find((log) => log && log.name === "ProposalCreated");
+    return event.args.id;
+  }
+
+  it("stores the proposal creation block as snapshotBlock", async function () {
+    const { governor, recipient } = await fixture();
+    const proposalId = await createProposal(governor, recipient.address);
+    const proposal = await governor.proposals(proposalId);
+
+    expect(proposal.snapshotBlock).to.be.lt(proposal.startBlock);
+  });
+
+  it("ignores tokens acquired after proposal creation", async function () {
+    const { governor, token, lateBuyer, recipient, threshold } = await fixture();
+    const proposalId = await createProposal(governor, recipient.address);
+
+    await token.mint(lateBuyer.address, threshold * 2n);
+    await token.connect(lateBuyer).delegate(lateBuyer.address);
+    await mineBlocks(2);
+
+    expect(await governor.getVotingPower(lateBuyer.address, proposalId)).to.equal(0n);
+  });
+
+  it("keeps snapshot voting power even after later balance changes", async function () {
+    const { governor, token, proposer, recipient, threshold } = await fixture();
+    const proposalId = await createProposal(governor, recipient.address);
+
+    await token.transfer(recipient.address, threshold / 2n);
+    await mineBlocks(2);
+
+    expect(await governor.getVotingPower(proposer.address, proposalId)).to.equal(threshold);
+  });
+});


### PR DESCRIPTION
Fixes #149
/claim #149

Summary:
- store snapshotBlock on each proposal at proposal creation
- add getVotingPower(account, proposalId) that reads voting power from the stored proposal snapshot
- use the proposal snapshot helper during vote counting
- add focused tests for snapshot storage, post-creation token acquisition having no effect, and later balance changes not reducing snapshot voting power

Verification:
- npx hardhat test --no-compile test/GovernorAlphaSnapshot.test.js -> 3 passing
- node standard JSON solc compile of contracts/governance/GovernorAlpha.sol with optimizer + viaIR -> ok
- node --check test/GovernorAlphaSnapshot.test.js
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
