### PR TITLE
sdk: add gas estimation margin

### DIFF
--- a/sdk/src/auth/wallet.ts
+++ b/sdk/src/auth/wallet.ts
@@ -11,8 +11,11 @@ export interface Transaction {
   to: string;
   value: bigint;
   data: string;
-  gasLimit: bigint;
+  gasLimit?: bigint;
   gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  gasMarginBps?: number;
   nonce?: number;
   chainId?: number;
 }
@@ -20,6 +23,13 @@ export interface Transaction {
 export interface SignedTransaction {
   raw: string;
   hash: string;
+}
+
+export interface PreparedTransaction extends Transaction {
+  gasLimit: bigint;
+  gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
 }
 
 export class Wallet {
@@ -42,7 +52,7 @@ export class Wallet {
   }
 
   private deriveAddress(privateKey: string): string {
-    const { ec as EC } = require("elliptic");
+    const EC = require("elliptic").ec;
     const curve = new EC("secp256k1");
     const key = curve.keyFromPrivate(privateKey, "hex");
     const pubKey = key.getPublic(false, "hex").slice(2); // remove 04 prefix
@@ -53,13 +63,14 @@ export class Wallet {
   async signTransaction(tx: Transaction): Promise<SignedTransaction> {
     // BUG: No chain ID validation — transaction could be replayed on a different
     // chain if chainId is missing or mismatched with the provider
+    const prepared = await this.prepareTransaction(tx);
     const nonce = tx.nonce ?? await this.getNonce();
-    const gasPrice = tx.gasPrice ?? BigInt(await this.provider.call("eth_gasPrice") as string);
+    const gasPrice = prepared.gasPrice ?? prepared.maxFeePerGas ?? BigInt(await this.provider.call("eth_gasPrice") as string);
 
     const txData = encodeParams([
       { type: "uint256", value: nonce } as AbiParam,
       { type: "uint256", value: gasPrice } as AbiParam,
-      { type: "uint256", value: tx.gasLimit } as AbiParam,
+      { type: "uint256", value: prepared.gasLimit } as AbiParam,
       { type: "address", value: tx.to } as AbiParam,
       { type: "uint256", value: tx.value } as AbiParam,
     ]);
@@ -71,6 +82,80 @@ export class Wallet {
       raw: "0x" + txData.slice(2) + signature,
       hash: "0x" + txHash,
     };
+  }
+
+  async prepareTransaction(tx: Transaction): Promise<PreparedTransaction> {
+    const gasLimit = tx.gasLimit ?? await this.estimateGasWithMargin(tx, tx.gasMarginBps ?? 2000);
+    const hasManualFees = tx.gasPrice !== undefined ||
+      (tx.maxFeePerGas !== undefined && tx.maxPriorityFeePerGas !== undefined);
+    const fees = hasManualFees
+      ? {}
+      : await this.getFeeData();
+
+    return {
+      ...tx,
+      gasLimit,
+      gasPrice: tx.gasPrice ?? fees.gasPrice,
+      maxFeePerGas: tx.maxFeePerGas ?? fees.maxFeePerGas,
+      maxPriorityFeePerGas: tx.maxPriorityFeePerGas ?? fees.maxPriorityFeePerGas,
+    };
+  }
+
+  async estimateGasWithMargin(tx: Transaction, marginBps = 2000): Promise<bigint> {
+    const estimated = BigInt(await this.provider.call("eth_estimateGas", [this.toRpcTransaction(tx)]) as string);
+    const withMargin = estimated + (estimated * BigInt(marginBps)) / 10000n;
+    const blockGasLimit = await this.getLatestBlockGasLimit();
+    return withMargin > blockGasLimit ? blockGasLimit : withMargin;
+  }
+
+  private async getLatestBlockGasLimit(): Promise<bigint> {
+    const block = await this.provider.call("eth_getBlockByNumber", ["latest", false]) as { gasLimit?: string };
+    if (!block || typeof block.gasLimit !== "string") {
+      throw new Error("Unable to read latest block gas limit");
+    }
+    return BigInt(block.gasLimit);
+  }
+
+  private async getFeeData(): Promise<{
+    gasPrice?: bigint;
+    maxFeePerGas?: bigint;
+    maxPriorityFeePerGas?: bigint;
+  }> {
+    const block = await this.provider.call("eth_getBlockByNumber", ["latest", false]) as { baseFeePerGas?: string };
+    if (block && typeof block.baseFeePerGas === "string") {
+      const priority = await this.getPriorityFee();
+      return {
+        maxPriorityFeePerGas: priority,
+        maxFeePerGas: BigInt(block.baseFeePerGas) * 2n + priority,
+      };
+    }
+
+    return {
+      gasPrice: BigInt(await this.provider.call("eth_gasPrice") as string),
+    };
+  }
+
+  private async getPriorityFee(): Promise<bigint> {
+    try {
+      return BigInt(await this.provider.call("eth_maxPriorityFeePerGas") as string);
+    } catch (_) {
+      return BigInt(await this.provider.call("eth_gasPrice") as string) / 10n;
+    }
+  }
+
+  private toRpcTransaction(tx: Transaction): Record<string, string> {
+    const rpcTx: Record<string, string> = {
+      from: this.address,
+      to: tx.to,
+      value: "0x" + tx.value.toString(16),
+      data: tx.data || "0x",
+    };
+    if (tx.gasPrice !== undefined) rpcTx.gasPrice = "0x" + tx.gasPrice.toString(16);
+    if (tx.maxFeePerGas !== undefined) rpcTx.maxFeePerGas = "0x" + tx.maxFeePerGas.toString(16);
+    if (tx.maxPriorityFeePerGas !== undefined) {
+      rpcTx.maxPriorityFeePerGas = "0x" + tx.maxPriorityFeePerGas.toString(16);
+    }
+    return rpcTx;
   }
 
   async getNonce(): Promise<number> {

--- a/test/WalletGasEstimation.test.js
+++ b/test/WalletGasEstimation.test.js
@@ -1,0 +1,102 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const test = require("node:test");
+const ts = require("typescript");
+
+require.extensions[".ts"] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+    },
+  });
+  module._compile(output.outputText, filename);
+};
+
+const { Wallet } = require(path.resolve("sdk/src/auth/wallet.ts"));
+
+class MockProvider {
+  constructor(responses) {
+    this.responses = responses;
+    this.calls = [];
+  }
+
+  async call(method, params = []) {
+    this.calls.push({ method, params });
+    const response = this.responses[method];
+    if (response instanceof Error) throw response;
+    return typeof response === "function" ? response(params) : response;
+  }
+
+  async getBalance() {
+    return 0n;
+  }
+
+  getChainId() {
+    return 1;
+  }
+}
+
+const privateKey = "1".padStart(64, "0");
+const baseTx = {
+  to: "0x000000000000000000000000000000000000dEaD",
+  value: 1n,
+  data: "0x1234",
+};
+
+test("prepareTransaction estimates gas with a 20% margin and caps at block gas limit", async () => {
+  const provider = new MockProvider({
+    eth_estimateGas: "0x2710",
+    eth_getBlockByNumber: { gasLimit: "0x2ee0", baseFeePerGas: "0x64" },
+    eth_maxPriorityFeePerGas: "0x2",
+  });
+  const wallet = new Wallet({ privateKey, provider });
+
+  const prepared = await wallet.prepareTransaction(baseTx);
+
+  assert.equal(prepared.gasLimit, 12_000n);
+  assert.equal(prepared.maxPriorityFeePerGas, 2n);
+  assert.equal(prepared.maxFeePerGas, 202n);
+  assert.deepEqual(provider.calls.slice(0, 3).map((call) => call.method), [
+    "eth_estimateGas",
+    "eth_getBlockByNumber",
+    "eth_getBlockByNumber",
+  ]);
+});
+
+test("prepareTransaction respects manual gas and fee overrides", async () => {
+  const provider = new MockProvider({});
+  const wallet = new Wallet({ privateKey, provider });
+
+  const prepared = await wallet.prepareTransaction({
+    ...baseTx,
+    gasLimit: 50_000n,
+    maxFeePerGas: 100n,
+    maxPriorityFeePerGas: 3n,
+  });
+
+  assert.equal(prepared.gasLimit, 50_000n);
+  assert.equal(prepared.maxFeePerGas, 100n);
+  assert.equal(prepared.maxPriorityFeePerGas, 3n);
+  assert.equal(provider.calls.length, 0);
+});
+
+test("prepareTransaction falls back to legacy gasPrice when EIP-1559 data is unavailable", async () => {
+  const provider = new MockProvider({
+    eth_estimateGas: "0x5208",
+    eth_getBlockByNumber: (params) => {
+      if (params[0] === "latest") return { gasLimit: "0x100000" };
+      return {};
+    },
+    eth_gasPrice: "0x9",
+  });
+  const wallet = new Wallet({ privateKey, provider });
+
+  const prepared = await wallet.prepareTransaction(baseTx);
+
+  assert.equal(prepared.gasLimit, 25_200n);
+  assert.equal(prepared.gasPrice, 9n);
+});


### PR DESCRIPTION
Fixes #101
/claim #101

Summary:
- add Wallet.prepareTransaction() to fill gas and fee fields before signing
- estimate gas with eth_estimateGas and a default 20% safety margin
- cap estimated gas at the latest block gas limit
- support manual gas/fee overrides without extra RPC calls
- populate EIP-1559 maxFeePerGas/maxPriorityFeePerGas from latest base fee + priority fee, with legacy gasPrice fallback
- add focused Node tests for margin/cap, manual override, and legacy fallback

Verification:
- node test/WalletGasEstimation.test.js -> 3 passing
- npx tsc --noEmit --ignoreConfig --target ES2020 --module commonjs --types node --noImplicitAny false sdk/src/auth/wallet.ts
- node --check test/WalletGasEstimation.test.js
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
