### PR TITLE
registry: track active agent count

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -20,6 +20,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public activeCount;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -50,6 +51,7 @@ contract AgentRegistry is Ownable {
 
         ownerAgents[msg.sender].push(agentId);
         agentIds.push(agentId);
+        activeCount++;
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
@@ -57,7 +59,9 @@ contract AgentRegistry is Ownable {
 
     function deactivateAgent(bytes32 agentId) external {
         require(agents[agentId].owner == msg.sender, "Not agent owner");
+        require(agents[agentId].active, "Agent inactive");
         agents[agentId].active = false;
+        activeCount--;
         emit AgentDeactivated(agentId);
     }
 
@@ -80,9 +84,42 @@ contract AgentRegistry is Ownable {
     }
 
     function getActiveAgentCount() external view returns (uint256 count) {
-        for (uint256 i = 0; i < agentIds.length; i++) {
-            if (agents[agentIds[i]].active) count++;
+        return activeCount;
+    }
+
+    function getAgents(uint256 offset, uint256 limit) external view returns (bytes32[] memory) {
+        if (offset >= agentIds.length) {
+            return new bytes32[](0);
         }
+
+        uint256 end = offset + limit;
+        if (end > agentIds.length) {
+            end = agentIds.length;
+        }
+
+        bytes32[] memory page = new bytes32[](end - offset);
+        for (uint256 i = offset; i < end; i++) {
+            page[i - offset] = agentIds[i];
+        }
+        return page;
+    }
+
+    function getAgentsByOwner(address owner, uint256 offset, uint256 limit) external view returns (bytes32[] memory) {
+        bytes32[] storage ids = ownerAgents[owner];
+        if (offset >= ids.length) {
+            return new bytes32[](0);
+        }
+
+        uint256 end = offset + limit;
+        if (end > ids.length) {
+            end = ids.length;
+        }
+
+        bytes32[] memory page = new bytes32[](end - offset);
+        for (uint256 i = offset; i < end; i++) {
+            page[i - offset] = ids[i];
+        }
+        return page;
     }
 
     function setRegistrationFee(uint256 _fee) external onlyOwner {

--- a/test/AgentRegistryActiveCount.test.js
+++ b/test/AgentRegistryActiveCount.test.js
@@ -1,0 +1,91 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+function findImport(importPath) {
+  const candidates = [
+    path.join("node_modules", importPath),
+    path.join(process.cwd(), importPath),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileRegistry() {
+  const input = {
+    language: "Solidity",
+    sources: { "AgentRegistry.sol": { content: fs.readFileSync("contracts/AgentRegistry.sol", "utf8") } },
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const fatal = (output.errors || []).filter((error) => error.severity === "error");
+  if (fatal.length > 0) {
+    throw new Error(fatal.map((error) => error.formattedMessage).join("\n"));
+  }
+  return output.contracts["AgentRegistry.sol"].AgentRegistry;
+}
+
+async function deployRegistry() {
+  const [owner] = await ethers.getSigners();
+  const compiled = compileRegistry();
+  const factory = new ethers.ContractFactory(compiled.abi, compiled.evm.bytecode.object, owner);
+  const registry = await factory.deploy(0);
+  await registry.waitForDeployment();
+  return registry;
+}
+
+async function register(registry, signer, name) {
+  const tx = await registry.connect(signer).registerAgent(name, `https://${name}.example`);
+  const receipt = await tx.wait();
+  const event = receipt.logs
+    .map((log) => {
+      try {
+        return registry.interface.parseLog(log);
+      } catch (_) {
+        return null;
+      }
+    })
+    .find((log) => log && log.name === "AgentRegistered");
+  return event.args.agentId;
+}
+
+describe("AgentRegistry active count and pagination", function () {
+  it("maintains activeCount in O(1) as agents are registered and deactivated", async function () {
+    const [owner, alice] = await ethers.getSigners();
+    const registry = await deployRegistry();
+
+    const first = await register(registry, owner, "alpha");
+    await register(registry, alice, "beta");
+
+    expect(await registry.getActiveAgentCount()).to.equal(2n);
+    await expect(registry.deactivateAgent(first))
+      .to.emit(registry, "AgentDeactivated")
+      .withArgs(first);
+
+    expect(await registry.getActiveAgentCount()).to.equal(1n);
+    await expect(registry.deactivateAgent(first)).to.be.revertedWith("Agent inactive");
+  });
+
+  it("paginates all agents and owner-specific agents", async function () {
+    const [owner, alice] = await ethers.getSigners();
+    const registry = await deployRegistry();
+
+    const first = await register(registry, owner, "alpha");
+    const second = await register(registry, owner, "beta");
+    const third = await register(registry, alice, "gamma");
+
+    expect(await registry.getAgents(1, 2)).to.deep.equal([second, third]);
+    expect(await registry.getAgents(99, 10)).to.deep.equal([]);
+    expect(await registry.getAgentsByOwner(owner.address, 0, 10)).to.deep.equal([first, second]);
+    expect(await registry.getAgentsByOwner(alice.address, 0, 10)).to.deep.equal([third]);
+  });
+});


### PR DESCRIPTION
Fixes #97
/claim #97

Summary:
- maintain activeCount on registration and deactivation so getActiveAgentCount is O(1)
- prevent repeated deactivation from double-decrementing the counter
- add getAgents(offset, limit) pagination over all agent IDs
- add getAgentsByOwner(owner, offset, limit) pagination for owner-specific agent IDs
- add focused tests for counter accuracy, repeated deactivation guard, all-agent pagination, and owner filtering

Verification:
- npx hardhat test --no-compile test/AgentRegistryActiveCount.test.js -> 2 passing
- npx solcjs --bin --abi --base-path . --include-path node_modules -o /tmp/openagents-solc-registry contracts/AgentRegistry.sol
- node --check test/AgentRegistryActiveCount.test.js
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
