### PR TITLE
api: serialize payment claims

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, UniqueConstraint,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -72,6 +72,9 @@ class Task(Base):
 
 class Payment(Base):
     __tablename__ = "payments"
+    __table_args__ = (
+        UniqueConstraint("task_id", "idempotency_key", name="uq_payment_task_idempotency"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
@@ -80,10 +83,24 @@ class Payment(Base):
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
     status = Column(String(32), default="pending")
+    idempotency_key = Column(String(128), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class PaymentAuditLog(Base):
+    __tablename__ = "payment_audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    payment_id = Column(Integer, ForeignKey("payments.id"), nullable=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    actor_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    action = Column(String(64), nullable=False)
+    amount = Column(Float, nullable=True)
+    idempotency_key = Column(String(128), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
 
 def init_db():

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,11 +1,11 @@
 """Payment and escrow endpoints for bounty payouts."""
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, validator
 from typing import Optional
 from datetime import datetime
 
-from ..models.database import get_db, Payment, Task
+from ..models.database import get_db, Payment, PaymentAuditLog, Task
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/payments", tags=["payments"])
@@ -13,10 +13,15 @@ router = APIRouter(prefix="/payments", tags=["payments"])
 
 class EscrowDeposit(BaseModel):
     task_id: int
-    # BUG: Amount is not validated as positive — negative or zero deposits
-    # could corrupt escrow balances or drain funds
-    amount: float
+    amount: float = Field(..., gt=0)
     token_address: Optional[str] = "0x0000000000000000000000000000000000000000"
+    idempotency_key: Optional[str] = Field(default=None, max_length=128)
+
+    @validator("idempotency_key")
+    def normalize_idempotency_key(cls, value):
+        if value is not None and not value.strip():
+            raise ValueError("idempotency_key cannot be blank")
+        return value
 
 
 class ClaimRequest(BaseModel):
@@ -34,17 +39,34 @@ async def deposit_escrow(
     if task.creator_id != user["id"]:
         raise HTTPException(status_code=403, detail="Only task creator can fund escrow")
 
-    # BUG: No idempotency key — retried requests create duplicate escrow entries,
-    # locking more funds than intended
+    if deposit.idempotency_key:
+        existing = db.query(Payment).filter(
+            Payment.task_id == deposit.task_id,
+            Payment.idempotency_key == deposit.idempotency_key,
+        ).first()
+        if existing:
+            return {"payment_id": existing.id, "status": existing.status, "amount": existing.amount}
+
     payment = Payment(
         task_id=deposit.task_id,
         from_address=user["address"],
         amount=deposit.amount,
         token_address=deposit.token_address,
+        idempotency_key=deposit.idempotency_key,
         status="escrowed",
         created_at=datetime.utcnow(),
     )
     db.add(payment)
+    db.flush()
+    db.add(PaymentAuditLog(
+        payment_id=payment.id,
+        task_id=deposit.task_id,
+        actor_id=user["id"],
+        action="escrow_deposit",
+        amount=payment.amount,
+        idempotency_key=deposit.idempotency_key,
+        created_at=datetime.utcnow(),
+    ))
     db.commit()
     db.refresh(payment)
     return {"payment_id": payment.id, "status": "escrowed", "amount": payment.amount}
@@ -63,17 +85,15 @@ async def get_escrow_balance(task_id: int, db=Depends(get_db)):
 async def claim_payment(
     claim: ClaimRequest, user=Depends(get_current_user), db=Depends(get_db)
 ):
-    task = db.query(Task).filter(Task.id == claim.task_id).first()
+    task = db.query(Task).filter(Task.id == claim.task_id).with_for_update().first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     if task.status != "completed":
         raise HTTPException(status_code=400, detail="Task not yet completed")
 
-    # BUG: Race condition — two concurrent claims can both read status="escrowed"
-    # before either updates it, causing a double-payout
     payments = db.query(Payment).filter(
         Payment.task_id == claim.task_id, Payment.status == "escrowed"
-    ).all()
+    ).with_for_update().all()
 
     if not payments:
         raise HTTPException(status_code=400, detail="No escrowed funds available")
@@ -84,6 +104,15 @@ async def claim_payment(
         payment.to_address = claim.recipient_address
         payment.claimed_at = datetime.utcnow()
         total_claimed += payment.amount
+        db.add(PaymentAuditLog(
+            payment_id=payment.id,
+            task_id=claim.task_id,
+            actor_id=user["id"],
+            action="payment_claimed",
+            amount=payment.amount,
+            idempotency_key=payment.idempotency_key,
+            created_at=datetime.utcnow(),
+        ))
 
     db.commit()
     return {

--- a/api/tests/test_payment_claim_race.py
+++ b/api/tests/test_payment_claim_race.py
@@ -1,0 +1,93 @@
+import asyncio
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import Base, Payment, PaymentAuditLog, Task, User
+from api.routes.payments import EscrowDeposit, ClaimRequest, claim_payment, deposit_escrow
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return TestingSession()
+
+
+def seed_task(db, status="completed"):
+    user = User(address="0x1111111111111111111111111111111111111111", username="creator")
+    db.add(user)
+    db.flush()
+    task = Task(
+        title="task",
+        reward_amount=10.0,
+        status=status,
+        creator_id=user.id,
+    )
+    db.add(task)
+    db.commit()
+    return user, task
+
+
+def test_deposit_rejects_non_positive_amount():
+    try:
+        EscrowDeposit(task_id=1, amount=-1)
+    except ValidationError as error:
+        assert "greater than 0" in str(error)
+    else:
+        raise AssertionError("negative escrow deposit was accepted")
+
+
+def test_deposit_idempotency_key_reuses_existing_payment():
+    db = make_session()
+    user, task = seed_task(db)
+    current_user = {"id": user.id, "address": user.address}
+    deposit = EscrowDeposit(task_id=task.id, amount=10.0, idempotency_key="retry-1")
+
+    first = asyncio.run(deposit_escrow(deposit, user=current_user, db=db))
+    second = asyncio.run(deposit_escrow(deposit, user=current_user, db=db))
+
+    assert first == second
+    assert db.query(Payment).count() == 1
+    assert db.query(PaymentAuditLog).filter_by(action="escrow_deposit").count() == 1
+
+
+def test_claim_serializes_payments_and_blocks_double_claim():
+    db = make_session()
+    user, task = seed_task(db)
+    payment = Payment(
+        task_id=task.id,
+        from_address=user.address,
+        amount=10.0,
+        status="escrowed",
+    )
+    db.add(payment)
+    db.commit()
+
+    current_user = {"id": user.id, "address": user.address}
+    first = asyncio.run(claim_payment(
+        ClaimRequest(task_id=task.id, recipient_address=user.address),
+        user=current_user,
+        db=db,
+    ))
+
+    assert first["claimed_amount"] == 10.0
+    assert db.query(Payment).first().status == "claimed"
+    assert db.query(PaymentAuditLog).filter_by(action="payment_claimed").count() == 1
+
+    try:
+        asyncio.run(claim_payment(
+            ClaimRequest(task_id=task.id, recipient_address=user.address),
+            user=current_user,
+            db=db,
+        ))
+    except HTTPException as error:
+        assert error.status_code == 400
+        assert error.detail == "No escrowed funds available"
+    else:
+        raise AssertionError("second claim unexpectedly succeeded")


### PR DESCRIPTION
Fixes #90
/claim #90

Summary:
- validate escrow deposit amount as strictly positive
- add optional idempotency_key to escrow deposits and enforce task/key uniqueness
- reuse the existing payment for repeated idempotent deposit requests
- lock the task and escrowed payment rows during claim processing with with_for_update()
- write audit log rows for escrow deposits and payment claims
- add focused tests for negative amount rejection, idempotent deposit reuse, claim serialization behavior, and audit records

Verification:
- python -m pytest api/tests/test_payment_claim_race.py -q -> 3 passed
- python -m py_compile api/routes/payments.py api/models/database.py api/tests/test_payment_claim_race.py
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
