### PR TITLE
api: add task webhooks

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -86,5 +86,31 @@ class Payment(Base):
     task = relationship("Task", back_populates="payments")
 
 
+class WebhookSubscription(Base):
+    __tablename__ = "webhook_subscriptions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    url = Column(String(512), nullable=False)
+    secret = Column(String(128), nullable=False)
+    events = Column(JSON, default=list)
+    active = Column(Integer, default=1)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class WebhookDelivery(Base):
+    __tablename__ = "webhook_deliveries"
+
+    id = Column(Integer, primary_key=True, index=True)
+    subscription_id = Column(Integer, ForeignKey("webhook_subscriptions.id"), nullable=False)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    event = Column(String(64), nullable=False)
+    status = Column(String(32), nullable=False)
+    attempts = Column(Integer, default=0)
+    last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    delivered_at = Column(DateTime, nullable=True)
+
+
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from ..models.database import get_db, Task
 from ..middleware.auth import get_current_user
+from .webhooks import deliver_task_webhooks
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
@@ -40,6 +41,7 @@ async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depen
     db.add(new_task)
     db.commit()
     db.refresh(new_task)
+    await deliver_task_webhooks(new_task, "created", db)
     return {"id": new_task.id, "status": new_task.status}
 
 
@@ -88,6 +90,8 @@ async def update_task_status(
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
+    if update.status in {"assigned", "completed", "disputed"}:
+        await deliver_task_webhooks(task, update.status, db)
     return {"id": task.id, "status": task.status}
 
 

--- a/api/routes/webhooks.py
+++ b/api/routes/webhooks.py
@@ -1,0 +1,188 @@
+"""Webhook subscription endpoints and task state delivery helpers."""
+
+import asyncio
+import hashlib
+import hmac
+import json
+import secrets
+from datetime import datetime
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, HttpUrl
+
+from ..middleware.auth import get_current_user
+from ..models.database import get_db, Task, WebhookDelivery, WebhookSubscription
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+TASK_EVENTS = {"created", "assigned", "completed", "disputed"}
+
+
+class WebhookCreate(BaseModel):
+    url: HttpUrl
+    events: list[str] = Field(default_factory=lambda: sorted(TASK_EVENTS))
+    secret: Optional[str] = Field(default=None, min_length=16, max_length=128)
+
+
+class WebhookUpdate(BaseModel):
+    url: Optional[HttpUrl] = None
+    events: Optional[list[str]] = None
+    active: Optional[bool] = None
+
+
+def _validate_events(events: list[str]) -> list[str]:
+    unknown = sorted(set(events) - TASK_EVENTS)
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unsupported webhook events: {', '.join(unknown)}")
+    return sorted(set(events))
+
+
+def sign_payload(secret: str, payload: dict) -> tuple[str, bytes]:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}", body
+
+
+@router.post("/")
+async def create_webhook(
+    webhook: WebhookCreate,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    subscription = WebhookSubscription(
+        owner_id=user["id"],
+        url=str(webhook.url),
+        secret=webhook.secret or secrets.token_urlsafe(32),
+        events=_validate_events(webhook.events),
+        active=1,
+        created_at=datetime.utcnow(),
+    )
+    db.add(subscription)
+    db.commit()
+    db.refresh(subscription)
+    return {
+        "id": subscription.id,
+        "url": subscription.url,
+        "events": subscription.events,
+        "active": bool(subscription.active),
+        "secret": subscription.secret,
+    }
+
+
+@router.get("/")
+async def list_webhooks(user=Depends(get_current_user), db=Depends(get_db)):
+    subscriptions = db.query(WebhookSubscription).filter(
+        WebhookSubscription.owner_id == user["id"]
+    ).all()
+    return [
+        {"id": sub.id, "url": sub.url, "events": sub.events, "active": bool(sub.active)}
+        for sub in subscriptions
+    ]
+
+
+@router.patch("/{webhook_id}")
+async def update_webhook(
+    webhook_id: int,
+    update: WebhookUpdate,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    subscription = db.query(WebhookSubscription).filter(
+        WebhookSubscription.id == webhook_id,
+        WebhookSubscription.owner_id == user["id"],
+    ).first()
+    if not subscription:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+
+    if update.url is not None:
+        subscription.url = str(update.url)
+    if update.events is not None:
+        subscription.events = _validate_events(update.events)
+    if update.active is not None:
+        subscription.active = 1 if update.active else 0
+    db.commit()
+    return {"id": subscription.id, "url": subscription.url, "events": subscription.events, "active": bool(subscription.active)}
+
+
+@router.delete("/{webhook_id}")
+async def delete_webhook(webhook_id: int, user=Depends(get_current_user), db=Depends(get_db)):
+    subscription = db.query(WebhookSubscription).filter(
+        WebhookSubscription.id == webhook_id,
+        WebhookSubscription.owner_id == user["id"],
+    ).first()
+    if not subscription:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    subscription.active = 0
+    db.commit()
+    return {"id": subscription.id, "active": False}
+
+
+def _matches_event(events: list[str], event: str) -> bool:
+    return event in (events or [])
+
+
+async def deliver_task_webhooks(task: Task, event: str, db, client: Optional[httpx.AsyncClient] = None) -> None:
+    if event not in TASK_EVENTS:
+        return
+
+    subscriptions = [
+        sub for sub in db.query(WebhookSubscription).filter(WebhookSubscription.active == 1).all()
+        if _matches_event(sub.events, event)
+    ]
+    payload = {
+        "event": event,
+        "task": {
+            "id": task.id,
+            "status": task.status,
+            "creator_id": task.creator_id,
+            "agent_id": task.agent_id,
+        },
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=5)
+
+    try:
+        for subscription in subscriptions:
+            delivery = WebhookDelivery(
+                subscription_id=subscription.id,
+                task_id=task.id,
+                event=event,
+                status="pending",
+                attempts=0,
+                created_at=datetime.utcnow(),
+            )
+            db.add(delivery)
+            db.flush()
+
+            signature, body = sign_payload(subscription.secret, payload)
+            for attempt in range(1, 6):
+                delivery.attempts = attempt
+                try:
+                    response = await client.post(
+                        subscription.url,
+                        content=body,
+                        headers={
+                            "Content-Type": "application/json",
+                            "X-OpenAgents-Event": event,
+                            "X-OpenAgents-Signature": signature,
+                        },
+                    )
+                    response.raise_for_status()
+                    delivery.status = "delivered"
+                    delivery.delivered_at = datetime.utcnow()
+                    delivery.last_error = None
+                    break
+                except Exception as exc:
+                    delivery.status = "failed"
+                    delivery.last_error = str(exc)
+                    if attempt < 5:
+                        await asyncio.sleep(0.1 * attempt)
+            db.commit()
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/api/tests/test_task_webhooks.py
+++ b/api/tests/test_task_webhooks.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+import httpx
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import Base, Task, User, WebhookDelivery, WebhookSubscription
+from api.routes.tasks import TaskCreate, TaskStatusUpdate, create_task, update_task_status
+from api.routes.webhooks import (
+    WebhookCreate,
+    create_webhook,
+    deliver_task_webhooks,
+    sign_payload,
+)
+
+
+class RecordingClient:
+    def __init__(self, failures=0):
+        self.failures = failures
+        self.posts = []
+
+    async def post(self, url, content, headers):
+        self.posts.append({"url": url, "content": content, "headers": headers})
+        request = httpx.Request("POST", url)
+        if len(self.posts) <= self.failures:
+            return httpx.Response(500, request=request)
+        return httpx.Response(200, request=request)
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return TestingSession()
+
+
+def seed_user(db):
+    user = User(address="0x1111111111111111111111111111111111111111", username="creator")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def test_sign_payload_is_hmac_sha256_and_stable():
+    payload = {"task": {"id": 1}, "event": "completed"}
+    signature, body = sign_payload("secret", payload)
+
+    assert signature.startswith("sha256=")
+    assert json.loads(body) == payload
+    assert signature == sign_payload("secret", payload)[0]
+
+
+def test_create_webhook_stores_subscription_secret_and_events():
+    db = make_session()
+    user = seed_user(db)
+
+    result = asyncio.run(create_webhook(
+        WebhookCreate(url="https://example.com/hook", events=["created"], secret="1234567890abcdef"),
+        user={"id": user.id, "address": user.address},
+        db=db,
+    ))
+
+    assert result["events"] == ["created"]
+    assert result["secret"] == "1234567890abcdef"
+    assert db.query(WebhookSubscription).count() == 1
+
+
+def test_delivery_retries_and_records_history():
+    db = make_session()
+    user = seed_user(db)
+    task = Task(title="task", reward_amount=1.0, status="completed", creator_id=user.id)
+    subscription = WebhookSubscription(
+        owner_id=user.id,
+        url="https://example.com/hook",
+        secret="1234567890abcdef",
+        events=["completed"],
+        active=1,
+    )
+    db.add_all([task, subscription])
+    db.commit()
+    client = RecordingClient(failures=2)
+
+    asyncio.run(deliver_task_webhooks(task, "completed", db, client=client))
+
+    delivery = db.query(WebhookDelivery).one()
+    assert len(client.posts) == 3
+    assert delivery.status == "delivered"
+    assert delivery.attempts == 3
+    assert client.posts[-1]["headers"]["X-OpenAgents-Event"] == "completed"
+    assert client.posts[-1]["headers"]["X-OpenAgents-Signature"].startswith("sha256=")
+
+
+def test_task_create_and_completed_status_fire_webhooks():
+    db = make_session()
+    user = seed_user(db)
+    db.add(WebhookSubscription(
+        owner_id=user.id,
+        url="https://example.com/hook",
+        secret="1234567890abcdef",
+        events=["created", "completed"],
+        active=1,
+    ))
+    db.commit()
+
+    created = asyncio.run(create_task(
+        TaskCreate(title="task", description="desc", reward_amount=1.0),
+        user={"id": user.id, "address": user.address},
+        db=db,
+    ))
+    asyncio.run(update_task_status(
+        created["id"],
+        TaskStatusUpdate(status="completed"),
+        user={"id": user.id, "address": user.address},
+        db=db,
+    ))
+
+    events = [delivery.event for delivery in db.query(WebhookDelivery).order_by(WebhookDelivery.id).all()]
+    assert events == ["created", "completed"]


### PR DESCRIPTION
Fixes #84
/claim #84

Summary:
- add WebhookSubscription and WebhookDelivery models for subscriptions and delivery history
- add webhook CRUD endpoints with event validation and generated/explicit secrets
- sign webhook payloads with HMAC-SHA256 in X-OpenAgents-Signature
- deliver task webhooks for created, assigned, completed, and disputed events
- retry delivery up to 5 times with incremental backoff and persist attempts/status/errors
- add focused tests for HMAC signing, subscription creation, retry/history behavior, and task create/completed triggers

Verification:
- python -m pytest api/tests/test_task_webhooks.py -q -> 4 passed
- python -m py_compile api/routes/webhooks.py api/routes/tasks.py api/models/database.py api/tests/test_task_webhooks.py
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata and contributor records containing private instructions. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
