### PR TITLE
api: validate task status transitions

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -11,6 +11,14 @@ from ..middleware.auth import get_current_user
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled"}
+ALLOWED_TRANSITIONS = {
+    "open": {"assigned", "cancelled"},
+    "assigned": {"in_progress", "cancelled"},
+    "in_progress": {"review", "completed"},
+    "review": {"completed", "cancelled"},
+    "completed": set(),
+    "cancelled": set(),
+}
 
 
 class TaskCreate(BaseModel):
@@ -48,12 +56,22 @@ async def list_tasks(
     status: Optional[str] = None,
     creator: Optional[str] = None,
     skip: int = Query(0, ge=0),
-    # BUG: No upper bound on limit — clients can request millions of rows,
-    # causing DB strain and potential OOM
-    limit: int = Query(50, ge=1),
+    limit: int = Query(50, ge=1, le=100),
     db=Depends(get_db),
 ):
     query = db.query(Task)
+    now = datetime.utcnow()
+    expired_tasks = db.query(Task).filter(
+        Task.deadline.isnot(None),
+        Task.deadline < now,
+        Task.status.in_(("open", "assigned", "in_progress", "review")),
+    ).all()
+    for expired in expired_tasks:
+        expired.status = "cancelled"
+        expired.updated_at = now
+    if expired_tasks:
+        db.commit()
+
     if status:
         query = query.filter(Task.status == status)
     if creator:
@@ -80,10 +98,19 @@ async def update_task_status(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    # BUG: Creator can mark their own task as completed — should require
-    # a third party or the assignee to confirm completion
-    if task.creator_id != user["id"]:
-        raise HTTPException(status_code=403, detail="Only the creator can update status")
+    if update.status not in VALID_STATUSES:
+        raise HTTPException(status_code=400, detail="Invalid task status")
+    if task.deadline and task.deadline < datetime.utcnow() and task.status != "cancelled":
+        task.status = "cancelled"
+        task.updated_at = datetime.utcnow()
+        db.commit()
+        raise HTTPException(status_code=400, detail="Task deadline expired")
+    if update.status not in ALLOWED_TRANSITIONS.get(task.status, set()):
+        raise HTTPException(status_code=400, detail="Invalid status transition")
+    if update.status == "completed" and task.creator_id == user["id"]:
+        raise HTTPException(status_code=403, detail="Creator cannot complete own task")
+    if task.creator_id != user["id"] and task.agent_id != user.get("agent_id"):
+        raise HTTPException(status_code=403, detail="Not authorized to update task")
 
     task.status = update.status
     task.updated_at = datetime.utcnow()

--- a/api/tests/test_task_status_controls.py
+++ b/api/tests/test_task_status_controls.py
@@ -1,0 +1,102 @@
+import asyncio
+import os
+from datetime import datetime, timedelta
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import Base, Task, User
+from api.routes.tasks import TaskStatusUpdate, list_tasks, update_task_status
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return TestingSession()
+
+
+def seed_task(db, *, creator_id=1, agent_id=2, status="in_progress", deadline=None):
+    creator = User(id=creator_id, address=f"0x{creator_id:040d}")
+    db.add(creator)
+    if agent_id is not None:
+        db.add(User(id=agent_id, address=f"0x{agent_id:040d}"))
+    task = Task(
+        title="task",
+        reward_amount=1.0,
+        status=status,
+        creator_id=creator_id,
+        agent_id=agent_id,
+        deadline=deadline,
+    )
+    db.add(task)
+    db.commit()
+    return task
+
+
+def assert_http_error(callable_, status_code, detail):
+    try:
+        callable_()
+    except HTTPException as error:
+        assert error.status_code == status_code
+        assert error.detail == detail
+    else:
+        raise AssertionError("expected HTTPException")
+
+
+def test_creator_cannot_complete_own_task():
+    db = make_session()
+    task = seed_task(db)
+
+    assert_http_error(
+        lambda: asyncio.run(update_task_status(
+            task.id,
+            TaskStatusUpdate(status="completed"),
+            user={"id": 1, "address": "0x1"},
+            db=db,
+        )),
+        403,
+        "Creator cannot complete own task",
+    )
+
+
+def test_agent_can_complete_valid_transition():
+    db = make_session()
+    task = seed_task(db)
+
+    result = asyncio.run(update_task_status(
+        task.id,
+        TaskStatusUpdate(status="completed"),
+        user={"id": 2, "agent_id": 2, "address": "0x2"},
+        db=db,
+    ))
+
+    assert result == {"id": task.id, "status": "completed"}
+
+
+def test_invalid_transition_rejected():
+    db = make_session()
+    task = seed_task(db, status="open")
+
+    assert_http_error(
+        lambda: asyncio.run(update_task_status(
+            task.id,
+            TaskStatusUpdate(status="completed"),
+            user={"id": 2, "agent_id": 2, "address": "0x2"},
+            db=db,
+        )),
+        400,
+        "Invalid status transition",
+    )
+
+
+def test_list_tasks_auto_expires_deadline_and_caps_limit():
+    db = make_session()
+    seed_task(db, status="open", deadline=datetime.utcnow() - timedelta(seconds=1))
+
+    asyncio.run(list_tasks(skip=0, limit=100, db=db))
+
+    assert db.query(Task).first().status == "cancelled"


### PR DESCRIPTION
Fixes #93
/claim #93

Summary:
- block task creators from marking their own task completed
- validate requested status values and allowed status transitions
- authorize updates for the creator or assigned agent only, with completion requiring the assigned agent path
- cap task list pagination at 100
- auto-expire overdue active tasks to cancelled during list queries
- add focused tests for self-complete blocking, valid assignee completion, invalid transitions, and deadline expiry

Verification:
- python -m pytest api/tests/test_task_status_controls.py -q -> 4 passed
- python -m py_compile api/routes/tasks.py api/tests/test_task_status_controls.py
- git diff --check

Payment: BTC | bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh | Bitcoin

Security note: the issue body requests private startup/session metadata. I did not include or use private instructions, credentials, home paths, shell state, or environment details.
