### PR TITLE
feat(sdk): add event subscription and decoding (#196)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "hermes-agent-kejuunuy",
+      "timestamp": "2026-05-30T00:00:00Z",
+      "platform_instructions": "Add event subscription and decoding to OpenAgents SDK for issue #196. Implement subscribeToEvents with ABI decoding, indexed filtering, WebSocket auto-reconnect.",
+      "runtime": {
+        "os": "linux",
+        "arch": "x64",
+        "home_dir": "/root",
+        "working_dir": "/root/OpenAgents",
+        "shell": "bash"
+      },
+      "contribution": "Added event subscription and decoding to OpenAgents SDK (issue #196): EventSubscriptionManager with ABI log decoding, indexed parameter filtering, WebSocket auto-reconnect with resubscription, subscribeToEvents SDK method, and 25 unit tests"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
     "compile": "hardhat compile",
     "test": "hardhat test",
     "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia",
-    "deploy:base": "hardhat run scripts/deploy.js --network base"
+    "deploy:base": "hardhat run scripts/deploy.js --network base",
+    "test:sdk": "cd sdk && npx jest"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
-    "hardhat": "^2.22.0"
+    "@types/jest": "^30.0.0",
+    "hardhat": "^2.22.0",
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11",
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.1.0",

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/tests"],
+  testMatch: ["**/*.test.ts"],
+  moduleFileExtensions: ["ts", "js", "json"],
+  transform: {
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "./tsconfig.json" }],
+  },
+};

--- a/sdk/src/events/EventSubscription.ts
+++ b/sdk/src/events/EventSubscription.ts
@@ -1,0 +1,502 @@
+/**
+ * @fix-author kejuunuy
+ * @fix-date 2026-05-30
+ * @fix-issue 196
+ * @fix-description Add event subscription and decoding to OpenAgents SDK
+ */
+
+import { EventEmitter } from "events";
+import { createHash } from "crypto";
+import {
+  WebSocketProvider,
+  WsProviderConfig,
+} from "../providers/websocket";
+
+/** Minimal ABI event input descriptor */
+export interface AbiEventInput {
+  name: string;
+  type: string;
+  indexed?: boolean;
+}
+
+/** ABI event entry (subset of full ABI JSON) */
+export interface AbiEventEntry {
+  type: "event";
+  name: string;
+  inputs: AbiEventInput[];
+  anonymous?: boolean;
+}
+
+/** Decoded event log returned to the subscriber callback */
+export interface DecodedEventLog {
+  event: string;
+  address: string;
+  blockNumber: number | null;
+  transactionHash: string | null;
+  logIndex: number | null;
+  args: Record<string, unknown>;
+  raw: RawLog;
+}
+
+/** Raw log as received from the node */
+export interface RawLog {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string | null;
+  transactionHash: string | null;
+  logIndex: string | null;
+  blockHash?: string;
+  transactionIndex?: string;
+  removed?: boolean;
+}
+
+/** Filter criteria for indexed event parameters */
+export interface EventFilter {
+  [paramName: string]: string | number | bigint | boolean;
+}
+
+/** Subscription handle returned to the caller */
+export interface SubscriptionHandle {
+  subscriptionId: string;
+  unsubscribe: () => Promise<void>;
+}
+
+/** Configuration for an event subscription */
+export interface EventSubscriptionConfig {
+  /** WebSocket provider config or an existing provider instance */
+  wsConfig?: WsProviderConfig;
+  wsProvider?: WebSocketProvider;
+  /** Default reconnect settings */
+  reconnectIntervalMs?: number;
+  maxReconnectAttempts?: number;
+}
+
+// ──────────────────────────────────────────────────────
+//  ABI helpers (keccak256 of canonical event signatures)
+// ──────────────────────────────────────────────────────
+
+function keccak256Hex(input: string): string {
+  return createHash("sha3-256").update(Buffer.from(input, "utf-8")).digest("hex");
+}
+
+/**
+ * Compute the topic-0 (event signature hash) for an event ABI entry.
+ * e.g. Transfer(address,address,uint256) → keccak256(...)
+ */
+export function computeEventTopic(abiEvent: AbiEventEntry): string {
+  const signature = buildCanonicalSignature(abiEvent);
+  return "0x" + keccak256Hex(signature);
+}
+
+function buildCanonicalSignature(abiEvent: AbiEventEntry): string {
+  const paramTypes = abiEvent.inputs.map((inp) => canonicalType(inp.type));
+  return `${abiEvent.name}(${paramTypes.join(",")})`;
+}
+
+/**
+ * Normalize tuple / array types to their canonical form for hashing.
+ */
+function canonicalType(t: string): string {
+  // Normalise "uint" → "uint256", "int" → "int256", "byte" → "bytes1"
+  if (t === "uint") return "uint256";
+  if (t === "int") return "int256";
+  if (t === "byte") return "bytes1";
+  return t;
+}
+
+// ──────────────────────────────────────────────────────
+//  ABI-based log decoding (without ethers dependency)
+// ──────────────────────────────────────────────────────
+
+/**
+ * Decode a raw log against a known ABI event definition.
+ * Indexed parameters come from `topics`, non-indexed from `data`.
+ */
+export function decodeEventLog(
+  abiEvent: AbiEventEntry,
+  log: RawLog
+): Record<string, unknown> {
+  const indexedInputs = abiEvent.inputs.filter((i) => i.indexed);
+  const nonIndexedInputs = abiEvent.inputs.filter((i) => !i.indexed);
+
+  const args: Record<string, unknown> = {};
+
+  // Decode indexed params from topics (topic[0] is the event sig)
+  for (let i = 0; i < indexedInputs.length; i++) {
+    const input = indexedInputs[i];
+    const topicHex = log.topics[i + 1]; // +1 because topics[0] is event signature
+    if (!topicHex) continue;
+
+    if (input.type === "string" || input.type === "bytes" || input.type.includes("[")) {
+      // For dynamic types, topics contain the keccak256 hash — store the hash
+      args[input.name] = topicHex;
+    } else {
+      args[input.name] = decodeSingleValue(input.type, topicHex);
+    }
+  }
+
+  // Decode non-indexed params from data
+  if (nonIndexedInputs.length > 0 && log.data && log.data !== "0x") {
+    const decoded = decodeAbiData(nonIndexedInputs.map((i) => i.type), log.data);
+    for (let i = 0; i < nonIndexedInputs.length; i++) {
+      args[nonIndexedInputs[i].name] = decoded[i];
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Decode a single ABI-encoded value from a 32-byte hex word.
+ */
+export function decodeSingleValue(type: string, hexWord: string): unknown {
+  const raw = hexWord.startsWith("0x") ? hexWord.slice(2) : hexWord;
+  const normalized = raw.padStart(64, "0");
+
+  if (type === "address") {
+    return "0x" + normalized.slice(24);
+  }
+  if (type === "bool") {
+    return BigInt("0x" + normalized) !== 0n;
+  }
+  if (type.startsWith("uint")) {
+    return BigInt("0x" + normalized);
+  }
+  if (type.startsWith("int")) {
+    const val = BigInt("0x" + normalized);
+    const bits = parseInt(type.slice(3) || "256");
+    const max = 1n << BigInt(bits - 1);
+    return val >= max ? val - (1n << BigInt(bits)) : val;
+  }
+  if (type === "bytes32") {
+    return "0x" + normalized;
+  }
+  if (type.startsWith("bytes")) {
+    return "0x" + normalized;
+  }
+  // Fallback: return raw hex
+  return "0x" + normalized;
+}
+
+/**
+ * Decode ABI-encoded data for a list of types.
+ * Supports: uint/int (8–256), address, bool, bytes32, string (static slots only).
+ */
+export function decodeAbiData(types: string[], hexData: string): unknown[] {
+  const data = hexData.startsWith("0x") ? hexData.slice(2) : hexData;
+  const results: unknown[] = [];
+
+  for (let i = 0; i < types.length; i++) {
+    const offset = i * 64;
+    const word = data.slice(offset, offset + 64);
+    if (word.length < 64) {
+      // Short data — left-pad
+      results.push(decodeSingleValue(types[i], word.padStart(64, "0")));
+    } else {
+      results.push(decodeSingleValue(types[i], word));
+    }
+  }
+
+  return results;
+}
+
+// ──────────────────────────────────────────────────────
+//  EventSubscriptionManager
+// ──────────────────────────────────────────────────────
+
+interface ActiveSubscription {
+  id: string;
+  abiEvent: AbiEventEntry;
+  contractAddress: string;
+  callback: (log: DecodedEventLog) => void;
+  filter?: EventFilter;
+  topic0: string;
+}
+
+export class EventSubscriptionManager extends EventEmitter {
+  private wsProvider: WebSocketProvider | null = null;
+  private wsConfig: WsProviderConfig | null = null;
+  private activeSubscriptions = new Map<string, ActiveSubscription>();
+  private resubscribeCallbacks: Array<() => Promise<void>> = [];
+  private _connected = false;
+
+  constructor(config: EventSubscriptionConfig = {}) {
+    super();
+    if (config.wsProvider) {
+      this.wsProvider = config.wsProvider;
+    }
+    if (config.wsConfig) {
+      this.wsConfig = config.wsConfig;
+    }
+  }
+
+  /**
+   * Connect the underlying WebSocket provider.
+   * If an existing provider was passed, uses that.
+   */
+  async connect(): Promise<void> {
+    if (this._connected && this.wsProvider) return;
+
+    if (!this.wsProvider) {
+      if (!this.wsConfig) {
+        throw new Error("No WebSocket config or provider supplied");
+      }
+      this.wsProvider = new WebSocketProvider(this.wsConfig);
+    }
+
+    // Listen for reconnects to resubscribe
+    this.wsProvider.on("connected", () => {
+      this._connected = true;
+      this.resubscribeAll();
+    });
+    this.wsProvider.on("disconnected", () => {
+      this._connected = false;
+      this.emit("disconnected");
+    });
+    this.wsProvider.on("maxReconnectsReached", () => {
+      this.emit("maxReconnectsReached");
+    });
+
+    await this.wsProvider.connect();
+    this._connected = true;
+  }
+
+  /**
+   * Subscribe to a contract event.
+   *
+   * @param contractAddress - The contract to listen to
+   * @param abiEvent        - The ABI event definition
+   * @param callback        - Called with decoded log on each event
+   * @param filter          - Optional indexed parameter filter
+   * @returns SubscriptionHandle with the subscriptionId and an unsubscribe function
+   */
+  async subscribeToEvents(
+    contractAddress: string,
+    abiEvent: AbiEventEntry,
+    callback: (log: DecodedEventLog) => void,
+    filter?: EventFilter
+  ): Promise<SubscriptionHandle> {
+    if (!this.wsProvider) {
+      await this.connect();
+    }
+    if (!this.wsProvider) {
+      throw new Error("Failed to establish WebSocket connection");
+    }
+
+    const topic0 = computeEventTopic(abiEvent);
+    const indexedInputs = abiEvent.inputs.filter((i) => i.indexed);
+
+    // Build the topics array for eth_subscribe
+    const topics: (string | string[] | null)[] = [topic0];
+
+    // Apply indexed filter: for each indexed param, if filter value provided,
+    // set the topic to the exact value; otherwise null (wildcard)
+    if (filter && indexedInputs.length > 0) {
+      for (const inp of indexedInputs) {
+        if (inp.name in filter) {
+          topics.push(encodeTopicValue(inp.type, filter[inp.name]));
+        } else {
+          topics.push(null); // wildcard for this indexed position
+        }
+      }
+    }
+
+    const subId = (await this.wsProvider.send("eth_subscribe", [
+      "logs",
+      {
+        address: contractAddress.toLowerCase(),
+        topics,
+      },
+    ])) as string;
+
+    const activeSub: ActiveSubscription = {
+      id: subId,
+      abiEvent,
+      contractAddress,
+      callback,
+      filter,
+      topic0,
+    };
+
+    this.activeSubscriptions.set(subId, activeSub);
+
+    // Register the raw data handler
+    this.wsProvider["subscriptions"].set(subId, (data: unknown) => {
+      this.handleLog(activeSub, data as RawLog);
+    });
+
+    // Store resubscribe callback
+    const resubCb = async () => {
+      if (this.wsProvider) {
+        try {
+          const newSubId = (await this.wsProvider.send("eth_subscribe", [
+            "logs",
+            {
+              address: contractAddress.toLowerCase(),
+              topics,
+            },
+          ])) as string;
+
+          activeSub.id = newSubId;
+          this.activeSubscriptions.delete(subId);
+          this.activeSubscriptions.set(newSubId, activeSub);
+          this.wsProvider["subscriptions"].set(newSubId, (data: unknown) => {
+            this.handleLog(activeSub, data as RawLog);
+          });
+        } catch (err) {
+          this.emit("resubscribeError", err);
+        }
+      }
+    };
+    this.resubscribeCallbacks.push(resubCb);
+
+    return {
+      subscriptionId: subId,
+      unsubscribe: async () => {
+        await this.unsubscribe(subId);
+      },
+    };
+  }
+
+  /**
+   * Unsubscribe from a specific subscription.
+   */
+  async unsubscribe(subscriptionId: string): Promise<void> {
+    const sub = this.activeSubscriptions.get(subscriptionId);
+    if (!sub) return;
+
+    this.activeSubscriptions.delete(subscriptionId);
+    if (this.wsProvider) {
+      this.wsProvider["subscriptions"].delete(subscriptionId);
+      try {
+        await this.wsProvider.unsubscribe(subscriptionId);
+      } catch {
+        // Already disconnected — ignore
+      }
+    }
+  }
+
+  /**
+   * Unsubscribe from all active subscriptions and disconnect.
+   */
+  async disconnect(): Promise<void> {
+    for (const [id] of this.activeSubscriptions) {
+      await this.unsubscribe(id);
+    }
+    this.resubscribeCallbacks = [];
+    if (this.wsProvider) {
+      this.wsProvider.disconnect();
+    }
+    this._connected = false;
+  }
+
+  /**
+   * Check if the manager is connected.
+   */
+  isConnected(): boolean {
+    return this._connected;
+  }
+
+  /**
+   * Get the number of active subscriptions.
+   */
+  getActiveSubscriptionCount(): number {
+    return this.activeSubscriptions.size;
+  }
+
+  // ── Private ──
+
+  private handleLog(activeSub: ActiveSubscription, raw: RawLog): void {
+    try {
+      // Verify topic0 matches (guard against misrouted logs)
+      if (raw.topics[0]?.toLowerCase() !== activeSub.topic0.toLowerCase()) {
+        return;
+      }
+
+      // Verify contract address
+      if (raw.address?.toLowerCase() !== activeSub.contractAddress.toLowerCase()) {
+        return;
+      }
+
+      const args = decodeEventLog(activeSub.abiEvent, raw);
+
+      // Apply additional indexed filter check client-side
+      if (activeSub.filter) {
+        const matchesFilter = Object.entries(activeSub.filter).every(
+          ([key, value]) => {
+            const decoded = args[key];
+            if (decoded === undefined) return true;
+            // Compare as lowercased hex strings for addresses, bigints for numbers
+            if (typeof value === "string" && typeof decoded === "string") {
+              return decoded.toLowerCase() === value.toLowerCase();
+            }
+            return decoded === value;
+          }
+        );
+        if (!matchesFilter) return;
+      }
+
+      const decoded: DecodedEventLog = {
+        event: activeSub.abiEvent.name,
+        address: raw.address,
+        blockNumber: raw.blockNumber ? parseInt(raw.blockNumber, 16) : null,
+        transactionHash: raw.transactionHash ?? null,
+        logIndex: raw.logIndex ? parseInt(raw.logIndex, 16) : null,
+        args,
+        raw,
+      };
+
+      activeSub.callback(decoded);
+      this.emit("event", decoded);
+    } catch (err) {
+      this.emit("decodeError", err);
+    }
+  }
+
+  private async resubscribeAll(): Promise<void> {
+    this.emit("resubscribing");
+    for (const cb of this.resubscribeCallbacks) {
+      try {
+        await cb();
+      } catch (err) {
+        this.emit("resubscribeError", err);
+      }
+    }
+    this.emit("resubscribed");
+  }
+}
+
+/**
+ * Encode a filter value into a 32-byte hex topic value.
+ */
+function encodeTopicValue(
+  type: string,
+  value: string | number | bigint | boolean
+): string {
+  if (type === "address") {
+    const addr = typeof value === "string" ? value.toLowerCase() : String(value);
+    const cleaned = addr.startsWith("0x") ? addr.slice(2) : addr;
+    return "0x" + cleaned.padStart(64, "0");
+  }
+  if (type === "bool") {
+    return "0x" + (value ? "1" : "0").padStart(64, "0");
+  }
+  if (type.startsWith("uint") || type.startsWith("int")) {
+    const n = BigInt(value as string | number | bigint);
+    return "0x" + n.toString(16).padStart(64, "0");
+  }
+  if (type === "bytes32") {
+    const s = typeof value === "string" ? value : String(value);
+    const cleaned = s.startsWith("0x") ? s.slice(2) : s;
+    return "0x" + cleaned.padEnd(64, "0");
+  }
+  if (type === "string" || type === "bytes") {
+    // Dynamic types: topic holds keccak256 hash
+    const s = typeof value === "string" ? value : String(value);
+    return "0x" + keccak256Hex(s);
+  }
+  // Fallback
+  const s = String(value);
+  return "0x" + (s.startsWith("0x") ? s.slice(2) : s).padStart(64, "0");
+}

--- a/sdk/src/events/index.ts
+++ b/sdk/src/events/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @fix-author kejuunuy
+ * @fix-date 2026-05-30
+ * @fix-issue 196
+ * @fix-description Event subscription and decoding module exports
+ */
+
+export {
+  EventSubscriptionManager,
+  computeEventTopic,
+  decodeEventLog,
+  decodeSingleValue,
+  decodeAbiData,
+  type AbiEventInput,
+  type AbiEventEntry,
+  type DecodedEventLog,
+  type RawLog,
+  type EventFilter,
+  type SubscriptionHandle,
+  type EventSubscriptionConfig,
+} from "./EventSubscription";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,22 @@
+/**
+ * @fix-author kejuunuy
+ * @fix-date 2026-05-30
+ * @fix-issue 196
+ * @fix-description Added subscribeToEvents method with ABI decoding, indexed filtering, and WebSocket auto-reconnect
+ */
+
 import { ethers } from "ethers";
+import {
+  EventSubscriptionManager,
+  EventSubscriptionConfig,
+  AbiEventEntry,
+  AbiEventInput,
+  DecodedEventLog,
+  EventFilter,
+  SubscriptionHandle,
+  computeEventTopic,
+  decodeEventLog,
+} from "./events";
 
 export interface AgentConfig {
   name: string;
@@ -7,12 +25,17 @@ export interface AgentConfig {
   rpcUrl: string;
   registryAddress: string;
   routerAddress: string;
+  /** Optional WebSocket RPC URL for event subscriptions */
+  wsRpcUrl?: string;
+  /** Optional WebSocket provider config for event subscriptions */
+  wsConfig?: EventSubscriptionConfig;
 }
 
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
   private config: AgentConfig;
+  private eventManager: EventSubscriptionManager | null = null;
 
   constructor(config: AgentConfig) {
     this.config = config;
@@ -88,4 +111,113 @@ export class OpenAgentsSDK {
 
     return openTasks;
   }
+
+  /**
+   * Subscribe to contract events with ABI decoding and optional indexed parameter filtering.
+   *
+   * @param contractAddress - The address of the contract to listen to
+   * @param abi             - The contract ABI (array of event definitions, or a single event definition)
+   * @param eventName       - The name of the event to subscribe to
+   * @param callback        - Called with decoded event data on each emission
+   * @param filter          - Optional indexed parameter filter
+   * @returns SubscriptionHandle with subscriptionId and unsubscribe function
+   *
+   * @example
+   * ```ts
+   * const handle = await sdk.subscribeToEvents(
+   *   "0x1234...",
+   *   [{ type: "event", name: "Transfer", inputs: [
+   *     { name: "from", type: "address", indexed: true },
+   *     { name: "to", type: "address", indexed: true },
+   *     { name: "value", type: "uint256", indexed: false },
+   *   ]}],
+   *   "Transfer",
+   *   (event) => console.log("Transfer:", event.args),
+   *   { from: "0xabc..." }
+   * );
+   *
+   * // Later...
+   * await handle.unsubscribe();
+   * ```
+   */
+  async subscribeToEvents(
+    contractAddress: string,
+    abi: AbiEventEntry[] | AbiEventEntry,
+    eventName: string,
+    callback: (event: DecodedEventLog) => void,
+    filter?: EventFilter
+  ): Promise<SubscriptionHandle> {
+    const manager = this.getEventManager();
+
+    // Find the matching event definition
+    const abiArray = Array.isArray(abi) ? abi : [abi];
+    const eventDef = abiArray.find(
+      (entry) => entry.type === "event" && entry.name === eventName
+    );
+
+    if (!eventDef) {
+      throw new Error(
+        `Event "${eventName}" not found in the provided ABI. ` +
+          `Available events: ${abiArray
+            .filter((e) => e.type === "event")
+            .map((e) => e.name)
+            .join(", ") || "(none)"}`
+      );
+    }
+
+    return manager.subscribeToEvents(
+      contractAddress,
+      eventDef,
+      callback,
+      filter
+    );
+  }
+
+  /**
+   * Disconnect all event subscriptions and clean up.
+   */
+  async disconnectEvents(): Promise<void> {
+    if (this.eventManager) {
+      await this.eventManager.disconnect();
+      this.eventManager = null;
+    }
+  }
+
+  /**
+   * Get or create the EventSubscriptionManager.
+   */
+  private getEventManager(): EventSubscriptionManager {
+    if (!this.eventManager) {
+      const eventConfig: EventSubscriptionConfig = {};
+
+      if (this.config.wsConfig) {
+        Object.assign(eventConfig, this.config.wsConfig);
+      } else if (this.config.wsRpcUrl) {
+        eventConfig.wsConfig = { url: this.config.wsRpcUrl };
+      } else {
+        // Fall back: convert HTTP RPC URL to WS if possible
+        const httpUrl = this.config.rpcUrl;
+        const wsUrl = httpUrl
+          .replace(/^http:\/\//, "ws://")
+          .replace(/^https:\/\//, "wss://");
+        eventConfig.wsConfig = { url: wsUrl };
+      }
+
+      this.eventManager = new EventSubscriptionManager(eventConfig);
+    }
+    return this.eventManager;
+  }
 }
+
+// Re-export event types for consumers
+export {
+  EventSubscriptionManager,
+  computeEventTopic,
+  decodeEventLog,
+  type AbiEventEntry,
+  type AbiEventInput,
+  type DecodedEventLog,
+  type EventFilter,
+  type SubscriptionHandle,
+  type EventSubscriptionConfig,
+} from "./events";

--- a/sdk/tests/events.test.ts
+++ b/sdk/tests/events.test.ts
@@ -1,0 +1,717 @@
+/**
+ * @fix-author kejuunuy
+ * @fix-date 2026-05-30
+ * @fix-issue 196
+ * @fix-description Tests for event subscription: subscribe, receive, filter, reconnect
+ */
+
+import {
+  EventSubscriptionManager,
+  computeEventTopic,
+  decodeEventLog,
+  decodeSingleValue,
+  decodeAbiData,
+  AbiEventEntry,
+  RawLog,
+  DecodedEventLog,
+} from "../src/events";
+
+// ──────────────────────────────────────────────────────
+//  Test Helpers — mock WebSocket provider
+// ──────────────────────────────────────────────────────
+
+type MockCallback = (data: unknown) => void;
+
+class MockWebSocketProvider {
+  public subscriptions = new Map<string, MockCallback>();
+  private listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  public connected = false;
+  public sendCalls: Array<{ method: string; params: unknown[] }> = [];
+  public disconnectCalls = 0;
+  private nextSubId = 1;
+  private _reconnectHandler: (() => void) | null = null;
+
+  on(event: string, cb: (...args: unknown[]) => void) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(cb);
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    (this.listeners[event] || []).forEach((cb) => cb(...args));
+  }
+
+  async connect(): Promise<void> {
+    this.connected = true;
+    this.emit("connected");
+  }
+
+  async send(method: string, params: unknown[] = []): Promise<string> {
+    this.sendCalls.push({ method, params });
+    const subId = `0x${this.nextSubId++}`;
+    return subId;
+  }
+
+  async unsubscribe(subscriptionId: string): Promise<boolean> {
+    this.subscriptions.delete(subscriptionId);
+    return true;
+  }
+
+  disconnect(): void {
+    this.connected = false;
+    this.disconnectCalls++;
+    this.subscriptions.clear();
+  }
+
+  // Helper to simulate an incoming log from the node
+  simulateLog(subscriptionId: string, log: unknown) {
+    const cb = this.subscriptions.get(subscriptionId);
+    if (cb) cb(log);
+  }
+
+  // Helper to simulate reconnect
+  simulateReconnect() {
+    this.connected = false;
+    this.emit("disconnected");
+    this.connected = true;
+    this.emit("connected");
+  }
+}
+
+// Patch EventSubscriptionManager to accept mock provider
+function createManagerWithMock(mock: MockWebSocketProvider): EventSubscriptionManager {
+  const manager = new EventSubscriptionManager({});
+  // Inject mock provider directly
+  (manager as any).wsProvider = mock;
+  (manager as any)._connected = mock.connected;
+
+  // Wire up the mock's event listeners to manager's resubscribe logic
+  mock.on("connected", async () => {
+    (manager as any)._connected = true;
+    // Trigger resubscribe
+    await (manager as any).resubscribeAll();
+  });
+  mock.on("disconnected", () => {
+    (manager as any)._connected = false;
+  });
+
+  return manager;
+}
+
+// ──────────────────────────────────────────────────────
+//  Test ABI definitions
+// ──────────────────────────────────────────────────────
+
+const TRANSFER_EVENT: AbiEventEntry = {
+  type: "event",
+  name: "Transfer",
+  inputs: [
+    { name: "from", type: "address", indexed: true },
+    { name: "to", type: "address", indexed: true },
+    { name: "value", type: "uint256", indexed: false },
+  ],
+};
+
+const TASK_ASSIGNED_EVENT: AbiEventEntry = {
+  type: "event",
+  name: "TaskAssigned",
+  inputs: [
+    { name: "taskId", type: "uint256", indexed: true },
+    { name: "agentId", type: "bytes32", indexed: true },
+    { name: "reward", type: "uint256", indexed: false },
+  ],
+};
+
+const APPROVAL_EVENT: AbiEventEntry = {
+  type: "event",
+  name: "Approval",
+  inputs: [
+    { name: "owner", type: "address", indexed: true },
+    { name: "spender", type: "address", indexed: true },
+    { name: "value", type: "uint256", indexed: false },
+  ],
+};
+
+const EVENT_WITH_BOOL: AbiEventEntry = {
+  type: "event",
+  name: "StatusChanged",
+  inputs: [
+    { name: "account", type: "address", indexed: true },
+    { name: "active", type: "bool", indexed: false },
+  ],
+};
+
+// ──────────────────────────────────────────────────────
+//  Tests
+// ──────────────────────────────────────────────────────
+
+describe("computeEventTopic", () => {
+  it("should compute correct topic for Transfer event", () => {
+    const topic = computeEventTopic(TRANSFER_EVENT);
+    expect(topic).toMatch(/^0x[0-9a-f]{64}$/);
+    // Known Transfer event topic: keccak256("Transfer(address,address,uint256)")
+    expect(topic).toBe(
+      "0x" +
+        require("crypto")
+          .createHash("sha3-256")
+          .update("Transfer(address,address,uint256)")
+          .digest("hex")
+    );
+  });
+
+  it("should compute correct topic for TaskAssigned event", () => {
+    const topic = computeEventTopic(TASK_ASSIGNED_EVENT);
+    const expected =
+      "0x" +
+      require("crypto")
+        .createHash("sha3-256")
+        .update("TaskAssigned(uint256,bytes32,uint256)")
+        .digest("hex");
+    expect(topic).toBe(expected);
+  });
+
+  it("should normalize uint → uint256", () => {
+    const event: AbiEventEntry = {
+      type: "event",
+      name: "Test",
+      inputs: [{ name: "val", type: "uint", indexed: false }],
+    };
+    const event2: AbiEventEntry = {
+      type: "event",
+      name: "Test",
+      inputs: [{ name: "val", type: "uint256", indexed: false }],
+    };
+    expect(computeEventTopic(event)).toBe(computeEventTopic(event2));
+  });
+});
+
+describe("decodeSingleValue", () => {
+  it("should decode address", () => {
+    const addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    const word = "0x" + "0".repeat(24) + addr.slice(2).toLowerCase();
+    expect(decodeSingleValue("address", word)).toBe(addr.toLowerCase());
+  });
+
+  it("should decode uint256", () => {
+    const hex = "0x" + BigInt(1000).toString(16).padStart(64, "0");
+    expect(decodeSingleValue("uint256", hex)).toBe(1000n);
+  });
+
+  it("should decode bool true", () => {
+    const hex = "0x" + "1".padStart(64, "0");
+    expect(decodeSingleValue("bool", hex)).toBe(true);
+  });
+
+  it("should decode bool false", () => {
+    const hex = "0x" + "0".padStart(64, "0");
+    expect(decodeSingleValue("bool", hex)).toBe(false);
+  });
+
+  it("should decode bytes32", () => {
+    const hex = "0x" + "ab".repeat(32);
+    expect(decodeSingleValue("bytes32", hex)).toBe("0x" + "ab".repeat(32));
+  });
+});
+
+describe("decodeAbiData", () => {
+  it("should decode multiple uint256 values", () => {
+    const val1 = BigInt(100);
+    const val2 = BigInt(200);
+    const data =
+      "0x" +
+      val1.toString(16).padStart(64, "0") +
+      val2.toString(16).padStart(64, "0");
+    const result = decodeAbiData(["uint256", "uint256"], data);
+    expect(result).toEqual([100n, 200n]);
+  });
+
+  it("should decode mixed types", () => {
+    const addr = "0x" + "11".repeat(20);
+    const val = BigInt(999);
+    const data =
+      "0x" +
+      "0".repeat(24) + addr.slice(2) +
+      val.toString(16).padStart(64, "0");
+    const result = decodeAbiData(["address", "uint256"], data);
+    expect(result[0]).toBe(addr.toLowerCase());
+    expect(result[1]).toBe(999n);
+  });
+});
+
+describe("decodeEventLog", () => {
+  const CONTRACT_ADDRESS = "0x" + "aa".repeat(20);
+
+  it("should decode Transfer event log", () => {
+    const from = "0x" + "11".repeat(20);
+    const to = "0x" + "22".repeat(20);
+    const value = BigInt("1000000000000000000"); // 1 ETH
+
+    const log: RawLog = {
+      address: CONTRACT_ADDRESS,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + from.slice(2).toLowerCase().padStart(64, "0"),
+        "0x" + to.slice(2).toLowerCase().padStart(64, "0"),
+      ],
+      data: "0x" + value.toString(16).padStart(64, "0"),
+      blockNumber: "0x1",
+      transactionHash: "0x" + "ab".repeat(32),
+      logIndex: "0x0",
+    };
+
+    const args = decodeEventLog(TRANSFER_EVENT, log);
+    expect(args.from).toBe(from.toLowerCase());
+    expect(args.to).toBe(to.toLowerCase());
+    expect(args.value).toBe(value);
+  });
+
+  it("should decode TaskAssigned event log", () => {
+    const taskId = BigInt(42);
+    const agentId = "0x" + "ff".repeat(32);
+    const reward = BigInt("5000000000000000000");
+
+    const log: RawLog = {
+      address: CONTRACT_ADDRESS,
+      topics: [
+        computeEventTopic(TASK_ASSIGNED_EVENT),
+        "0x" + taskId.toString(16).padStart(64, "0"),
+        agentId,
+      ],
+      data: "0x" + reward.toString(16).padStart(64, "0"),
+      blockNumber: "0xa",
+      transactionHash: "0x" + "cd".repeat(32),
+      logIndex: "0x1",
+    };
+
+    const args = decodeEventLog(TASK_ASSIGNED_EVENT, log);
+    expect(args.taskId).toBe(taskId);
+    expect(args.agentId).toBe(agentId);
+    expect(args.reward).toBe(reward);
+  });
+
+  it("should decode Approval event log", () => {
+    const owner = "0x" + "33".repeat(20);
+    const spender = "0x" + "44".repeat(20);
+    const value = BigInt(500);
+
+    const log: RawLog = {
+      address: CONTRACT_ADDRESS,
+      topics: [
+        computeEventTopic(APPROVAL_EVENT),
+        "0x" + owner.slice(2).toLowerCase().padStart(64, "0"),
+        "0x" + spender.slice(2).toLowerCase().padStart(64, "0"),
+      ],
+      data: "0x" + value.toString(16).padStart(64, "0"),
+      blockNumber: "0x5",
+      transactionHash: null,
+      logIndex: null,
+    };
+
+    const args = decodeEventLog(APPROVAL_EVENT, log);
+    expect(args.owner).toBe(owner.toLowerCase());
+    expect(args.spender).toBe(spender.toLowerCase());
+    expect(args.value).toBe(500n);
+  });
+
+  it("should decode event with bool parameter", () => {
+    const account = "0x" + "55".repeat(20);
+
+    const log: RawLog = {
+      address: CONTRACT_ADDRESS,
+      topics: [
+        computeEventTopic(EVENT_WITH_BOOL),
+        "0x" + account.slice(2).toLowerCase().padStart(64, "0"),
+      ],
+      data: "0x" + "1".padStart(64, "0"),
+      blockNumber: "0x3",
+      transactionHash: null,
+      logIndex: null,
+    };
+
+    const args = decodeEventLog(EVENT_WITH_BOOL, log);
+    expect(args.account).toBe(account.toLowerCase());
+    expect(args.active).toBe(true);
+  });
+});
+
+describe("EventSubscriptionManager", () => {
+  let mock: MockWebSocketProvider;
+  let manager: EventSubscriptionManager;
+  const CONTRACT = "0x" + "aa".repeat(20);
+
+  beforeEach(async () => {
+    mock = new MockWebSocketProvider();
+    await mock.connect();
+    manager = createManagerWithMock(mock);
+  });
+
+  afterEach(async () => {
+    await manager.disconnect();
+  });
+
+  // ── Test: Subscribe ──
+  it("should subscribe to events and return a handle", async () => {
+    const callback = jest.fn();
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      callback
+    );
+
+    expect(handle.subscriptionId).toBeDefined();
+    expect(typeof handle.unsubscribe).toBe("function");
+    expect(mock.sendCalls.length).toBe(1);
+    expect(mock.sendCalls[0].method).toBe("eth_subscribe");
+    expect(manager.getActiveSubscriptionCount()).toBe(1);
+  });
+
+  // ── Test: Receive ──
+  it("should receive and decode event logs via callback", async () => {
+    const received: DecodedEventLog[] = [];
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => received.push(log)
+    );
+
+    const from = "0x" + "11".repeat(20);
+    const to = "0x" + "22".repeat(20);
+    const value = BigInt("1000000000000000000");
+
+    const rawLog: RawLog = {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + from.slice(2).padStart(64, "0"),
+        "0x" + to.slice(2).padStart(64, "0"),
+      ],
+      data: "0x" + value.toString(16).padStart(64, "0"),
+      blockNumber: "0xa",
+      transactionHash: "0x" + "ab".repeat(32),
+      logIndex: "0x0",
+    };
+
+    mock.simulateLog(handle.subscriptionId, rawLog);
+
+    expect(received.length).toBe(1);
+    expect(received[0].event).toBe("Transfer");
+    expect(received[0].args.from).toBe(from.toLowerCase());
+    expect(received[0].args.to).toBe(to.toLowerCase());
+    expect(received[0].args.value).toBe(value);
+    expect(received[0].blockNumber).toBe(10);
+    expect(received[0].address).toBe(CONTRACT);
+  });
+
+  it("should emit 'event' on the manager when log is received", async () => {
+    const eventPromise = new Promise<DecodedEventLog>((resolve) => {
+      manager.on("event", resolve);
+    });
+
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      () => {}
+    );
+
+    const rawLog: RawLog = {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + "11".repeat(32),
+        "0x" + "22".repeat(32),
+      ],
+      data: "0x" + "0".repeat(63) + "1",
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    };
+
+    mock.simulateLog(handle.subscriptionId, rawLog);
+    const event = await eventPromise;
+    expect(event.event).toBe("Transfer");
+  });
+
+  // ── Test: Filter ──
+  it("should filter events by indexed parameter", async () => {
+    const received: DecodedEventLog[] = [];
+    const specificFrom = "0x" + "11".repeat(20);
+    const otherFrom = "0x" + "99".repeat(20);
+    const to = "0x" + "22".repeat(20);
+
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => received.push(log),
+      { from: specificFrom }
+    );
+
+    // Verify the subscribe call includes the filter topic
+    const sendCall = mock.sendCalls[0];
+    const topics = sendCall.params[1] as { topics: string[] };
+    expect(topics.topics[0]).toBe(computeEventTopic(TRANSFER_EVENT));
+    // The from filter should be encoded as a topic
+    expect(topics.topics[1]).toBe(
+      "0x" + specificFrom.toLowerCase().slice(2).padStart(64, "0")
+    );
+
+    // Simulate a log from the specific address — should be received
+    const matchingLog: RawLog = {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + specificFrom.slice(2).toLowerCase().padStart(64, "0"),
+        "0x" + to.slice(2).padStart(64, "0"),
+      ],
+      data: "0x" + BigInt(100).toString(16).padStart(64, "0"),
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    };
+    mock.simulateLog(handle.subscriptionId, matchingLog);
+    expect(received.length).toBe(1);
+
+    // Simulate a log from a different address — should be filtered out
+    const nonMatchingLog: RawLog = {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + otherFrom.slice(2).toLowerCase().padStart(64, "0"),
+        "0x" + to.slice(2).padStart(64, "0"),
+      ],
+      data: "0x" + BigInt(200).toString(16).padStart(64, "0"),
+      blockNumber: "0x2",
+      transactionHash: null,
+      logIndex: null,
+    };
+    mock.simulateLog(handle.subscriptionId, nonMatchingLog);
+    expect(received.length).toBe(1); // Still 1 — the second was filtered
+  });
+
+  it("should filter by multiple indexed params", async () => {
+    const received: DecodedEventLog[] = [];
+    const from = "0x" + "11".repeat(20);
+    const to = "0x" + "22".repeat(20);
+
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => received.push(log),
+      { from, to }
+    );
+
+    const sendCall = mock.sendCalls[0];
+    const topics = sendCall.params[1] as { topics: (string | null)[] };
+    expect(topics.topics[1]).toBe(
+      "0x" + from.toLowerCase().slice(2).padStart(64, "0")
+    );
+    expect(topics.topics[2]).toBe(
+      "0x" + to.toLowerCase().slice(2).padStart(64, "0")
+    );
+
+    // Matching log
+    mock.simulateLog(handle.subscriptionId, {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + from.slice(2).toLowerCase().padStart(64, "0"),
+        "0x" + to.slice(2).toLowerCase().padStart(64, "0"),
+      ],
+      data: "0x" + BigInt(100).toString(16).padStart(64, "0"),
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    });
+    expect(received.length).toBe(1);
+
+    // Non-matching (different `to`)
+    mock.simulateLog(handle.subscriptionId, {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + from.slice(2).toLowerCase().padStart(64, "0"),
+        "0x" + "33".repeat(32),
+      ],
+      data: "0x" + BigInt(200).toString(16).padStart(64, "0"),
+      blockNumber: "0x2",
+      transactionHash: null,
+      logIndex: null,
+    });
+    expect(received.length).toBe(1); // Still 1
+  });
+
+  // ── Test: Reconnect and resubscribe ──
+  it("should resubscribe after WebSocket reconnect", async () => {
+    const received: DecodedEventLog[] = [];
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => received.push(log)
+    );
+
+    const originalSubId = handle.subscriptionId;
+    expect(manager.getActiveSubscriptionCount()).toBe(1);
+
+    // Simulate reconnect
+    mock.simulateReconnect();
+
+    // After resubscribe, there should be a new subscription ID
+    // (the mock generates incrementing IDs)
+    const newSubId = mock.sendCalls[mock.sendCalls.length - 1];
+    expect(newSubId.method).toBe("eth_subscribe");
+
+    // The old subscription should have been cleaned up
+    // and a new one registered
+    expect(manager.getActiveSubscriptionCount()).toBe(1);
+
+    // Simulate a log on the new subscription
+    const rawLog: RawLog = {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + "11".repeat(32),
+        "0x" + "22".repeat(32),
+      ],
+      data: "0x" + "0".repeat(63) + "1",
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    };
+
+    // Find the new subscription ID from the subscriptions map
+    const subIds = Array.from(mock.subscriptions.keys());
+    const newId = subIds[subIds.length - 1];
+    mock.simulateLog(newId, rawLog);
+
+    expect(received.length).toBe(1);
+    expect(received[0].event).toBe("Transfer");
+  });
+
+  // ── Test: Unsubscribe ──
+  it("should unsubscribe from events", async () => {
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      () => {}
+    );
+
+    expect(manager.getActiveSubscriptionCount()).toBe(1);
+    await handle.unsubscribe();
+    expect(manager.getActiveSubscriptionCount()).toBe(0);
+  });
+
+  // ── Test: Topic mismatch rejection ──
+  it("should ignore logs with mismatched topic0", async () => {
+    const received: DecodedEventLog[] = [];
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => received.push(log)
+    );
+
+    // Simulate a log with wrong topic0 (Approval event instead of Transfer)
+    const wrongLog: RawLog = {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(APPROVAL_EVENT), // Wrong event!
+        "0x" + "11".repeat(32),
+        "0x" + "22".repeat(32),
+      ],
+      data: "0x" + "0".repeat(63) + "1",
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    };
+
+    mock.simulateLog(handle.subscriptionId, wrongLog);
+    expect(received.length).toBe(0); // Should be ignored
+  });
+
+  // ── Test: Address mismatch rejection ──
+  it("should ignore logs from non-matching contract address", async () => {
+    const received: DecodedEventLog[] = [];
+    const handle = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => received.push(log)
+    );
+
+    const wrongAddress = "0x" + "bb".repeat(20);
+    const wrongLog: RawLog = {
+      address: wrongAddress,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + "11".repeat(32),
+        "0x" + "22".repeat(32),
+      ],
+      data: "0x" + "0".repeat(63) + "1",
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    };
+
+    mock.simulateLog(handle.subscriptionId, wrongLog);
+    expect(received.length).toBe(0);
+  });
+
+  // ── Test: Disconnect ──
+  it("should clean up all subscriptions on disconnect", async () => {
+    await manager.subscribeToEvents(CONTRACT, TRANSFER_EVENT, () => {});
+    await manager.subscribeToEvents(CONTRACT, APPROVAL_EVENT, () => {});
+    expect(manager.getActiveSubscriptionCount()).toBe(2);
+
+    await manager.disconnect();
+    expect(manager.getActiveSubscriptionCount()).toBe(0);
+    expect(mock.disconnectCalls).toBe(1);
+  });
+
+  // ── Test: Multiple subscriptions ──
+  it("should handle multiple concurrent subscriptions", async () => {
+    const transfers: DecodedEventLog[] = [];
+    const approvals: DecodedEventLog[] = [];
+
+    const handle1 = await manager.subscribeToEvents(
+      CONTRACT,
+      TRANSFER_EVENT,
+      (log) => transfers.push(log)
+    );
+    const handle2 = await manager.subscribeToEvents(
+      CONTRACT,
+      APPROVAL_EVENT,
+      (log) => approvals.push(log)
+    );
+
+    expect(manager.getActiveSubscriptionCount()).toBe(2);
+
+    // Simulate Transfer log
+    mock.simulateLog(handle1.subscriptionId, {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(TRANSFER_EVENT),
+        "0x" + "11".repeat(32),
+        "0x" + "22".repeat(32),
+      ],
+      data: "0x" + BigInt(100).toString(16).padStart(64, "0"),
+      blockNumber: "0x1",
+      transactionHash: null,
+      logIndex: null,
+    });
+
+    // Simulate Approval log
+    mock.simulateLog(handle2.subscriptionId, {
+      address: CONTRACT,
+      topics: [
+        computeEventTopic(APPROVAL_EVENT),
+        "0x" + "33".repeat(32),
+        "0x" + "44".repeat(32),
+      ],
+      data: "0x" + BigInt(500).toString(16).padStart(64, "0"),
+      blockNumber: "0x2",
+      transactionHash: null,
+      logIndex: null,
+    });
+
+    expect(transfers.length).toBe(1);
+    expect(transfers[0].event).toBe("Transfer");
+    expect(approvals.length).toBe(1);
+    expect(approvals[0].event).toBe("Approval");
+  });
+});

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

This PR adds event subscription and decoding capabilities to the OpenAgents SDK, implementing the requirements from issue #196.

### Changes

**New files:**
- `sdk/src/events/EventSubscription.ts` — Core event subscription module with:
  - `EventSubscriptionManager` class for managing subscriptions via WebSocket
  - ABI-based event log decoding (indexed params from topics, non-indexed from data)
  - Indexed parameter filtering
  - WebSocket auto-reconnect with automatic resubscription
  - Helper functions: `computeEventTopic`, `decodeEventLog`, `decodeSingleValue`, `decodeAbiData`
- `sdk/src/events/index.ts` — Module exports
- `sdk/tests/events.test.ts` — 25 unit tests
- `sdk/tsconfig.json` — TypeScript config for SDK
- `sdk/jest.config.js` — Jest config for SDK tests

**Modified files:**
- `sdk/src/index.ts` — Added `subscribeToEvents()` method and `disconnectEvents()` to `OpenAgentsSDK` class, plus re-exports of event types
- `CONTRIBUTORS.json` — Added contributor record
- `package.json` — Added `test:sdk` script

### Key features

1. **`subscribeToEvents(contractAddress, abi, eventName, callback, filter?)`** — Main SDK method
2. **ABI decoding** — Decodes event logs using the event ABI definition (topic0 matching, indexed params from topics, data params from hex)
3. **Indexed filtering** — Pass `{ from: "0x..." }` to filter by indexed event parameters at the subscription level
4. **Auto-reconnect** — Uses existing `WebSocketProvider` reconnect + resubscribes all active subscriptions on reconnect
5. **`@fix-author` headers** — Added to all new/modified files

### Tests (25 passing)

- `computeEventTopic` — correct hashing, type normalization
- `decodeSingleValue` — address, uint256, bool, bytes32
- `decodeAbiData` — multiple values, mixed types
- `decodeEventLog` — Transfer, TaskAssigned, Approval, bool params
- `EventSubscriptionManager` — subscribe, receive, emit, filter (single & multiple indexed), reconnect+resubscribe, unsubscribe, topic mismatch, address mismatch, disconnect, concurrent subscriptions

### Wallet

`0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26`