### PR TITLE
fix(sdk): add rpc timeout, typed errors, and batch gas guard

### DIFF
--- a/sdk/src/providers/rpc.ts
+++ b/sdk/src/providers/rpc.ts
@@ -1,4 +1,4 @@
-import { withRetry, RetryOptions } from "../utils/retry";
+import { RetryOptions } from "../utils/retry";
 
 export interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -19,6 +19,66 @@ export interface RpcProviderConfig {
   chainId: number;
   retryOptions?: RetryOptions;
   headers?: Record<string, string>;
+  timeoutMs?: number;
+  maxBatchGas?: bigint;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 5_000;
+const DEFAULT_MAX_BATCH_GAS = 30_000_000n;
+
+type JsonRpcErrorData = { code: number; message: string; data?: unknown };
+
+export class RpcTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`RPC request timed out after ${timeoutMs}ms`);
+    this.name = "RpcTimeoutError";
+  }
+}
+
+export class RpcHttpError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+
+  constructor(status: number, statusText: string) {
+    super(`RPC HTTP ${status}${statusText ? ` ${statusText}` : ""}`.trim());
+    this.name = "RpcHttpError";
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
+export class RpcResponseFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RpcResponseFormatError";
+  }
+}
+
+export class RpcResponseError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(error: JsonRpcErrorData) {
+    super(`RPC error ${error.code}: ${error.message}`);
+    this.name = "RpcResponseError";
+    this.code = error.code;
+    this.data = error.data;
+  }
+}
+
+export class RpcBatchGasLimitError extends Error {
+  readonly totalGas: bigint;
+  readonly maxBatchGas: bigint;
+
+  constructor(totalGas: bigint, maxBatchGas: bigint) {
+    super(`Batch gas ${totalGas.toString()} exceeds max ${maxBatchGas.toString()}`);
+    this.name = "RpcBatchGasLimitError";
+    this.totalGas = totalGas;
+    this.maxBatchGas = maxBatchGas;
+  }
 }
 
 export class RpcProvider {
@@ -26,6 +86,8 @@ export class RpcProvider {
   private chainId: number;
   private retryOptions: RetryOptions;
   private headers: Record<string, string>;
+  private timeoutMs: number;
+  private maxBatchGas: bigint;
   private requestId = 0;
 
   constructor(config: RpcProviderConfig) {
@@ -33,6 +95,8 @@ export class RpcProvider {
     this.chainId = config.chainId;
     this.retryOptions = config.retryOptions ?? {};
     this.headers = config.headers ?? {};
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxBatchGas = config.maxBatchGas ?? DEFAULT_MAX_BATCH_GAS;
   }
 
   async call(method: string, params: unknown[] = []): Promise<unknown> {
@@ -42,32 +106,14 @@ export class RpcProvider {
       method,
       params,
     };
-
-    return withRetry(async () => {
-      // BUG: No timeout — fetch can hang indefinitely if the RPC node is unresponsive
-      const res = await fetch(this.url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...this.headers },
-        body: JSON.stringify(request),
-      });
-
-      const json = await res.json();
-
-      // BUG: Error response is not type-checked — json.error could have unexpected
-      // shape and json.result is returned even when error is present
-      if (json.error) {
-        throw new Error(`RPC error ${json.error.code}: ${json.error.message}`);
-      }
-
-      return json.result;
-    }, this.retryOptions);
+    const json = await this.fetchWithRetry(request);
+    return this.parseSingleResponse(json);
   }
 
   async batchCall(
     calls: Array<{ method: string; params: unknown[] }>
   ): Promise<unknown[]> {
-    // BUG: No limit on batch size — sending thousands of calls in one batch
-    // can exceed the node's gas/payload limit and fail silently or OOM
+    this.validateBatchGas(calls);
     const requests: JsonRpcRequest[] = calls.map((c) => ({
       jsonrpc: "2.0" as const,
       id: ++this.requestId,
@@ -75,16 +121,8 @@ export class RpcProvider {
       params: c.params,
     }));
 
-    const res = await fetch(this.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...this.headers },
-      body: JSON.stringify(requests),
-    });
-
-    const responses: JsonRpcResponse[] = await res.json();
-    return responses
-      .sort((a, b) => a.id - b.id)
-      .map((r) => r.result);
+    const raw = await this.fetchWithRetry(requests);
+    return this.parseBatchResponse(raw);
   }
 
   async getBlockNumber(): Promise<number> {
@@ -99,5 +137,164 @@ export class RpcProvider {
 
   getChainId(): number {
     return this.chainId;
+  }
+
+  private async fetchWithRetry(payload: JsonRpcRequest | JsonRpcRequest[]): Promise<unknown> {
+    const maxRetries = this.retryOptions.maxRetries ?? DEFAULT_MAX_RETRIES;
+    const baseDelayMs = this.retryOptions.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+    const maxDelayMs = this.retryOptions.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.fetchJson(payload);
+      } catch (error) {
+        const typedError = error instanceof Error ? error : new Error(String(error));
+        lastError = typedError;
+        if (!this.isRetryableHttpError(typedError) || attempt === maxRetries) {
+          throw typedError;
+        }
+
+        this.retryOptions.onRetry?.(attempt + 1, typedError);
+        const delayMs = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+        await this.sleep(delayMs);
+      }
+    }
+
+    throw lastError ?? new Error("RPC request failed");
+  }
+
+  private async fetchJson(payload: JsonRpcRequest | JsonRpcRequest[]): Promise<unknown> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(this.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...this.headers },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new RpcHttpError(res.status, res.statusText);
+      }
+
+      return await res.json();
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new RpcTimeoutError(this.timeoutMs);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private parseSingleResponse(raw: unknown): unknown {
+    const response = this.assertJsonRpcResponse(raw, "single RPC response");
+    if (response.error) {
+      throw new RpcResponseError(response.error);
+    }
+    return response.result;
+  }
+
+  private parseBatchResponse(raw: unknown): unknown[] {
+    if (!Array.isArray(raw)) {
+      throw new RpcResponseFormatError("Invalid batch RPC response: expected array");
+    }
+
+    const responses = raw.map((item) => this.assertJsonRpcResponse(item, "batch RPC response"));
+    return responses
+      .sort((a, b) => a.id - b.id)
+      .map((response) => {
+        if (response.error) {
+          throw new RpcResponseError(response.error);
+        }
+        return response.result;
+      });
+  }
+
+  private assertJsonRpcResponse(raw: unknown, context: string): JsonRpcResponse {
+    if (!raw || typeof raw !== "object") {
+      throw new RpcResponseFormatError(`Invalid ${context}: expected object`);
+    }
+
+    const candidate = raw as Partial<JsonRpcResponse>;
+    if (candidate.jsonrpc !== "2.0" || typeof candidate.id !== "number") {
+      throw new RpcResponseFormatError(`Invalid ${context}: missing jsonrpc/id`);
+    }
+
+    if (candidate.error !== undefined) {
+      if (!candidate.error || typeof candidate.error !== "object") {
+        throw new RpcResponseFormatError(`Invalid ${context}: error must be object`);
+      }
+      const rpcError = candidate.error as { code?: unknown; message?: unknown; data?: unknown };
+      if (typeof rpcError.code !== "number" || typeof rpcError.message !== "string") {
+        throw new RpcResponseFormatError(`Invalid ${context}: error.code/error.message invalid`);
+      }
+    }
+
+    return candidate as JsonRpcResponse;
+  }
+
+  private validateBatchGas(calls: Array<{ method: string; params: unknown[] }>): void {
+    const totalGas = calls.reduce((sum, call) => sum + this.extractGasFromCall(call), 0n);
+    if (totalGas > this.maxBatchGas) {
+      throw new RpcBatchGasLimitError(totalGas, this.maxBatchGas);
+    }
+  }
+
+  private extractGasFromCall(call: { method: string; params: unknown[] }): bigint {
+    if (call.method !== "eth_call" && call.method !== "eth_estimateGas") {
+      return 0n;
+    }
+    if (call.params.length === 0) {
+      return 0n;
+    }
+
+    const tx = call.params[0];
+    if (!tx || typeof tx !== "object") {
+      return 0n;
+    }
+
+    const gasValue = (tx as { gas?: unknown; gasLimit?: unknown }).gas
+      ?? (tx as { gas?: unknown; gasLimit?: unknown }).gasLimit;
+    if (gasValue === undefined) {
+      return 0n;
+    }
+
+    return this.parseGasValue(gasValue);
+  }
+
+  private parseGasValue(value: unknown): bigint {
+    if (typeof value === "bigint") {
+      return value;
+    }
+    if (typeof value === "number") {
+      if (!Number.isInteger(value) || value < 0) {
+        throw new RpcResponseFormatError("Invalid batch gas value: number must be a non-negative integer");
+      }
+      return BigInt(value);
+    }
+    if (typeof value === "string") {
+      if (value.startsWith("0x") || value.startsWith("0X")) {
+        return BigInt(value);
+      }
+      if (/^\d+$/.test(value)) {
+        return BigInt(value);
+      }
+      throw new RpcResponseFormatError("Invalid batch gas value: string must be decimal or hex");
+    }
+
+    throw new RpcResponseFormatError("Invalid batch gas value type");
+  }
+
+  private isRetryableHttpError(error: Error): boolean {
+    return error instanceof RpcHttpError && (error.status === 429 || error.status === 503);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/test/RpcProvider.test.js
+++ b/test/RpcProvider.test.js
@@ -1,0 +1,120 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const ts = require("typescript");
+
+function transpileSdkProvider() {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openagents-sdk-"));
+  const outputFiles = [
+    { in: "sdk/src/utils/retry.ts", out: "utils/retry.js" },
+    { in: "sdk/src/providers/rpc.ts", out: "providers/rpc.js" },
+  ];
+
+  for (const entry of outputFiles) {
+    const source = fs.readFileSync(path.join(__dirname, "..", entry.in), "utf8");
+    const transpiled = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: entry.in,
+    });
+
+    const outPath = path.join(tmpRoot, entry.out);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, transpiled.outputText, "utf8");
+  }
+
+  return require(path.join(tmpRoot, "providers/rpc.js"));
+}
+
+describe("RpcProvider", function () {
+  let RpcProvider;
+  let RpcBatchGasLimitError;
+  let originalFetch;
+
+  before(function () {
+    ({ RpcProvider, RpcBatchGasLimitError } = transpileSdkProvider());
+  });
+
+  beforeEach(function () {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(function () {
+    global.fetch = originalFetch;
+  });
+
+  it("aborts requests that exceed timeout", async function () {
+    global.fetch = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+
+    const provider = new RpcProvider({
+      url: "http://127.0.0.1:8545",
+      chainId: 1,
+      timeoutMs: 20,
+      retryOptions: { maxRetries: 0 },
+    });
+
+    await assert.rejects(
+      () => provider.call("eth_chainId"),
+      /timed out/i
+    );
+  });
+
+  it("rejects batch requests that exceed configured gas budget", async function () {
+    let called = false;
+    global.fetch = async () => {
+      called = true;
+      return new Response("[]", { status: 200 });
+    };
+
+    const provider = new RpcProvider({
+      url: "http://127.0.0.1:8545",
+      chainId: 1,
+      maxBatchGas: 100n,
+      retryOptions: { maxRetries: 0 },
+    });
+
+    await assert.rejects(
+      () => provider.batchCall([
+        { method: "eth_call", params: [{ gas: "0x40" }] },
+        { method: "eth_call", params: [{ gasLimit: "0x50" }] },
+      ]),
+      RpcBatchGasLimitError
+    );
+
+    assert.equal(called, false);
+  });
+
+  it("retries on 429 and eventually succeeds", async function () {
+    let attempts = 0;
+    global.fetch = async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        return new Response("rate limited", { status: 429, statusText: "Too Many Requests" });
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x2a" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+
+    const provider = new RpcProvider({
+      url: "http://127.0.0.1:8545",
+      chainId: 1,
+      retryOptions: { maxRetries: 3, baseDelayMs: 1, maxDelayMs: 2 },
+    });
+
+    const result = await provider.call("eth_chainId");
+    assert.equal(result, "0x2a");
+    assert.equal(attempts, 3);
+  });
+});


### PR DESCRIPTION
/claim #38

## Summary
- add AbortController timeout support (default 30s) for RPC requests
- add typed RPC errors (timeout/http/response format/json-rpc error/batch gas limit)
- enforce batch eth_call/eth_estimateGas gas budget check before sending
- retry only HTTP 429/503 with exponential backoff

## Tests
- npx mocha test/RpcProvider.test.js