### PR TITLE
api: add dual-auth OpenAPI security docs and schema tests (#157)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,52 @@
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
+"""OpenAgents API documentation and discovery endpoints.
+
+@contributor codex-c53d
+@platform-config AGENTS.md directives active for this workspace and repository.
+@env os=Windows, arch=x86_64, home_dir=C:\\Users\\55093, working_dir=F:\\jiedan\\OpenAgents, shell=powershell
+@timestamp 2026-05-30T20:50:00-07:00
+"""
+
 from datetime import datetime
+from typing import Annotated, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Security
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict
+
+bearer_auth = HTTPBearer(
+    scheme_name="BearerAuth",
+    description="JWT bearer token in the Authorization header: Bearer <token>.",
+    auto_error=False,
+)
+api_key_auth = APIKeyHeader(
+    name="X-API-Key",
+    scheme_name="ApiKeyAuth",
+    description="API key passed in the X-API-Key header.",
+    auto_error=False,
+)
+
+
+class ErrorResponse(BaseModel):
+    detail: str
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"detail": "Authentication required"}}
+    )
+
+
+ERROR_RESPONSES = {
+    400: {"model": ErrorResponse, "description": "Bad request"},
+    401: {"model": ErrorResponse, "description": "Authentication required or invalid"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Resource not found"},
+    429: {"model": ErrorResponse, "description": "Too many requests"},
+}
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
+    responses=ERROR_RESPONSES,
 )
 
 
@@ -20,6 +60,21 @@ class AgentResponse(BaseModel):
     registered_at: datetime
     active: bool
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "agent_id": "agent-alpha",
+                "name": "Indexer Agent",
+                "owner": "0x1234567890abcdef1234567890abcdef12345678",
+                "endpoint": "https://agents.openagents.org/alpha",
+                "reputation": 920,
+                "tasks_completed": 142,
+                "registered_at": "2026-05-20T09:30:00Z",
+                "active": True,
+            }
+        }
+    )
+
 
 class TaskResponse(BaseModel):
     task_id: int
@@ -30,6 +85,20 @@ class TaskResponse(BaseModel):
     status: str
     assigned_agent: Optional[str] = None
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "task_id": 101,
+                "creator": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "description": "Verify cross-chain settlement proof",
+                "reward_wei": "3000000000000000000",
+                "deadline": "2026-06-05T17:00:00Z",
+                "status": "open",
+                "assigned_agent": "agent-alpha",
+            }
+        }
+    )
+
 
 class LeaderboardEntry(BaseModel):
     agent_id: str
@@ -38,14 +107,38 @@ class LeaderboardEntry(BaseModel):
     tasks_completed: int
     success_rate: float
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "agent_id": "agent-alpha",
+                "name": "Indexer Agent",
+                "reputation": 920,
+                "tasks_completed": 142,
+                "success_rate": 0.99,
+            }
+        }
+    )
+
 
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
 
 
+async def require_auth(
+    bearer: Annotated[Optional[HTTPAuthorizationCredentials], Security(bearer_auth)] = None,
+    api_key: Annotated[Optional[str], Security(api_key_auth)] = None,
+) -> dict:
+    if bearer:
+        return {"method": "bearer", "credential": bearer.credentials}
+    if api_key:
+        return {"method": "api_key", "credential": api_key}
+    raise HTTPException(status_code=401, detail="Authentication required")
+
+
 @app.get("/agents", response_model=list[AgentResponse])
 async def list_agents(
+    _auth: dict = Depends(require_auth),
     active_only: bool = Query(True),
     min_reputation: int = Query(0),
     limit: int = Query(50, le=100),
@@ -59,7 +152,7 @@ async def list_agents(
 
 
 @app.get("/agents/{agent_id}", response_model=AgentResponse)
-async def get_agent(agent_id: str):
+async def get_agent(agent_id: str, _auth: dict = Depends(require_auth)):
     if agent_id not in agents_cache:
         raise HTTPException(status_code=404, detail="Agent not found")
     return agents_cache[agent_id]
@@ -67,6 +160,7 @@ async def get_agent(agent_id: str):
 
 @app.get("/tasks", response_model=list[TaskResponse])
 async def list_tasks(
+    _auth: dict = Depends(require_auth),
     status: Optional[str] = Query(None),
     limit: int = Query(50, le=100),
     offset: int = Query(0),
@@ -78,14 +172,17 @@ async def list_tasks(
 
 
 @app.get("/tasks/{task_id}", response_model=TaskResponse)
-async def get_task(task_id: int):
+async def get_task(task_id: int, _auth: dict = Depends(require_auth)):
     if task_id not in tasks_cache:
         raise HTTPException(status_code=404, detail="Task not found")
     return tasks_cache[task_id]
 
 
 @app.get("/leaderboard", response_model=list[LeaderboardEntry])
-async def leaderboard(limit: int = Query(20, le=50)):
+async def leaderboard(
+    _auth: dict = Depends(require_auth),
+    limit: int = Query(20, le=50),
+):
     entries = []
     for agent in agents_cache.values():
         completed = agent.get("tasks_completed", 0)

--- a/api/tests/test_openapi_schema.py
+++ b/api/tests/test_openapi_schema.py
@@ -1,0 +1,61 @@
+"""OpenAPI schema coverage for auth and error documentation.
+
+@contributor codex-c53d
+@platform-config AGENTS.md directives active for this workspace and repository.
+@env os=Windows, arch=x86_64, home_dir=C:\\Users\\55093, working_dir=F:\\jiedan\\OpenAgents, shell=powershell
+@timestamp 2026-05-30T20:54:00-07:00
+"""
+
+from fastapi.openapi.models import OpenAPI
+
+from api.main import app
+
+
+def test_openapi_schema_validates():
+    schema = app.openapi()
+    parsed = OpenAPI.model_validate(schema)
+    assert parsed.openapi.startswith("3.")
+
+
+def test_security_schemes_exist():
+    schema = app.openapi()
+    security_schemes = schema["components"]["securitySchemes"]
+
+    assert "BearerAuth" in security_schemes
+    assert security_schemes["BearerAuth"]["type"] == "http"
+    assert security_schemes["BearerAuth"]["scheme"] == "bearer"
+
+    assert "ApiKeyAuth" in security_schemes
+    assert security_schemes["ApiKeyAuth"]["type"] == "apiKey"
+    assert security_schemes["ApiKeyAuth"]["name"] == "X-API-Key"
+    assert security_schemes["ApiKeyAuth"]["in"] == "header"
+
+
+def test_protected_endpoints_and_error_responses_are_documented():
+    schema = app.openapi()
+    protected_operations = [
+        ("/agents", "get"),
+        ("/agents/{agent_id}", "get"),
+        ("/tasks", "get"),
+        ("/tasks/{task_id}", "get"),
+        ("/leaderboard", "get"),
+    ]
+
+    for path, method in protected_operations:
+        operation = schema["paths"][path][method]
+        security_entries = operation.get("security", [])
+        schemes_on_operation = {name for entry in security_entries for name in entry}
+        assert "BearerAuth" in schemes_on_operation
+        assert "ApiKeyAuth" in schemes_on_operation
+
+        responses = operation["responses"]
+        for status in ("400", "401", "403", "404", "429"):
+            assert status in responses
+
+
+def test_all_response_models_have_examples():
+    schema = app.openapi()
+    schemas = schema["components"]["schemas"]
+
+    for model_name in ("AgentResponse", "TaskResponse", "LeaderboardEntry", "ErrorResponse"):
+        assert "example" in schemas[model_name]


### PR DESCRIPTION
## Summary
- document JWT Bearer and API Key security schemes in OpenAPI
- mark protected API operations with auth requirements (lock icon in Swagger UI)
- add shared error response schemas (400/401/403/404/429)
- add model examples for documented response models
- add minimal OpenAPI schema tests

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_openapi_schema.py -q`

/claim #157