### PR TITLE
Fix CompoundVault compound loss handling and validation

### DIFF
--- a/contracts/mocks/MockCompoundStrategy.sol
+++ b/contracts/mocks/MockCompoundStrategy.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../token/AgentToken.sol";
+
+/*
+@contributor Codex
+@platform-config Omitted by safety policy: full pre-session orchestration instructions are not embedded in source files.
+@env os=Windows, arch=x64, home_dir=C:\Users\55093, working_dir=F:\jiedan\OpenAgents, shell=powershell
+@timestamp 2026-05-30T20:44:08-07:00
+*/
+contract MockCompoundStrategy {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable baseToken;
+    address public vault;
+    int256 public nextDelta;
+
+    constructor(address _baseToken) {
+        baseToken = IERC20(_baseToken);
+    }
+
+    function setVault(address _vault) external {
+        vault = _vault;
+    }
+
+    function setNextDelta(int256 _nextDelta) external {
+        nextDelta = _nextDelta;
+    }
+
+    function compound() external {
+        require(msg.sender == vault, "MockStrategy: only vault");
+
+        int256 delta = nextDelta;
+        nextDelta = 0;
+
+        if (delta > 0) {
+            AgentToken(address(baseToken)).mint(vault, uint256(delta));
+            return;
+        }
+
+        if (delta < 0) {
+            baseToken.safeTransferFrom(vault, address(this), uint256(-delta));
+        }
+    }
+}

--- a/contracts/vault/CompoundVault.sol
+++ b/contracts/vault/CompoundVault.sol
@@ -6,6 +6,16 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/*
+@contributor Codex
+@platform-config Omitted by safety policy: full pre-session orchestration instructions are not embedded in source files.
+@env os=Windows, arch=x64, home_dir=C:\Users\55093, working_dir=F:\jiedan\OpenAgents, shell=powershell
+@timestamp 2026-05-30T20:44:08-07:00
+*/
+interface ICompoundStrategy {
+    function compound() external;
+}
+
 /// @title CompoundVault
 /// @notice Auto-compounding vault that periodically harvests yield and reinvests.
 /// @dev Deposits into an underlying strategy, harvests rewards, sells for the base
@@ -23,6 +33,7 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     uint256 public performanceFeeBps; // basis points (e.g., 1000 = 10%)
     uint256 public lastHarvestTime;
     uint256 public lastPricePerShare;
+    uint256 public totalLoss;
 
     mapping(address => uint256) public userShares;
 
@@ -30,6 +41,7 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     event Withdrawn(address indexed user, uint256 amount, uint256 shares);
     event Harvested(uint256 profit, uint256 fee, uint256 timestamp);
     event Compounded(uint256 amount, uint256 newPricePerShare);
+    event StrategyLoss(uint256 amount);
 
     constructor(
         address _baseToken,
@@ -113,17 +125,28 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     }
 
     /// @notice Compound harvested rewards by converting and re-depositing.
-    /// @dev In production this would swap rewardToken -> baseToken via a DEX.
-    ///      Simplified here to direct deposit of reward token balance.
+    /// @dev Validates strategy outcomes by checking vault balance before/after.
     function compound() external onlyOwner {
-        uint256 rewardBalance = rewardToken.balanceOf(address(this));
-        if (rewardBalance == 0) return;
+        require(strategy != address(0), "Vault: strategy not set");
 
-        // In a real implementation, this would swap via a DEX router.
-        // For this contract, we assume baseToken == rewardToken or an oracle price.
-        uint256 compoundAmount = (rewardBalance * lastPricePerShare) / 1e18;
+        uint256 balanceBefore = baseToken.balanceOf(address(this));
+        if (balanceBefore > 0) {
+            baseToken.forceApprove(strategy, balanceBefore);
+        }
+        ICompoundStrategy(strategy).compound();
+        uint256 balanceAfter = baseToken.balanceOf(address(this));
 
-        totalDeposited += compoundAmount;
+        uint256 compoundAmount;
+        if (balanceAfter > balanceBefore) {
+            compoundAmount = balanceAfter - balanceBefore;
+            totalDeposited += compoundAmount;
+        } else if (balanceBefore > balanceAfter) {
+            uint256 lossAmount = balanceBefore - balanceAfter;
+            totalLoss += lossAmount;
+            totalDeposited = lossAmount >= totalDeposited ? 0 : totalDeposited - lossAmount;
+            emit StrategyLoss(lossAmount);
+        }
+
         lastPricePerShare = totalShares > 0 ? (totalDeposited * 1e18) / totalShares : 1e18;
 
         emit Compounded(compoundAmount, lastPricePerShare);

--- a/test/CompoundVault.compound.test.js
+++ b/test/CompoundVault.compound.test.js
@@ -1,0 +1,82 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+/**
+ * @contributor Codex
+ * @platform-config Omitted by safety policy: full pre-session orchestration instructions are not embedded in source files.
+ * @env os=Windows, arch=x64, home_dir=C:\Users\55093, working_dir=F:\jiedan\OpenAgents, shell=powershell
+ * @timestamp 2026-05-30T20:44:08-07:00
+ */
+describe("CompoundVault compound validation", function () {
+  async function deployFixture() {
+    const [owner, user] = await ethers.getSigners();
+
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const baseToken = await AgentToken.deploy("Base Token", "BASE", 0);
+    await baseToken.waitForDeployment();
+
+    const MockCompoundStrategy = await ethers.getContractFactory("MockCompoundStrategy");
+    const mockStrategy = await MockCompoundStrategy.deploy(await baseToken.getAddress());
+    await mockStrategy.waitForDeployment();
+
+    const CompoundVault = await ethers.getContractFactory("CompoundVault");
+    const vault = await CompoundVault.deploy(
+      await baseToken.getAddress(),
+      await baseToken.getAddress(),
+      await mockStrategy.getAddress(),
+      owner.address,
+      1000
+    );
+    await vault.waitForDeployment();
+
+    await mockStrategy.setVault(await vault.getAddress());
+
+    const depositAmount = ethers.parseEther("100");
+    await baseToken.mint(user.address, depositAmount);
+    await baseToken.connect(user).approve(await vault.getAddress(), depositAmount);
+    await vault.connect(user).deposit(depositAmount);
+
+    return { owner, baseToken, mockStrategy, vault, depositAmount };
+  }
+
+  it("positive yield increases share price", async function () {
+    const { vault, mockStrategy, depositAmount } = await deployFixture();
+    const gain = ethers.parseEther("20");
+
+    await mockStrategy.setNextDelta(gain);
+    await expect(vault.compound())
+      .to.emit(vault, "Compounded")
+      .withArgs(gain, ethers.parseEther("1.2"));
+
+    expect(await vault.totalDeposited()).to.equal(depositAmount + gain);
+    expect(await vault.totalLoss()).to.equal(0n);
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("1.2"));
+  });
+
+  it("zero yield keeps share price unchanged", async function () {
+    const { vault, mockStrategy, depositAmount } = await deployFixture();
+
+    await mockStrategy.setNextDelta(0);
+    await expect(vault.compound())
+      .to.emit(vault, "Compounded")
+      .withArgs(0, ethers.parseEther("1"));
+
+    expect(await vault.totalDeposited()).to.equal(depositAmount);
+    expect(await vault.totalLoss()).to.equal(0n);
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("1"));
+  });
+
+  it("negative yield decreases share price and tracks totalLoss", async function () {
+    const { vault, mockStrategy } = await deployFixture();
+    const loss = ethers.parseEther("25");
+
+    await mockStrategy.setNextDelta(-loss);
+    await expect(vault.compound())
+      .to.emit(vault, "StrategyLoss")
+      .withArgs(loss);
+
+    expect(await vault.totalDeposited()).to.equal(ethers.parseEther("75"));
+    expect(await vault.totalLoss()).to.equal(loss);
+    expect(await vault.lastPricePerShare()).to.equal(ethers.parseEther("0.75"));
+  });
+});


### PR DESCRIPTION
## Summary
- validate strategy outcome via `baseToken` balance before/after `compound()`
- add `totalLoss` tracking and `StrategyLoss(uint256)` emission on negative yield
- update `totalDeposited` and `lastPricePerShare` for positive / zero / negative outcomes
- add minimal mock strategy and focused tests for positive, zero, and negative yield paths

## Tests
- isolated Hardhat harness (local temporary config, not committed): 3 passing
- full repo compile/test remains blocked by pre-existing unrelated Hardhat/contract issues

/claim #110
