### PR TITLE
[codex] Harden API model IDs with UUID public identifiers

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -1,4 +1,10 @@
-"""SQLAlchemy models and database session management."""
+"""SQLAlchemy models and database session management.
+
+@contributor codex-gpt5
+@platform Codex Desktop session bootstrap (platform-managed initialization context)
+@runtime Windows 11 x64, cwd=F:/jiedan/OpenAgents
+@date 2026-05-31T03:41:14Z
+"""
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
@@ -7,6 +13,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
 from datetime import datetime
+from uuid import uuid4
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
@@ -27,7 +34,8 @@ def get_db():
 class User(Base):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    uuid = Column(String(36), unique=True, nullable=False, default=lambda: str(uuid4()), index=True)
     address = Column(String(42), unique=True, nullable=False)
     username = Column(String(64), unique=True, nullable=True)
     # BUG: No index on address — wallet lookups on every auth request do full table scans
@@ -39,7 +47,8 @@ class User(Base):
 class Agent(Base):
     __tablename__ = "agents"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    uuid = Column(String(36), unique=True, nullable=False, default=lambda: str(uuid4()), index=True)
     name = Column(String(128), nullable=False)
     description = Column(Text, nullable=True)
     model_type = Column(String(32), default="gpt-4")
@@ -55,7 +64,8 @@ class Agent(Base):
 class Task(Base):
     __tablename__ = "tasks"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    uuid = Column(String(36), unique=True, nullable=False, default=lambda: str(uuid4()), index=True)
     title = Column(String(256), nullable=False)
     description = Column(Text, nullable=True)
     reward_amount = Column(Float, nullable=False)
@@ -73,7 +83,8 @@ class Task(Base):
 class Payment(Base):
     __tablename__ = "payments"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    uuid = Column(String(36), unique=True, nullable=False, default=lambda: str(uuid4()), index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
     from_address = Column(String(42), nullable=False)
     to_address = Column(String(42), nullable=True)

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,14 +1,32 @@
-"""Agent CRUD endpoints for the OpenAgents platform."""
+"""Agent CRUD endpoints for the OpenAgents platform.
+
+@contributor codex-gpt5
+@platform Codex Desktop session bootstrap (platform-managed initialization context)
+@runtime Windows 11 x64, cwd=F:/jiedan/OpenAgents
+@date 2026-05-31T03:41:14Z
+"""
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
-from ..models.database import get_db, Agent
+from ..models.database import get_db, Agent, User
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+def _serialize_agent(agent: Agent) -> dict:
+    return {
+        "id": agent.uuid,
+        "name": agent.name,
+        "description": agent.description,
+        "model_type": agent.model_type,
+        "config": agent.config,
+        "owner": agent.owner.uuid if agent.owner else None,
+        "created_at": agent.created_at,
+    }
 
 
 class AgentCreate(BaseModel):
@@ -37,7 +55,7 @@ async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=De
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {"id": new_agent.uuid, "name": new_agent.name, "owner": user["address"]}
 
 
 @router.get("/")
@@ -49,24 +67,24 @@ async def list_agents(
 ):
     query = db.query(Agent)
     if owner:
-        # BUG: String interpolation in query — vulnerable to SQL injection
-        query = query.filter(Agent.owner_id == owner)
-    return query.offset(skip).limit(limit).all()
+        query = query.join(User, Agent.owner_id == User.id).filter(User.uuid == owner)
+    agents = query.offset(skip).limit(limit).all()
+    return [_serialize_agent(agent) for agent in agents]
 
 
 @router.get("/{agent_id}")
-async def get_agent(agent_id: int, db=Depends(get_db)):
-    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+async def get_agent(agent_id: str, db=Depends(get_db)):
+    agent = db.query(Agent).filter(Agent.uuid == agent_id).first()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    return agent
+    return _serialize_agent(agent)
 
 
 @router.put("/{agent_id}")
 async def update_agent(
-    agent_id: int, update: AgentUpdate, user=Depends(get_current_user), db=Depends(get_db)
+    agent_id: str, update: AgentUpdate, user=Depends(get_current_user), db=Depends(get_db)
 ):
-    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    agent = db.query(Agent).filter(Agent.uuid == agent_id).first()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.owner_id != user["id"]:
@@ -74,15 +92,17 @@ async def update_agent(
     for field, value in update.dict(exclude_unset=True).items():
         setattr(agent, field, value)
     db.commit()
-    return agent
+    db.refresh(agent)
+    return _serialize_agent(agent)
 
 
 # BUG: No authentication — anyone can delete any agent
 @router.delete("/{agent_id}")
-async def delete_agent(agent_id: int, db=Depends(get_db)):
-    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+async def delete_agent(agent_id: str, db=Depends(get_db)):
+    agent = db.query(Agent).filter(Agent.uuid == agent_id).first()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    deleted_uuid = agent.uuid
     db.delete(agent)
     db.commit()
-    return {"deleted": True}
+    return {"deleted": True, "id": deleted_uuid}

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,4 +1,10 @@
-"""Payment and escrow endpoints for bounty payouts."""
+"""Payment and escrow endpoints for bounty payouts.
+
+@contributor codex-gpt5
+@platform Codex Desktop session bootstrap (platform-managed initialization context)
+@runtime Windows 11 x64, cwd=F:/jiedan/OpenAgents
+@date 2026-05-31T03:41:14Z
+"""
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -12,7 +18,7 @@ router = APIRouter(prefix="/payments", tags=["payments"])
 
 
 class EscrowDeposit(BaseModel):
-    task_id: int
+    task_id: str
     # BUG: Amount is not validated as positive — negative or zero deposits
     # could corrupt escrow balances or drain funds
     amount: float
@@ -20,7 +26,7 @@ class EscrowDeposit(BaseModel):
 
 
 class ClaimRequest(BaseModel):
-    task_id: int
+    task_id: str
     recipient_address: str
 
 
@@ -28,7 +34,7 @@ class ClaimRequest(BaseModel):
 async def deposit_escrow(
     deposit: EscrowDeposit, user=Depends(get_current_user), db=Depends(get_db)
 ):
-    task = db.query(Task).filter(Task.id == deposit.task_id).first()
+    task = db.query(Task).filter(Task.uuid == deposit.task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     if task.creator_id != user["id"]:
@@ -47,13 +53,17 @@ async def deposit_escrow(
     db.add(payment)
     db.commit()
     db.refresh(payment)
-    return {"payment_id": payment.id, "status": "escrowed", "amount": payment.amount}
+    return {"payment_id": payment.uuid, "status": "escrowed", "amount": payment.amount}
 
 
 @router.get("/escrow/{task_id}")
-async def get_escrow_balance(task_id: int, db=Depends(get_db)):
+async def get_escrow_balance(task_id: str, db=Depends(get_db)):
+    task = db.query(Task).filter(Task.uuid == task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
     payments = db.query(Payment).filter(
-        Payment.task_id == task_id, Payment.status == "escrowed"
+        Payment.task_id == task.id, Payment.status == "escrowed"
     ).all()
     total = sum(p.amount for p in payments)
     return {"task_id": task_id, "escrowed_total": total, "deposits": len(payments)}
@@ -63,7 +73,7 @@ async def get_escrow_balance(task_id: int, db=Depends(get_db)):
 async def claim_payment(
     claim: ClaimRequest, user=Depends(get_current_user), db=Depends(get_db)
 ):
-    task = db.query(Task).filter(Task.id == claim.task_id).first()
+    task = db.query(Task).filter(Task.uuid == claim.task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     if task.status != "completed":
@@ -72,7 +82,7 @@ async def claim_payment(
     # BUG: Race condition — two concurrent claims can both read status="escrowed"
     # before either updates it, causing a double-payout
     payments = db.query(Payment).filter(
-        Payment.task_id == claim.task_id, Payment.status == "escrowed"
+        Payment.task_id == task.id, Payment.status == "escrowed"
     ).all()
 
     if not payments:
@@ -101,6 +111,6 @@ async def payment_history(
     sent = db.query(Payment).filter(Payment.from_address == user["address"]).all()
     received = db.query(Payment).filter(Payment.to_address == user["address"]).all()
     return {
-        "sent": [{"id": p.id, "amount": p.amount, "status": p.status} for p in sent],
-        "received": [{"id": p.id, "amount": p.amount, "status": p.status} for p in received],
+        "sent": [{"id": p.uuid, "amount": p.amount, "status": p.status} for p in sent],
+        "received": [{"id": p.uuid, "amount": p.amount, "status": p.status} for p in received],
     }

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,11 +1,17 @@
-"""Task management endpoints for bounty assignments."""
+"""Task management endpoints for bounty assignments.
+
+@contributor codex-gpt5
+@platform Codex Desktop session bootstrap (platform-managed initialization context)
+@runtime Windows 11 x64, cwd=F:/jiedan/OpenAgents
+@date 2026-05-31T03:41:14Z
+"""
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
-from ..models.database import get_db, Task
+from ..models.database import get_db, Task, User, Agent
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
@@ -13,11 +19,25 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
 VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled"}
 
 
+def _serialize_task(task: Task) -> dict:
+    return {
+        "id": task.uuid,
+        "title": task.title,
+        "description": task.description,
+        "reward_amount": task.reward_amount,
+        "status": task.status,
+        "agent_id": task.agent.uuid if task.agent else None,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+        "deadline": task.deadline,
+    }
+
+
 class TaskCreate(BaseModel):
     title: str
     description: str
     reward_amount: float
-    agent_id: Optional[int] = None
+    agent_id: Optional[str] = None
     deadline: Optional[datetime] = None
 
 
@@ -27,12 +47,19 @@ class TaskStatusUpdate(BaseModel):
 
 @router.post("/")
 async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    agent_internal_id = None
+    if task.agent_id:
+        agent = db.query(Agent).filter(Agent.uuid == task.agent_id).first()
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        agent_internal_id = agent.id
+
     new_task = Task(
         title=task.title,
         description=task.description,
         reward_amount=task.reward_amount,
         creator_id=user["id"],
-        agent_id=task.agent_id,
+        agent_id=agent_internal_id,
         status="open",
         created_at=datetime.utcnow(),
         deadline=task.deadline,
@@ -40,7 +67,7 @@ async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depen
     db.add(new_task)
     db.commit()
     db.refresh(new_task)
-    return {"id": new_task.id, "status": new_task.status}
+    return {"id": new_task.uuid, "status": new_task.status}
 
 
 @router.get("/")
@@ -57,26 +84,27 @@ async def list_tasks(
     if status:
         query = query.filter(Task.status == status)
     if creator:
-        query = query.filter(Task.creator_id == creator)
-    return query.order_by(Task.created_at.desc()).offset(skip).limit(limit).all()
+        query = query.join(User, Task.creator_id == User.id).filter(User.uuid == creator)
+    tasks = query.order_by(Task.created_at.desc()).offset(skip).limit(limit).all()
+    return [_serialize_task(task) for task in tasks]
 
 
 @router.get("/{task_id}")
-async def get_task(task_id: int, db=Depends(get_db)):
-    task = db.query(Task).filter(Task.id == task_id).first()
+async def get_task(task_id: str, db=Depends(get_db)):
+    task = db.query(Task).filter(Task.uuid == task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
-    return task
+    return _serialize_task(task)
 
 
 @router.patch("/{task_id}/status")
 async def update_task_status(
-    task_id: int,
+    task_id: str,
     update: TaskStatusUpdate,
     user=Depends(get_current_user),
     db=Depends(get_db),
 ):
-    task = db.query(Task).filter(Task.id == task_id).first()
+    task = db.query(Task).filter(Task.uuid == task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
@@ -88,12 +116,13 @@ async def update_task_status(
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
-    return {"id": task.id, "status": task.status}
+    db.refresh(task)
+    return {"id": task.uuid, "status": task.status}
 
 
 @router.delete("/{task_id}")
-async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(get_db)):
-    task = db.query(Task).filter(Task.id == task_id).first()
+async def cancel_task(task_id: str, user=Depends(get_current_user), db=Depends(get_db)):
+    task = db.query(Task).filter(Task.uuid == task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     if task.creator_id != user["id"]:
@@ -102,4 +131,4 @@ async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(g
         raise HTTPException(status_code=400, detail="Cannot cancel an active task")
     task.status = "cancelled"
     db.commit()
-    return {"id": task.id, "status": "cancelled"}
+    return {"id": task.uuid, "status": "cancelled"}

--- a/api/tests/test_uuid_public_ids.py
+++ b/api/tests/test_uuid_public_ids.py
@@ -1,0 +1,139 @@
+"""UUID public ID regression tests.
+
+@contributor codex-gpt5
+@platform Codex Desktop session bootstrap (platform-managed initialization context)
+@runtime Windows 11 x64, cwd=F:/jiedan/OpenAgents
+@date 2026-05-31T03:41:14Z
+"""
+
+import os
+import tempfile
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models import database as db_models
+from api.models.database import User, Agent, Task, Payment
+from api.routes.agents import router as agents_router
+from api.routes.tasks import router as tasks_router
+from api.routes.payments import router as payments_router
+
+
+def _assert_uuid4(value: str) -> None:
+    parsed = UUID(value)
+    assert parsed.version == 4
+
+
+@pytest.fixture()
+def test_db():
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db_models.Base.metadata.create_all(bind=engine)
+
+    try:
+        yield session_local
+    finally:
+        db_models.Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+        os.remove(db_path)
+
+
+@pytest.fixture()
+def client(test_db):
+    app = FastAPI()
+    app.include_router(agents_router)
+    app.include_router(tasks_router)
+    app.include_router(payments_router)
+
+    def override_get_db():
+        db = test_db()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[db_models.get_db] = override_get_db
+    return TestClient(app)
+
+
+def _seed_records(test_db):
+    db = test_db()
+    try:
+        user = User(address="0x1111111111111111111111111111111111111111", username="u1")
+        db.add(user)
+        db.flush()
+
+        agent = Agent(name="agent-1", owner_id=user.id)
+        db.add(agent)
+        db.flush()
+
+        task = Task(
+            title="task-1",
+            description="desc",
+            reward_amount=1.5,
+            creator_id=user.id,
+            agent_id=agent.id,
+            status="open",
+        )
+        db.add(task)
+        db.flush()
+
+        payment = Payment(
+            task_id=task.id,
+            from_address=user.address,
+            amount=2.5,
+            status="escrowed",
+        )
+        db.add(payment)
+        db.commit()
+        db.refresh(user)
+        db.refresh(agent)
+        db.refresh(task)
+        db.refresh(payment)
+        return user, agent, task, payment
+    finally:
+        db.close()
+
+
+def test_models_generate_uuid_v4(test_db):
+    user, agent, task, payment = _seed_records(test_db)
+    _assert_uuid4(user.uuid)
+    _assert_uuid4(agent.uuid)
+    _assert_uuid4(task.uuid)
+    _assert_uuid4(payment.uuid)
+
+
+def test_api_returns_public_uuid_and_no_internal_integer_ids(client, test_db):
+    _, agent, task, _ = _seed_records(test_db)
+
+    agent_resp = client.get(f"/agents/{agent.uuid}")
+    assert agent_resp.status_code == 200
+    agent_data = agent_resp.json()
+    assert agent_data["id"] == agent.uuid
+    _assert_uuid4(agent_data["id"])
+    assert "owner_id" not in agent_data
+
+    task_resp = client.get(f"/tasks/{task.uuid}")
+    assert task_resp.status_code == 200
+    task_data = task_resp.json()
+    assert task_data["id"] == task.uuid
+    _assert_uuid4(task_data["id"])
+    assert "creator_id" not in task_data
+
+
+def test_payment_escrow_uses_task_uuid_in_response(client, test_db):
+    _, _, task, _ = _seed_records(test_db)
+
+    escrow_resp = client.get(f"/payments/escrow/{task.uuid}")
+    assert escrow_resp.status_code == 200
+    payload = escrow_resp.json()
+    assert payload["task_id"] == task.uuid
+    _assert_uuid4(payload["task_id"])


### PR DESCRIPTION
## Summary\n- add UUID v4 public identifiers to User/Agent/Task/Payment models while retaining internal integer PKs for joins\n- switch agent/task/payment route lookups and response IDs to UUID-based public identifiers\n- add regression tests verifying UUID v4 generation and absence of internal integer ID leaks in API responses\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_uuid_public_ids.py -q\n\n/claim #122