### PR TITLE
Fix #139: validate agent endpoint URL format and reachability

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -42,6 +42,7 @@ class Agent(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(128), nullable=False)
     description = Column(Text, nullable=True)
+    endpoint = Column(String(512), nullable=False)
     model_type = Column(String(32), default="gpt-4")
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,18 +1,25 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
+import ipaddress
+import socket
+from datetime import datetime
+from typing import Optional, Union
+from urllib.parse import urlparse
+
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+ENDPOINT_TIMEOUT_SECONDS = 5.0
 
 
 class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    endpoint: str
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
@@ -24,10 +31,81 @@ class AgentUpdate(BaseModel):
     config: Optional[dict] = None
 
 
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _is_private_or_internal_ip(ip: IPAddress) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _validate_public_endpoint_host(hostname: str) -> None:
+    if hostname.lower() == "localhost":
+        raise HTTPException(status_code=400, detail="Endpoint URL cannot use localhost")
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+        except socket.gaierror as exc:
+            raise HTTPException(status_code=400, detail="Endpoint host could not be resolved") from exc
+
+        for _, _, _, _, sockaddr in resolved:
+            resolved_ip = ipaddress.ip_address(sockaddr[0])
+            if _is_private_or_internal_ip(resolved_ip):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Endpoint URL resolves to private/internal IP: {resolved_ip}",
+                )
+        return
+
+    if _is_private_or_internal_ip(ip):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Endpoint URL cannot use private/internal IP: {ip}",
+        )
+
+
+async def _validate_endpoint_url(endpoint: str) -> str:
+    candidate = endpoint.strip()
+    parsed = urlparse(candidate)
+
+    if parsed.scheme not in {"http", "https"}:
+        raise HTTPException(status_code=400, detail="Endpoint URL must use http or https")
+    if not parsed.netloc or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="Endpoint URL must include a host")
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="Endpoint URL cannot contain credentials")
+
+    _validate_public_endpoint_host(parsed.hostname)
+
+    try:
+        async with httpx.AsyncClient(timeout=ENDPOINT_TIMEOUT_SECONDS, follow_redirects=True) as client:
+            await client.head(candidate)
+    except httpx.TimeoutException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Endpoint URL timed out after {int(ENDPOINT_TIMEOUT_SECONDS)}s",
+        ) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=400, detail=f"Endpoint URL is unreachable: {exc}") from exc
+
+    return candidate
+
+
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    validated_endpoint = await _validate_endpoint_url(agent.endpoint)
     new_agent = Agent(
         name=agent.name,
+        endpoint=validated_endpoint,
         description=agent.description,
         model_type=agent.model_type,
         config=agent.config or {},
@@ -37,7 +115,12 @@ async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=De
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {
+        "id": new_agent.id,
+        "name": new_agent.name,
+        "endpoint": new_agent.endpoint,
+        "owner": user["address"],
+    }
 
 
 @router.get("/")

--- a/api/tests/test_agent_endpoint_validation.py
+++ b/api/tests/test_agent_endpoint_validation.py
@@ -1,0 +1,109 @@
+import asyncio
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from api.routes import agents as agents_route
+
+
+def _run_validate(endpoint: str) -> str:
+    return asyncio.run(agents_route._validate_endpoint_url(endpoint))
+
+
+def test_valid_url_is_accepted_and_uses_five_second_timeout(monkeypatch):
+    observed = {}
+
+    class MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            observed["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def head(self, endpoint):
+            return httpx.Response(200, request=httpx.Request("HEAD", endpoint))
+
+    monkeypatch.setattr(agents_route.httpx, "AsyncClient", MockAsyncClient)
+
+    endpoint = "https://8.8.8.8/agent"
+    assert _run_validate(endpoint) == endpoint
+    assert observed["timeout"] == agents_route.ENDPOINT_TIMEOUT_SECONDS
+
+
+def test_invalid_format_is_rejected():
+    with pytest.raises(HTTPException) as excinfo:
+        _run_validate("ftp://example.com/agent")
+
+    assert excinfo.value.status_code == 400
+    assert "http or https" in excinfo.value.detail
+
+
+def test_private_ip_is_blocked_before_network_probe(monkeypatch):
+    class ShouldNotBeCalled:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - defensive check
+            raise AssertionError("HEAD probe should not run for private IP")
+
+    monkeypatch.setattr(agents_route.httpx, "AsyncClient", ShouldNotBeCalled)
+
+    with pytest.raises(HTTPException) as excinfo:
+        _run_validate("http://127.0.0.1:9000/agent")
+
+    assert excinfo.value.status_code == 400
+    assert "private/internal IP" in excinfo.value.detail
+
+
+def test_timeout_is_rejected():
+    class TimeoutAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def head(self, endpoint):
+            raise httpx.TimeoutException("timed out")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(agents_route.httpx, "AsyncClient", TimeoutAsyncClient)
+        with pytest.raises(HTTPException) as excinfo:
+            _run_validate("https://8.8.8.8/agent")
+
+    assert excinfo.value.status_code == 400
+    assert "timed out after 5s" in excinfo.value.detail
+
+
+def test_create_agent_stores_validated_endpoint(monkeypatch):
+    class DummyDB:
+        def __init__(self):
+            self.added = None
+
+        def add(self, instance):
+            self.added = instance
+
+        def commit(self):
+            return None
+
+        def refresh(self, instance):
+            instance.id = 42
+
+    async def fake_validate(endpoint: str) -> str:
+        return "https://agent.example.com/entry"
+
+    monkeypatch.setattr(agents_route, "_validate_endpoint_url", fake_validate)
+
+    payload = agents_route.AgentCreate(name="demo", endpoint="https://ignored.invalid")
+    db = DummyDB()
+
+    result = asyncio.run(
+        agents_route.create_agent(payload, user={"id": 7, "address": "0xabc"}, db=db)
+    )
+
+    assert db.added.endpoint == "https://agent.example.com/entry"
+    assert result["endpoint"] == "https://agent.example.com/entry"


### PR DESCRIPTION
/claim #139

## Summary
- require endpoint in AgentCreate
- validate endpoint URL format (http/https only)
- block private/internal/loopback hosts (including resolved DNS IPs)
- verify reachability via HEAD request with 5s timeout
- store validated endpoint on Agent
- add minimal endpoint-validation tests for valid/invalid/private/timeout + storage

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1; JWT_SECRET=test-secret; python -m pytest api/tests/test_agent_endpoint_validation.py -q
- python -m py_compile api/routes/agents.py api/models/database.py api/tests/test_agent_endpoint_validation.py
