### PR TITLE
Add webhook notifications for task state changes

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, Boolean,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -34,6 +34,7 @@ class User(Base):
     created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
 
     agents = relationship("Agent", back_populates="owner")
+    webhook_subscriptions = relationship("WebhookSubscription", back_populates="creator")
 
 
 class Agent(Base):
@@ -68,6 +69,7 @@ class Task(Base):
 
     agent = relationship("Agent", back_populates="tasks")
     payments = relationship("Payment", back_populates="task")
+    webhook_deliveries = relationship("WebhookDelivery", back_populates="task")
 
 
 class Payment(Base):
@@ -84,6 +86,40 @@ class Payment(Base):
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class WebhookSubscription(Base):
+    __tablename__ = "webhook_subscriptions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    creator_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    target_url = Column(String(512), nullable=False)
+    secret = Column(String(128), nullable=False)
+    events = Column(JSON, default=list, nullable=False)
+    enabled = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=True)
+
+    creator = relationship("User", back_populates="webhook_subscriptions")
+    deliveries = relationship("WebhookDelivery", back_populates="subscription")
+
+
+class WebhookDelivery(Base):
+    __tablename__ = "webhook_deliveries"
+
+    id = Column(Integer, primary_key=True, index=True)
+    subscription_id = Column(Integer, ForeignKey("webhook_subscriptions.id"), nullable=False)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    event = Column(String(32), nullable=False)
+    attempt = Column(Integer, nullable=False)
+    success = Column(Boolean, default=False, nullable=False)
+    status_code = Column(Integer, nullable=True)
+    response_body = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    subscription = relationship("WebhookSubscription", back_populates="deliveries")
+    task = relationship("Task", back_populates="webhook_deliveries")
 
 
 def init_db():

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -7,10 +7,11 @@ from datetime import datetime
 
 from ..models.database import get_db, Task
 from ..middleware.auth import get_current_user
+from ..services.webhooks import notify_task_state_change
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
-VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled"}
+VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled", "disputed"}
 
 
 class TaskCreate(BaseModel):
@@ -40,6 +41,7 @@ async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depen
     db.add(new_task)
     db.commit()
     db.refresh(new_task)
+    await notify_task_state_change(db, new_task, "created")
     return {"id": new_task.id, "status": new_task.status}
 
 
@@ -76,6 +78,9 @@ async def update_task_status(
     user=Depends(get_current_user),
     db=Depends(get_db),
 ):
+    if update.status not in VALID_STATUSES:
+        raise HTTPException(status_code=400, detail="Invalid status")
+
     task = db.query(Task).filter(Task.id == task_id).first()
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -88,6 +93,8 @@ async def update_task_status(
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
+    if update.status in {"assigned", "completed", "disputed"}:
+        await notify_task_state_change(db, task, update.status)
     return {"id": task.id, "status": task.status}
 
 

--- a/api/routes/webhooks.py
+++ b/api/routes/webhooks.py
@@ -1,0 +1,196 @@
+"""Webhook subscription CRUD and delivery history endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field, HttpUrl
+
+from ..middleware.auth import get_current_user
+from ..models.database import get_db, WebhookSubscription, WebhookDelivery
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+ALLOWED_EVENTS = {"created", "assigned", "completed", "disputed"}
+
+
+class WebhookCreate(BaseModel):
+    target_url: HttpUrl
+    secret: str = Field(min_length=8, max_length=128)
+    events: list[str] = Field(default_factory=lambda: sorted(ALLOWED_EVENTS))
+    enabled: bool = True
+
+
+class WebhookUpdate(BaseModel):
+    target_url: Optional[HttpUrl] = None
+    secret: Optional[str] = Field(default=None, min_length=8, max_length=128)
+    events: Optional[list[str]] = None
+    enabled: Optional[bool] = None
+
+
+def _validate_events(events: list[str]) -> list[str]:
+    invalid = sorted(set(events) - ALLOWED_EVENTS)
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"Unsupported events: {', '.join(invalid)}")
+    return sorted(set(events))
+
+
+@router.post("/")
+async def create_webhook(subscription: WebhookCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    events = _validate_events(subscription.events)
+    record = WebhookSubscription(
+        creator_id=user["id"],
+        target_url=str(subscription.target_url),
+        secret=subscription.secret,
+        events=events,
+        enabled=subscription.enabled,
+        created_at=datetime.utcnow(),
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return {
+        "id": record.id,
+        "target_url": record.target_url,
+        "events": record.events,
+        "enabled": record.enabled,
+    }
+
+
+@router.get("/")
+async def list_webhooks(user=Depends(get_current_user), db=Depends(get_db)):
+    records = (
+        db.query(WebhookSubscription)
+        .filter(WebhookSubscription.creator_id == user["id"])
+        .order_by(WebhookSubscription.created_at.desc())
+        .all()
+    )
+    return [
+        {
+            "id": record.id,
+            "target_url": record.target_url,
+            "events": record.events,
+            "enabled": record.enabled,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+        }
+        for record in records
+    ]
+
+
+@router.get("/{subscription_id}")
+async def get_webhook(subscription_id: int, user=Depends(get_current_user), db=Depends(get_db)):
+    record = (
+        db.query(WebhookSubscription)
+        .filter(
+            WebhookSubscription.id == subscription_id,
+            WebhookSubscription.creator_id == user["id"],
+        )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Webhook subscription not found")
+    return {
+        "id": record.id,
+        "target_url": record.target_url,
+        "events": record.events,
+        "enabled": record.enabled,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+    }
+
+
+@router.patch("/{subscription_id}")
+async def update_webhook(
+    subscription_id: int,
+    update: WebhookUpdate,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    record = (
+        db.query(WebhookSubscription)
+        .filter(
+            WebhookSubscription.id == subscription_id,
+            WebhookSubscription.creator_id == user["id"],
+        )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Webhook subscription not found")
+
+    if update.target_url is not None:
+        record.target_url = str(update.target_url)
+    if update.secret is not None:
+        record.secret = update.secret
+    if update.events is not None:
+        record.events = _validate_events(update.events)
+    if update.enabled is not None:
+        record.enabled = update.enabled
+    record.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(record)
+    return {
+        "id": record.id,
+        "target_url": record.target_url,
+        "events": record.events,
+        "enabled": record.enabled,
+        "updated_at": record.updated_at,
+    }
+
+
+@router.delete("/{subscription_id}")
+async def delete_webhook(subscription_id: int, user=Depends(get_current_user), db=Depends(get_db)):
+    record = (
+        db.query(WebhookSubscription)
+        .filter(
+            WebhookSubscription.id == subscription_id,
+            WebhookSubscription.creator_id == user["id"],
+        )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Webhook subscription not found")
+    db.delete(record)
+    db.commit()
+    return {"id": subscription_id, "deleted": True}
+
+
+@router.get("/{subscription_id}/deliveries")
+async def list_deliveries(
+    subscription_id: int,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+    limit: int = Query(50, ge=1, le=200),
+):
+    record = (
+        db.query(WebhookSubscription)
+        .filter(
+            WebhookSubscription.id == subscription_id,
+            WebhookSubscription.creator_id == user["id"],
+        )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Webhook subscription not found")
+
+    deliveries = (
+        db.query(WebhookDelivery)
+        .filter(WebhookDelivery.subscription_id == subscription_id)
+        .order_by(WebhookDelivery.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "id": delivery.id,
+            "task_id": delivery.task_id,
+            "event": delivery.event,
+            "attempt": delivery.attempt,
+            "success": delivery.success,
+            "status_code": delivery.status_code,
+            "response_body": delivery.response_body,
+            "error_message": delivery.error_message,
+            "created_at": delivery.created_at,
+        }
+        for delivery in deliveries
+    ]

--- a/api/services/webhooks.py
+++ b/api/services/webhooks.py
@@ -1,0 +1,122 @@
+"""Webhook delivery service for task state changes."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from datetime import datetime
+
+import httpx
+
+from ..models.database import WebhookSubscription, WebhookDelivery
+
+TRACKED_EVENTS = {"created", "assigned", "completed", "disputed"}
+MAX_RETRIES = 5
+
+
+def _build_payload(task, event: str) -> dict:
+    return {
+        "event": event,
+        "task": {
+            "id": task.id,
+            "title": task.title,
+            "status": task.status,
+            "creator_id": task.creator_id,
+            "agent_id": task.agent_id,
+            "updated_at": (task.updated_at or task.created_at or datetime.utcnow()).isoformat(),
+        },
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+
+def _sign_payload(secret: str, payload_bytes: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+async def _deliver_with_retries(
+    db,
+    subscription: WebhookSubscription,
+    task_id: int,
+    event: str,
+    payload_bytes: bytes,
+    headers: dict,
+    client: httpx.AsyncClient,
+    sleep=asyncio.sleep,
+) -> None:
+    for attempt in range(1, MAX_RETRIES + 1):
+        status_code = None
+        body = None
+        error_message = None
+        success = False
+        try:
+            response = await client.post(
+                subscription.target_url,
+                content=payload_bytes,
+                headers=headers,
+                timeout=10.0,
+            )
+            status_code = response.status_code
+            body = response.text[:2000]
+            success = 200 <= response.status_code < 300
+        except Exception as exc:
+            error_message = str(exc)
+
+        db.add(
+            WebhookDelivery(
+                subscription_id=subscription.id,
+                task_id=task_id,
+                event=event,
+                attempt=attempt,
+                success=success,
+                status_code=status_code,
+                response_body=body,
+                error_message=error_message,
+            )
+        )
+        db.commit()
+
+        if success:
+            return
+        if attempt < MAX_RETRIES:
+            await sleep(2 ** (attempt - 1))
+
+
+async def notify_task_state_change(db, task, event: str) -> int:
+    if event not in TRACKED_EVENTS:
+        return 0
+
+    subscriptions = (
+        db.query(WebhookSubscription)
+        .filter(
+            WebhookSubscription.creator_id == task.creator_id,
+            WebhookSubscription.enabled.is_(True),
+        )
+        .all()
+    )
+    subscriptions = [s for s in subscriptions if event in (s.events or [])]
+    if not subscriptions:
+        return 0
+
+    payload = _build_payload(task, event)
+    payload_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    async with httpx.AsyncClient() as client:
+        for subscription in subscriptions:
+            headers = {
+                "Content-Type": "application/json",
+                "X-OpenAgents-Event": event,
+                "X-OpenAgents-Signature": _sign_payload(subscription.secret, payload_bytes),
+            }
+            await _deliver_with_retries(
+                db=db,
+                subscription=subscription,
+                task_id=task.id,
+                event=event,
+                payload_bytes=payload_bytes,
+                headers=headers,
+                client=client,
+            )
+    return len(subscriptions)

--- a/api/tests/test_webhook_notifications.py
+++ b/api/tests/test_webhook_notifications.py
@@ -1,0 +1,228 @@
+import asyncio
+import hashlib
+import hmac
+import os
+import tempfile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models import database as db_models
+from api.middleware.auth import get_current_user
+from api.models.database import Task, User, WebhookDelivery, WebhookSubscription
+from api.routes.tasks import router as tasks_router
+from api.routes.webhooks import router as webhooks_router
+from api.services import webhooks
+
+
+def _make_session_local():
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db_models.Base.metadata.create_all(bind=engine)
+    return session_local, engine, db_path
+
+
+def test_task_routes_emit_webhook_events(monkeypatch):
+    session_local, engine, db_path = _make_session_local()
+    fired_events = []
+
+    async def fake_notify(db, task, event):
+        fired_events.append(event)
+        return 1
+
+    monkeypatch.setattr("api.routes.tasks.notify_task_state_change", fake_notify)
+
+    app = FastAPI()
+    app.include_router(tasks_router)
+
+    def override_get_db():
+        db = session_local()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_get_current_user():
+        return {"id": 1, "address": "0x1", "roles": []}
+
+    app.dependency_overrides[db_models.get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    client = TestClient(app)
+
+    db = session_local()
+    db.add(User(id=1, address="0x1111111111111111111111111111111111111111", username="u1"))
+    db.commit()
+    db.close()
+
+    create_resp = client.post(
+        "/tasks/",
+        json={
+            "title": "test-task",
+            "description": "desc",
+            "reward_amount": 1.0,
+        },
+    )
+    assert create_resp.status_code == 200
+    task_id = create_resp.json()["id"]
+
+    for status in ("assigned", "completed", "disputed"):
+        update_resp = client.patch(f"/tasks/{task_id}/status", json={"status": status})
+        assert update_resp.status_code == 200
+        assert update_resp.json()["status"] == status
+
+    assert fired_events == ["created", "assigned", "completed", "disputed"]
+
+    engine.dispose()
+    os.remove(db_path)
+
+
+def test_webhook_retries_hmac_and_history(monkeypatch):
+    session_local, engine, db_path = _make_session_local()
+    db = session_local()
+    user = User(id=1, address="0x2222222222222222222222222222222222222222", username="u2")
+    db.add(user)
+    db.flush()
+    task = Task(
+        title="notify-task",
+        description="desc",
+        reward_amount=2.0,
+        creator_id=user.id,
+        status="completed",
+    )
+    db.add(task)
+    db.flush()
+    subscription = WebhookSubscription(
+        creator_id=user.id,
+        target_url="https://example.com/hook",
+        secret="supersecret",
+        events=["completed"],
+        enabled=True,
+    )
+    db.add(subscription)
+    db.commit()
+
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, status_code):
+            self.status_code = status_code
+            self.text = f"status={status_code}"
+
+    class FakeAsyncClient:
+        def __init__(self):
+            self._statuses = [500, 500, 500, 500, 200]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, content, headers, timeout):
+            calls.append({"url": url, "content": content, "headers": headers, "timeout": timeout})
+            return FakeResponse(self._statuses.pop(0))
+
+    monkeypatch.setattr(webhooks.httpx, "AsyncClient", FakeAsyncClient)
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    original_deliver = webhooks._deliver_with_retries
+
+    async def wrapped_deliver(*args, **kwargs):
+        kwargs["sleep"] = fake_sleep
+        return await original_deliver(*args, **kwargs)
+
+    monkeypatch.setattr(webhooks, "_deliver_with_retries", wrapped_deliver)
+
+    delivered = asyncio.run(webhooks.notify_task_state_change(db, task, "completed"))
+    assert delivered == 1
+
+    deliveries = (
+        db.query(WebhookDelivery)
+        .filter(WebhookDelivery.subscription_id == subscription.id)
+        .order_by(WebhookDelivery.attempt.asc())
+        .all()
+    )
+    assert len(deliveries) == 5
+    assert [d.attempt for d in deliveries] == [1, 2, 3, 4, 5]
+    assert deliveries[-1].success is True
+    assert sleeps == [1, 2, 4, 8]
+
+    assert len(calls) == 5
+    first_call = calls[0]
+    expected_sig = "sha256=" + hmac.new(
+        b"supersecret", first_call["content"], hashlib.sha256
+    ).hexdigest()
+    assert first_call["headers"]["X-OpenAgents-Signature"] == expected_sig
+
+    db.close()
+    engine.dispose()
+    os.remove(db_path)
+
+
+def test_webhook_crud_endpoints():
+    session_local, engine, db_path = _make_session_local()
+
+    app = FastAPI()
+    app.include_router(webhooks_router)
+
+    def override_get_db():
+        db = session_local()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_get_current_user():
+        return {"id": 1, "address": "0x1", "roles": []}
+
+    app.dependency_overrides[db_models.get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    client = TestClient(app)
+
+    db = session_local()
+    db.add(User(id=1, address="0x3333333333333333333333333333333333333333", username="u3"))
+    db.commit()
+    db.close()
+
+    create_resp = client.post(
+        "/webhooks/",
+        json={
+            "target_url": "https://example.com/webhook",
+            "secret": "secret-12345",
+            "events": ["created", "completed"],
+            "enabled": True,
+        },
+    )
+    assert create_resp.status_code == 200
+    webhook_id = create_resp.json()["id"]
+
+    list_resp = client.get("/webhooks/")
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 1
+
+    update_resp = client.patch(
+        f"/webhooks/{webhook_id}",
+        json={"events": ["assigned", "disputed"], "enabled": False},
+    )
+    assert update_resp.status_code == 200
+    assert sorted(update_resp.json()["events"]) == ["assigned", "disputed"]
+    assert update_resp.json()["enabled"] is False
+
+    delete_resp = client.delete(f"/webhooks/{webhook_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["deleted"] is True
+
+    engine.dispose()
+    os.remove(db_path)


### PR DESCRIPTION
## Summary\n- add WebhookSubscription and WebhookDelivery persistence models\n- add webhook delivery service with HMAC-SHA256 signing and 5-attempt exponential backoff retry\n- add /webhooks CRUD + delivery history endpoints\n- trigger webhook notifications on task created, ssigned, completed, and disputed state changes\n\n## Tests\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_webhook_notifications.py -q\n\n/claim #33