### PR TITLE
[API] Auto-refund expired escrows after 30-day grace

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -6,7 +6,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
-from datetime import datetime
+from datetime import datetime, timedelta
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
@@ -84,6 +84,12 @@ class Payment(Base):
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+    @property
+    def expired_at(self):
+        if not self.created_at:
+            return None
+        return self.created_at + timedelta(days=30)
 
 
 def init_db():

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -3,12 +3,14 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
+import logging
 
 from ..models.database import get_db, Payment, Task
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/payments", tags=["payments"])
+logger = logging.getLogger(__name__)
 
 
 class EscrowDeposit(BaseModel):
@@ -103,4 +105,32 @@ async def payment_history(
     return {
         "sent": [{"id": p.id, "amount": p.amount, "status": p.status} for p in sent],
         "received": [{"id": p.id, "amount": p.amount, "status": p.status} for p in received],
+    }
+
+
+@router.post("/process-expired")
+async def process_expired_escrows(db=Depends(get_db)):
+    now = datetime.utcnow()
+    expiration_cutoff = now - timedelta(days=30)
+    expired_escrows = db.query(Payment).filter(
+        Payment.status == "escrowed",
+        Payment.created_at <= expiration_cutoff,
+    ).all()
+
+    refunded_escrow_ids = []
+    for escrow in expired_escrows:
+        escrow.status = "refunded"
+        escrow.to_address = escrow.from_address
+        escrow.claimed_at = now
+        refunded_escrow_ids.append(escrow.id)
+        logger.info(
+            "escrow_auto_refund escrow_id=%s timestamp=%s",
+            escrow.id,
+            now.isoformat(),
+        )
+
+    db.commit()
+    return {
+        "processed": len(refunded_escrow_ids),
+        "refunded_escrow_ids": refunded_escrow_ids,
     }

--- a/api/tests/test_payments_process_expired.py
+++ b/api/tests/test_payments_process_expired.py
@@ -1,0 +1,137 @@
+import logging
+import os
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import Base, Payment, Task, get_db
+from api.routes import payments as payments_routes
+
+
+@pytest.fixture
+def client_and_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = testing_session_local()
+    app = FastAPI()
+    app.include_router(payments_routes.router)
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    try:
+        yield client, db
+    finally:
+        client.close()
+        db.close()
+
+
+def create_task(db, task_id: int):
+    task = Task(
+        id=task_id,
+        title=f"Task {task_id}",
+        description="Escrow test task",
+        reward_amount=100.0,
+        status="open",
+        creator_id=1,
+        created_at=datetime.utcnow(),
+    )
+    db.add(task)
+    db.commit()
+    return task
+
+
+def test_process_expired_leaves_fresh_escrow_untouched(client_and_db):
+    client, db = client_and_db
+    create_task(db, task_id=1)
+
+    fresh_payment = Payment(
+        task_id=1,
+        from_address="0x1111111111111111111111111111111111111111",
+        amount=5.0,
+        status="escrowed",
+        created_at=datetime.utcnow() - timedelta(days=10),
+    )
+    db.add(fresh_payment)
+    db.commit()
+    db.refresh(fresh_payment)
+
+    assert fresh_payment.expired_at == fresh_payment.created_at + timedelta(days=30)
+
+    response = client.post("/payments/process-expired")
+    assert response.status_code == 200
+    assert response.json()["processed"] == 0
+
+    db.refresh(fresh_payment)
+    assert fresh_payment.status == "escrowed"
+    assert fresh_payment.to_address is None
+    assert fresh_payment.claimed_at is None
+
+
+def test_process_expired_refunds_all_expired_and_logs(client_and_db, caplog):
+    client, db = client_and_db
+    create_task(db, task_id=2)
+
+    expired_a = Payment(
+        task_id=2,
+        from_address="0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        amount=7.0,
+        status="escrowed",
+        created_at=datetime.utcnow() - timedelta(days=31),
+    )
+    expired_b = Payment(
+        task_id=2,
+        from_address="0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        amount=9.0,
+        status="escrowed",
+        created_at=datetime.utcnow() - timedelta(days=45),
+    )
+    fresh = Payment(
+        task_id=2,
+        from_address="0xcccccccccccccccccccccccccccccccccccccccc",
+        amount=3.0,
+        status="escrowed",
+        created_at=datetime.utcnow() - timedelta(days=5),
+    )
+    db.add_all([expired_a, expired_b, fresh])
+    db.commit()
+    db.refresh(expired_a)
+    db.refresh(expired_b)
+    db.refresh(fresh)
+
+    caplog.set_level(logging.INFO, logger=payments_routes.__name__)
+    response = client.post("/payments/process-expired")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["processed"] == 2
+    assert set(payload["refunded_escrow_ids"]) == {expired_a.id, expired_b.id}
+
+    db.refresh(expired_a)
+    db.refresh(expired_b)
+    db.refresh(fresh)
+
+    assert expired_a.status == "refunded"
+    assert expired_a.to_address == expired_a.from_address
+    assert expired_a.claimed_at is not None
+
+    assert expired_b.status == "refunded"
+    assert expired_b.to_address == expired_b.from_address
+    assert expired_b.claimed_at is not None
+
+    assert fresh.status == "escrowed"
+    assert fresh.to_address is None
+
+    log_output = " ".join(caplog.messages)
+    assert f"escrow_id={expired_a.id}" in log_output
+    assert f"escrow_id={expired_b.id}" in log_output
+    assert "timestamp=" in log_output


### PR DESCRIPTION
## Summary
- add `POST /payments/process-expired` to process expired escrows in one call
- add `Payment.expired_at` computed field (30-day grace from escrow creation)
- auto-refund expired escrows to payer and log each refund with escrow ID + timestamp
- add focused tests for fresh escrow unchanged and expired escrows refunded

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_payments_process_expired.py -q`
- Result: `2 passed`

Closes #197
/claim #197
