### PR TITLE
sdk: add minimal deployContract helper with confirmation-aware receipt metadata

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,15 +9,32 @@ export interface AgentConfig {
   routerAddress: string;
 }
 
+export interface DeployContractOptions {
+  confirmations?: number;
+  overrides?: ethers.Overrides;
+}
+
+export interface DeployContractResult {
+  contract: ethers.BaseContract;
+  address: string;
+  txHash: string;
+  gasUsed: bigint;
+  receipt: ethers.TransactionReceipt;
+}
+
 export class OpenAgentsSDK {
-  private provider: ethers.JsonRpcProvider;
-  private signer: ethers.Wallet;
+  private provider: ethers.Provider;
+  private signer: ethers.Signer;
   private config: AgentConfig;
 
-  constructor(config: AgentConfig) {
+  constructor(
+    config: AgentConfig,
+    runtime?: { provider?: ethers.Provider; signer?: ethers.Signer }
+  ) {
     this.config = config;
-    this.provider = new ethers.JsonRpcProvider(config.rpcUrl);
-    this.signer = new ethers.Wallet(config.privateKey, this.provider);
+    this.provider = runtime?.provider ?? new ethers.JsonRpcProvider(config.rpcUrl);
+    this.signer =
+      runtime?.signer ?? new ethers.Wallet(config.privateKey, this.provider);
   }
 
   async registerAgent(): Promise<string> {
@@ -58,6 +75,41 @@ export class OpenAgentsSDK {
       ethers.toUtf8Bytes(result)
     );
     await tx.wait();
+  }
+
+  async deployContract(
+    abi: ethers.InterfaceAbi,
+    bytecode: ethers.BytesLike,
+    args: unknown[] = [],
+    options: DeployContractOptions = {}
+  ): Promise<DeployContractResult> {
+    const factory = new ethers.ContractFactory(abi, bytecode, this.signer);
+    const deploymentArgs = [...args];
+
+    if (options.overrides) {
+      deploymentArgs.push(options.overrides);
+    }
+
+    const contract = await factory.deploy(...deploymentArgs);
+    await contract.waitForDeployment();
+
+    const deploymentTx = contract.deploymentTransaction();
+    if (!deploymentTx) {
+      throw new Error("Deployment transaction not found");
+    }
+
+    const receipt = await deploymentTx.wait(options.confirmations ?? 1);
+    if (!receipt) {
+      throw new Error("Deployment receipt not found");
+    }
+
+    return {
+      contract,
+      address: await contract.getAddress(),
+      txHash: deploymentTx.hash,
+      gasUsed: receipt.gasUsed,
+      receipt,
+    };
   }
 
   async getOpenTasks(): Promise<any[]> {

--- a/test/SDKDeployHelpers.test.js
+++ b/test/SDKDeployHelpers.test.js
@@ -1,0 +1,122 @@
+const assert = require("node:assert/strict");
+const { describe, it, before } = require("mocha");
+const hre = require("hardhat");
+const solc = require("solc");
+
+const { ethers, network } = hre;
+
+function compileDeployTarget() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "DeployTarget.sol": {
+        content: `
+          // SPDX-License-Identifier: MIT
+          pragma solidity ^0.8.20;
+          contract DeployTarget {
+            uint256 public value;
+            constructor(uint256 _value) {
+              value = _value;
+            }
+          }
+        `,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const contract =
+    output.contracts["DeployTarget.sol"] &&
+    output.contracts["DeployTarget.sol"].DeployTarget;
+
+  if (!contract) {
+    throw new Error("Failed to compile DeployTarget");
+  }
+
+  return {
+    abi: contract.abi,
+    bytecode: `0x${contract.evm.bytecode.object}`,
+  };
+}
+
+function buildConfig(privateKey) {
+  return {
+    name: "sdk-test-agent",
+    endpoint: "https://example.com/agent",
+    privateKey,
+    rpcUrl: "http://127.0.0.1:8545",
+    registryAddress: ethers.ZeroAddress,
+    routerAddress: ethers.ZeroAddress,
+  };
+}
+
+describe("OpenAgentsSDK deployContract", () => {
+  let OpenAgentsSDK;
+  let signer;
+  let compiledContract;
+
+  before(async () => {
+    ({ OpenAgentsSDK } = await import("../sdk/src/index.ts"));
+    [signer] = await ethers.getSigners();
+    compiledContract = compileDeployTarget();
+  });
+
+  it("deploys with constructor args and returns deployment metadata", async () => {
+    const sdk = new OpenAgentsSDK(buildConfig(ethers.Wallet.createRandom().privateKey), {
+      provider: signer.provider,
+      signer,
+    });
+    const initialValue = 1234n;
+
+    const deployment = await sdk.deployContract(
+      compiledContract.abi,
+      compiledContract.bytecode,
+      [initialValue]
+    );
+
+    const deployedAddress = await deployment.contract.getAddress();
+    assert.equal(deployment.address, deployedAddress);
+    assert.match(deployment.txHash, /^0x[0-9a-fA-F]{64}$/);
+    assert.ok(deployment.gasUsed > 0n);
+
+    const deployed = new ethers.Contract(
+      deployment.address,
+      compiledContract.abi,
+      signer.provider
+    );
+    assert.equal(await deployed.value(), initialValue);
+  });
+
+  it("waits for configurable confirmation blocks", async () => {
+    const sdk = new OpenAgentsSDK(buildConfig(ethers.Wallet.createRandom().privateKey), {
+      provider: signer.provider,
+      signer,
+    });
+
+    const deployPromise = sdk.deployContract(
+      compiledContract.abi,
+      compiledContract.bytecode,
+      [1n],
+      { confirmations: 2 }
+    );
+
+    const stateBeforeExtraBlock = await Promise.race([
+      deployPromise.then(() => "resolved"),
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 100)),
+    ]);
+    assert.equal(stateBeforeExtraBlock, "pending");
+
+    await network.provider.send("evm_mine");
+    const deployment = await deployPromise;
+
+    const currentBlock = await signer.provider.getBlockNumber();
+    assert.ok(currentBlock - deployment.receipt.blockNumber >= 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAgentsSDK.deployContract(abi, bytecode, args, options)
- wait for deployment tx receipt with configurable confirmations
- return deployed contract instance plus deployment metadata (ddress, 	xHash, gasUsed, eceipt)
- add focused test coverage for constructor args and confirmation waiting

## Verification
- 
px hardhat test --no-compile test/SDKDeployHelpers.test.js

Closes #199
/claim #199