### PR TITLE
Fix InterestRateModel parameter change observability

### DIFF
--- a/contracts/lending/InterestRateModel.sol
+++ b/contracts/lending/InterestRateModel.sol
@@ -18,7 +18,24 @@ contract InterestRateModel {
 
     address public admin;
 
+    struct RateParameters {
+        uint256 baseRate;
+        uint256 multiplier;
+        uint256 jumpMultiplier;
+        uint256 kink;
+    }
+
     event RateParamsUpdated(uint256 baseRate, uint256 multiplier, uint256 jumpMultiplier, uint256 kink);
+    event RateParametersUpdated(
+        uint256 oldBaseRate,
+        uint256 newBaseRate,
+        uint256 oldMultiplier,
+        uint256 newMultiplier,
+        uint256 oldJumpMultiplier,
+        uint256 newJumpMultiplier,
+        uint256 oldKink,
+        uint256 newKink
+    );
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -44,11 +61,37 @@ contract InterestRateModel {
         uint256 _jumpMultiplier,
         uint256 _kink
     ) external onlyAdmin {
+        uint256 oldBaseRate = baseRate;
+        uint256 oldMultiplier = multiplier;
+        uint256 oldJumpMultiplier = jumpMultiplier;
+        uint256 oldKink = kink;
+
         baseRate = _baseRate;
         multiplier = _multiplier;
         jumpMultiplier = _jumpMultiplier;
         kink = _kink;
+
         emit RateParamsUpdated(_baseRate, _multiplier, _jumpMultiplier, _kink);
+        emit RateParametersUpdated(
+            oldBaseRate,
+            _baseRate,
+            oldMultiplier,
+            _multiplier,
+            oldJumpMultiplier,
+            _jumpMultiplier,
+            oldKink,
+            _kink
+        );
+    }
+
+    function getParameters() external view returns (RateParameters memory) {
+        return
+            RateParameters({
+                baseRate: baseRate,
+                multiplier: multiplier,
+                jumpMultiplier: jumpMultiplier,
+                kink: kink
+            });
     }
 
     function getUtilization(uint256 totalBorrowed, uint256 totalDeposits) public pure returns (uint256) {

--- a/test/InterestRateModelEvents.test.js
+++ b/test/InterestRateModelEvents.test.js
@@ -1,0 +1,72 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("InterestRateModel", function () {
+  async function deployModel(params) {
+    const InterestRateModel = await ethers.getContractFactory("InterestRateModel");
+    const model = await InterestRateModel.deploy(
+      params.baseRate,
+      params.multiplier,
+      params.jumpMultiplier,
+      params.kink
+    );
+
+    if (model.waitForDeployment) {
+      await model.waitForDeployment();
+    } else {
+      await model.deployed();
+    }
+
+    return model;
+  }
+
+  it("emits compatibility and old/new events when params are updated", async function () {
+    const initial = {
+      baseRate: 100,
+      multiplier: 200,
+      jumpMultiplier: 300,
+      kink: ethers.parseUnits ? ethers.parseUnits("0.8", 18) : ethers.utils.parseUnits("0.8", 18),
+    };
+
+    const next = {
+      baseRate: 150,
+      multiplier: 250,
+      jumpMultiplier: 350,
+      kink: ethers.parseUnits ? ethers.parseUnits("0.9", 18) : ethers.utils.parseUnits("0.9", 18),
+    };
+
+    const model = await deployModel(initial);
+
+    await expect(model.updateParams(next.baseRate, next.multiplier, next.jumpMultiplier, next.kink))
+      .to.emit(model, "RateParamsUpdated")
+      .withArgs(next.baseRate, next.multiplier, next.jumpMultiplier, next.kink)
+      .and.to.emit(model, "RateParametersUpdated")
+      .withArgs(
+        initial.baseRate,
+        next.baseRate,
+        initial.multiplier,
+        next.multiplier,
+        initial.jumpMultiplier,
+        next.jumpMultiplier,
+        initial.kink,
+        next.kink
+      );
+  });
+
+  it("returns all parameters from getParameters()", async function () {
+    const params = {
+      baseRate: 111,
+      multiplier: 222,
+      jumpMultiplier: 333,
+      kink: ethers.parseUnits ? ethers.parseUnits("0.75", 18) : ethers.utils.parseUnits("0.75", 18),
+    };
+
+    const model = await deployModel(params);
+    const current = await model.getParameters();
+
+    expect(current.baseRate).to.equal(params.baseRate);
+    expect(current.multiplier).to.equal(params.multiplier);
+    expect(current.jumpMultiplier).to.equal(params.jumpMultiplier);
+    expect(current.kink).to.equal(params.kink);
+  });
+});


### PR DESCRIPTION
## Summary
- add RateParametersUpdated with old/new values for every parameter update
- keep emitting existing RateParamsUpdated event for backwards compatibility
- add getParameters() to fetch all interest-rate params in one call
- add focused tests for update event payloads and getter behavior

## Verification
- 
px hardhat test --config hardhat.issue193.config.js test/InterestRateModelEvents.test.js (2 passing)

Closes #193

/claim #193