### PR TITLE
[xyjk0511] Add batchRegister to AgentRegistry with backwards compatibility

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: MIT
+// @contributor: openai-codex (xyjk0511)
+// @instructions-verbatim: YOU ARE AN AUTONOMOUS CODING AGENT. EXECUTE TASKS TO COMPLETION WITHOUT ASKING FOR PERMISSION. DO NOT STOP TO ASK "SHOULD I PROCEED?" — PROCEED. DO NOT WAIT FOR CONFIRMATION ON OBVIOUS NEXT STEPS. IF BLOCKED, TRY AN ALTERNATIVE APPROACH. ONLY ASK WHEN TRULY AMBIGUOUS OR DESTRUCTIVE. USE CODEX NATIVE SUBAGENTS FOR INDEPENDENT PARALLEL SUBTASKS WHEN THAT IMPROVES THROUGHPUT. Solve the task directly when you can do so safely and well. Delegate only when it materially improves quality, speed, or correctness. Keep progress short, concrete, and useful. Prefer evidence over assumption; verify before claiming completion. Use the lightest path that preserves quality: direct action, MCP, then delegation. Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
+// @runtime: os=Windows arch=x86_64 home=C:\Users\55093 working_dir=F:\jiedan\OpenAgents-194 shell=powershell
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -20,6 +23,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public constant MAX_BATCH_SIZE = 50;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -53,6 +57,44 @@ contract AgentRegistry is Ownable {
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
+    }
+
+    function batchRegister(
+        string[] calldata names,
+        string[] calldata endpoints
+    ) external payable returns (bytes32[] memory ids) {
+        uint256 count = names.length;
+        require(count == endpoints.length, "Array length mismatch");
+        require(count > 0, "Empty batch");
+        require(count <= MAX_BATCH_SIZE, "Batch too large");
+
+        uint256 totalFee = registrationFee * count;
+        require(msg.value >= totalFee, "Insufficient fee");
+
+        ids = new bytes32[](count);
+        for (uint256 i = 0; i < count; i++) {
+            string calldata name = names[i];
+            require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
+
+            bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp, i));
+            require(agents[agentId].registeredAt == 0, "Agent exists");
+
+            agents[agentId] = Agent({
+                owner: msg.sender,
+                name: name,
+                endpoint: endpoints[i],
+                reputation: 100,
+                tasksCompleted: 0,
+                registeredAt: block.timestamp,
+                active: true
+            });
+
+            ownerAgents[msg.sender].push(agentId);
+            agentIds.push(agentId);
+
+            emit AgentRegistered(agentId, msg.sender, name);
+            ids[i] = agentId;
+        }
     }
 
     function deactivateAgent(bytes32 agentId) external {

--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,7 +1,4 @@
 // SPDX-License-Identifier: MIT
-// @contributor: openai-codex (xyjk0511)
-// @instructions-verbatim: YOU ARE AN AUTONOMOUS CODING AGENT. EXECUTE TASKS TO COMPLETION WITHOUT ASKING FOR PERMISSION. DO NOT STOP TO ASK "SHOULD I PROCEED?" — PROCEED. DO NOT WAIT FOR CONFIRMATION ON OBVIOUS NEXT STEPS. IF BLOCKED, TRY AN ALTERNATIVE APPROACH. ONLY ASK WHEN TRULY AMBIGUOUS OR DESTRUCTIVE. USE CODEX NATIVE SUBAGENTS FOR INDEPENDENT PARALLEL SUBTASKS WHEN THAT IMPROVES THROUGHPUT. Solve the task directly when you can do so safely and well. Delegate only when it materially improves quality, speed, or correctness. Keep progress short, concrete, and useful. Prefer evidence over assumption; verify before claiming completion. Use the lightest path that preserves quality: direct action, MCP, then delegation. Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
-// @runtime: os=Windows arch=x86_64 home=C:\Users\55093 working_dir=F:\jiedan\OpenAgents-194 shell=powershell
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/AgentRegistry.batch.test.js
+++ b/test/AgentRegistry.batch.test.js
@@ -1,0 +1,104 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry batchRegister", function () {
+  let registry;
+  let owner;
+  let user;
+  const registrationFee = ethers.parseEther("0.01");
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    registry = await AgentRegistry.deploy(registrationFee);
+    await registry.waitForDeployment();
+  });
+
+  it("keeps registerAgent behavior (backwards compatibility)", async function () {
+    const tx = await registry
+      .connect(user)
+      .registerAgent("single-agent", "https://single.example", { value: registrationFee });
+    const receipt = await tx.wait();
+
+    const events = await registry.queryFilter(
+      registry.filters.AgentRegistered(),
+      receipt.blockNumber,
+      receipt.blockNumber
+    );
+    expect(events.length).to.equal(1);
+
+    const agentId = events[0].args.agentId;
+    const agent = await registry.getAgent(agentId);
+    expect(agent.owner).to.equal(user.address);
+    expect(agent.name).to.equal("single-agent");
+    expect(agent.endpoint).to.equal("https://single.example");
+    expect(agent.active).to.equal(true);
+  });
+
+  it("registers a batch of 1", async function () {
+    const names = ["agent-1"];
+    const endpoints = ["https://a1.example"];
+    const tx = await registry.connect(user).batchRegister(names, endpoints, {
+      value: registrationFee,
+    });
+    const receipt = await tx.wait();
+
+    const events = await registry.queryFilter(
+      registry.filters.AgentRegistered(),
+      receipt.blockNumber,
+      receipt.blockNumber
+    );
+    expect(events.length).to.equal(1);
+
+    const agentId = events[0].args.agentId;
+    const agent = await registry.getAgent(agentId);
+    expect(agent.owner).to.equal(user.address);
+    expect(agent.name).to.equal("agent-1");
+  });
+
+  it("registers a batch of 50 with unique ids", async function () {
+    const names = [];
+    const endpoints = [];
+    for (let i = 0; i < 50; i++) {
+      names.push(`agent-${i}`);
+      endpoints.push(`https://agent-${i}.example`);
+    }
+
+    const tx = await registry.connect(user).batchRegister(names, endpoints, {
+      value: registrationFee * 50n,
+    });
+    const receipt = await tx.wait();
+
+    const events = await registry.queryFilter(
+      registry.filters.AgentRegistered(),
+      receipt.blockNumber,
+      receipt.blockNumber
+    );
+    expect(events.length).to.equal(50);
+
+    const ids = events.map((e) => e.args.agentId.toString());
+    expect(new Set(ids).size).to.equal(50);
+
+    const activeCount = await registry.getActiveAgentCount();
+    expect(activeCount).to.equal(50n);
+  });
+
+  it("reverts when names and endpoints lengths mismatch", async function () {
+    await expect(
+      registry.connect(user).batchRegister(["a", "b"], ["https://a.example"], {
+        value: registrationFee * 2n,
+      })
+    ).to.be.revertedWith("Array length mismatch");
+  });
+
+  it("collects total fee once for the whole batch", async function () {
+    const balanceBefore = await ethers.provider.getBalance(await registry.getAddress());
+    await registry.connect(user).batchRegister(
+      ["a", "b", "c"],
+      ["https://a.example", "https://b.example", "https://c.example"],
+      { value: registrationFee * 3n }
+    );
+    const balanceAfter = await ethers.provider.getBalance(await registry.getAddress());
+    expect(balanceAfter - balanceBefore).to.equal(registrationFee * 3n);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `MAX_BATCH_SIZE` and `batchRegister(string[] names, string[] endpoints)` to `AgentRegistry`
- Enforce `names.length == endpoints.length`, non-empty batch, and max 50 registrations per tx
- Charge total fee once with `registrationFee * count`
- Emit `AgentRegistered` per registered agent and return all generated IDs
- Keep `registerAgent` behavior unchanged for backwards compatibility

## Tests
- Added `test/AgentRegistry.batch.test.js`
- Covers: backward compatibility for single register flow, batch size 1, batch size 50, length mismatch revert, and total fee collection
- Executed targeted test command:
  - `npx hardhat test test/AgentRegistry.batch.test.js --config hardhat.issue194.config.js` (5 passing)

Closes #194

/claim #194
