### PR TITLE
[API] Add task websocket endpoint for real-time task updates

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,9 +1,11 @@
 """Task management endpoints for bounty assignments."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
+import asyncio
 from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
 from ..models.database import get_db, Task
 from ..middleware.auth import get_current_user
@@ -25,6 +27,138 @@ class TaskStatusUpdate(BaseModel):
     status: str  # BUG: Not validated against VALID_STATUSES enum — any string accepted
 
 
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+def _serialize_task_update(task: Task) -> dict:
+    return {
+        "id": task.id,
+        "title": task.title,
+        "status": task.status,
+        "agent_id": task.agent_id,
+        "updated_at": task.updated_at.isoformat() if task.updated_at else None,
+    }
+
+
+def _extract_task_ids(message: dict) -> set[int]:
+    raw_ids = message.get("task_ids")
+    if raw_ids is None and "task_id" in message:
+        raw_ids = [message.get("task_id")]
+    if raw_ids is None:
+        return set()
+    if not isinstance(raw_ids, list):
+        raw_ids = [raw_ids]
+
+    parsed: set[int] = set()
+    for value in raw_ids:
+        try:
+            task_id = int(value)
+        except (TypeError, ValueError):
+            continue
+        if task_id > 0:
+            parsed.add(task_id)
+    return parsed
+
+
+class TaskWebSocketManager:
+    def __init__(self) -> None:
+        self.active_connections: set[WebSocket] = set()
+        self.subscriptions: dict[int, set[WebSocket]] = {}
+        self.connection_subscriptions: dict[WebSocket, set[int]] = {}
+        self.heartbeat_tasks: dict[WebSocket, asyncio.Task] = {}
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.add(websocket)
+        self.connection_subscriptions[websocket] = set()
+        self.heartbeat_tasks[websocket] = asyncio.create_task(self._heartbeat_loop(websocket))
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        self.active_connections.discard(websocket)
+
+        subscribed_task_ids = self.connection_subscriptions.pop(websocket, set())
+        for task_id in subscribed_task_ids:
+            listeners = self.subscriptions.get(task_id)
+            if not listeners:
+                continue
+            listeners.discard(websocket)
+            if not listeners:
+                self.subscriptions.pop(task_id, None)
+
+        heartbeat_task = self.heartbeat_tasks.pop(websocket, None)
+        if heartbeat_task and heartbeat_task is not asyncio.current_task():
+            heartbeat_task.cancel()
+
+    async def subscribe(self, websocket: WebSocket, task_ids: set[int]) -> list[int]:
+        subscribed_task_ids = self.connection_subscriptions.setdefault(websocket, set())
+        for task_id in task_ids:
+            listeners = self.subscriptions.setdefault(task_id, set())
+            listeners.add(websocket)
+            subscribed_task_ids.add(task_id)
+        return sorted(subscribed_task_ids)
+
+    async def unsubscribe(self, websocket: WebSocket, task_ids: set[int]) -> list[int]:
+        subscribed_task_ids = self.connection_subscriptions.setdefault(websocket, set())
+        for task_id in task_ids:
+            listeners = self.subscriptions.get(task_id)
+            if listeners:
+                listeners.discard(websocket)
+                if not listeners:
+                    self.subscriptions.pop(task_id, None)
+            subscribed_task_ids.discard(task_id)
+        return sorted(subscribed_task_ids)
+
+    async def broadcast_task_update(self, task: Task) -> None:
+        listeners = list(self.subscriptions.get(task.id, set()))
+        if not listeners:
+            return
+
+        payload = {"type": "task_update", "task": _serialize_task_update(task)}
+        for websocket in listeners:
+            try:
+                await websocket.send_json(payload)
+            except Exception:
+                await self.disconnect(websocket)
+
+    async def _heartbeat_loop(self, websocket: WebSocket) -> None:
+        try:
+            while True:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+                await websocket.send_json(
+                    {
+                        "type": "heartbeat",
+                        "timestamp": datetime.utcnow().isoformat(),
+                    }
+                )
+        except Exception:
+            await self.disconnect(websocket)
+
+
+task_ws_manager = TaskWebSocketManager()
+
+
+@router.websocket("/ws")
+async def task_updates_websocket(websocket: WebSocket):
+    await task_ws_manager.connect(websocket)
+    await websocket.send_json({"type": "connected"})
+    try:
+        while True:
+            message = await websocket.receive_json()
+            action = message.get("action")
+            task_ids = _extract_task_ids(message)
+
+            if action == "subscribe":
+                subscribed = await task_ws_manager.subscribe(websocket, task_ids)
+                await websocket.send_json({"type": "subscribed", "task_ids": subscribed})
+            elif action == "unsubscribe":
+                subscribed = await task_ws_manager.unsubscribe(websocket, task_ids)
+                await websocket.send_json({"type": "unsubscribed", "task_ids": subscribed})
+            else:
+                await websocket.send_json({"type": "error", "detail": "Unsupported action"})
+    except WebSocketDisconnect:
+        await task_ws_manager.disconnect(websocket)
+
+
 @router.post("/")
 async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depends(get_db)):
     new_task = Task(
@@ -40,6 +174,7 @@ async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depen
     db.add(new_task)
     db.commit()
     db.refresh(new_task)
+    await task_ws_manager.broadcast_task_update(new_task)
     return {"id": new_task.id, "status": new_task.status}
 
 
@@ -88,6 +223,8 @@ async def update_task_status(
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
+    db.refresh(task)
+    await task_ws_manager.broadcast_task_update(task)
     return {"id": task.id, "status": task.status}
 
 
@@ -101,5 +238,8 @@ async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(g
     if task.status not in ("open", "assigned"):
         raise HTTPException(status_code=400, detail="Cannot cancel an active task")
     task.status = "cancelled"
+    task.updated_at = datetime.utcnow()
     db.commit()
+    db.refresh(task)
+    await task_ws_manager.broadcast_task_update(task)
     return {"id": task.id, "status": "cancelled"}

--- a/tests/test_task_websocket.py
+++ b/tests/test_task_websocket.py
@@ -1,0 +1,146 @@
+import os
+import time
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from api.models.database import Base, User
+from api.routes.tasks import (
+    router,
+    task_ws_manager,
+)
+from api.routes.tasks import get_current_user, get_db
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _override_get_current_user():
+    return {"id": 1, "address": "0xabc"}
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    return TestClient(app)
+
+
+def _seed_user():
+    db = TestingSessionLocal()
+    try:
+        existing = db.query(User).filter(User.id == 1).first()
+        if not existing:
+            db.add(User(id=1, address="0xabc", username="ws-test"))
+            db.commit()
+    finally:
+        db.close()
+
+
+def _reset_ws_manager_state():
+    task_ws_manager.active_connections.clear()
+    task_ws_manager.subscriptions.clear()
+    task_ws_manager.connection_subscriptions.clear()
+    for task in list(task_ws_manager.heartbeat_tasks.values()):
+        task.cancel()
+    task_ws_manager.heartbeat_tasks.clear()
+
+
+def _create_task(client: TestClient) -> int:
+    response = client.post(
+        "/tasks/",
+        json={
+            "title": "ws test task",
+            "description": "task for websocket validation",
+            "reward_amount": 1.0,
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["id"]
+
+
+def test_websocket_subscribe_and_receive_task_update():
+    _seed_user()
+    _reset_ws_manager_state()
+    client = _build_client()
+    task_id = _create_task(client)
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        connected = websocket.receive_json()
+        assert connected["type"] == "connected"
+
+        websocket.send_json({"action": "subscribe", "task_ids": [task_id]})
+        subscribed = websocket.receive_json()
+        assert subscribed["type"] == "subscribed"
+        assert task_id in subscribed["task_ids"]
+
+        response = client.patch(f"/tasks/{task_id}/status", json={"status": "in_progress"})
+        assert response.status_code == 200
+
+        update = websocket.receive_json()
+        assert update["type"] == "task_update"
+        assert update["task"]["id"] == task_id
+        assert update["task"]["status"] == "in_progress"
+
+
+def test_websocket_unsubscribe_stops_updates():
+    _seed_user()
+    _reset_ws_manager_state()
+    client = _build_client()
+    task_id = _create_task(client)
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "subscribe", "task_ids": [task_id]})
+        websocket.receive_json()
+
+        websocket.send_json({"action": "unsubscribe", "task_ids": [task_id]})
+        unsubscribed = websocket.receive_json()
+        assert unsubscribed["type"] == "unsubscribed"
+        assert task_id not in unsubscribed["task_ids"]
+
+        response = client.patch(f"/tasks/{task_id}/status", json={"status": "review"})
+        assert response.status_code == 200
+
+        # No subscriber should remain for this task.
+        assert task_id not in task_ws_manager.subscriptions
+
+
+def test_websocket_heartbeat_and_disconnect_cleanup(monkeypatch):
+    _seed_user()
+    _reset_ws_manager_state()
+    client = _build_client()
+
+    monkeypatch.setattr("api.routes.tasks.HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.receive_json()
+        heartbeat = websocket.receive_json()
+        assert heartbeat["type"] == "heartbeat"
+
+    timeout_at = time.time() + 1.0
+    while task_ws_manager.active_connections and time.time() < timeout_at:
+        time.sleep(0.01)
+
+    assert not task_ws_manager.active_connections
+    assert not task_ws_manager.connection_subscriptions


### PR DESCRIPTION
## Summary
- add `ws /tasks/ws` in `api/routes/tasks.py`
- support `subscribe` / `unsubscribe` by task id and broadcast only to subscribers
- emit heartbeat every 30s and clean disconnected clients
- broadcast task updates from existing create/status/cancel handlers without changing REST responses
- add focused tests for connect+subscribe+update, unsubscribe behavior, and heartbeat/cleanup

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_task_websocket.py -q`
- `python -m py_compile api/routes/tasks.py tests/test_task_websocket.py`

Closes #188

/claim #188
