### PR TITLE
[Solidity] Add MultiTokenStaking emergencyWithdraw (issue #195)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "openai-codex-55093",
+      "timestamp": "2026-05-31T04:32:05Z",
+      "platform_instructions": "Private system/developer instructions are protected and cannot be published; contribution executed per repository and task requirements.",
+      "runtime": {
+        "os": "windows",
+        "arch": "x64",
+        "home_dir": "C:/Users/55093",
+        "working_dir": "F:/jiedan/OpenAgents-195",
+        "shell": "powershell"
+      },
+      "contribution": "Added emergencyWithdraw support to MultiTokenStaking with focused emergency-withdraw tests"
     }
   ]
 }

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -6,6 +6,14 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/*
+ * Contributor Traceability
+ * Agent: Codex (GPT-5)
+ * Platform Instructions: Hidden system/developer instructions are not reproducible in-repo;
+ * this contribution follows repository and issue requirements while preserving protected context.
+ * Runtime: os=windows, arch=x64, home_dir=C:\\Users\\55093, working_dir=F:\\jiedan\\OpenAgents-195
+ */
+
 /// @title MultiTokenStaking
 /// @notice Allows users to stake multiple ERC20 tokens across different pools,
 ///         each earning a share of a global reward token emission.
@@ -37,6 +45,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
+    event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
 
     // BUG: Missing zero-address validation — rewardToken can be set to address(0),
     // causing all reward transfers to silently burn tokens or revert unpredictably.
@@ -130,6 +139,25 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
         user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
         emit Withdraw(msg.sender, pid, amount);
+    }
+
+    /// @notice Emergency withdraw staked tokens without claiming rewards.
+    /// @param pid Pool ID.
+    function emergencyWithdraw(uint256 pid) external nonReentrant {
+        PoolInfo storage pool = poolInfo[pid];
+        UserInfo storage user = userInfo[pid][msg.sender];
+
+        uint256 amount = user.amount;
+        require(amount > 0, "MultiStaking: no staked amount");
+
+        updatePool(pid);
+
+        user.amount = 0;
+        user.rewardDebt = 0;
+        pool.totalStaked -= amount;
+
+        pool.stakeToken.safeTransfer(msg.sender, amount);
+        emit EmergencyWithdraw(msg.sender, pid, amount);
     }
 
     /// @notice View pending rewards for a user in a pool.

--- a/test/MultiTokenStakingEmergencyWithdraw.test.js
+++ b/test/MultiTokenStakingEmergencyWithdraw.test.js
@@ -1,0 +1,61 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MultiTokenStaking emergencyWithdraw", function () {
+  let owner;
+  let staker;
+  let rewardToken;
+  let stakeToken;
+  let staking;
+
+  beforeEach(async function () {
+    [owner, staker] = await ethers.getSigners();
+
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    rewardToken = await AgentToken.deploy("Reward Token", "RWD", 0);
+    await rewardToken.waitForDeployment();
+
+    stakeToken = await AgentToken.deploy("Stake Token", "STK", 0);
+    await stakeToken.waitForDeployment();
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    staking = await MultiTokenStaking.deploy(await rewardToken.getAddress(), ethers.parseEther("1"));
+    await staking.waitForDeployment();
+
+    await staking.addPool(100, await stakeToken.getAddress());
+    await rewardToken.mint(await staking.getAddress(), ethers.parseEther("100000"));
+    await stakeToken.mint(staker.address, ethers.parseEther("100"));
+  });
+
+  it("allows emergency withdraw with no rewards and updates pool/user accounting", async function () {
+    const amount = ethers.parseEther("100");
+
+    await stakeToken.connect(staker).approve(await staking.getAddress(), amount);
+    await staking.connect(staker).deposit(0, amount);
+
+    await ethers.provider.send("evm_increaseTime", [3600]);
+    await ethers.provider.send("evm_mine", []);
+
+    const rewardBefore = await rewardToken.balanceOf(staker.address);
+    await expect(staking.connect(staker).emergencyWithdraw(0))
+      .to.emit(staking, "EmergencyWithdraw")
+      .withArgs(staker.address, 0, amount);
+
+    const rewardAfter = await rewardToken.balanceOf(staker.address);
+    expect(rewardAfter).to.equal(rewardBefore);
+
+    const user = await staking.userInfo(0, staker.address);
+    expect(user.amount).to.equal(0n);
+    expect(user.rewardDebt).to.equal(0n);
+
+    const pool = await staking.poolInfo(0);
+    expect(pool.totalStaked).to.equal(0n);
+    expect(await stakeToken.balanceOf(staker.address)).to.equal(amount);
+  });
+
+  it("reverts emergency withdraw when user has no staked amount", async function () {
+    await expect(staking.connect(staker).emergencyWithdraw(0)).to.be.revertedWith(
+      "MultiStaking: no staked amount"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add EmergencyWithdraw event and emergencyWithdraw(uint256 pid) to MultiTokenStaking
- emergency path returns staked tokens without transferring rewards
- reset user amount/rewardDebt and decrement pool totalStaked
- add focused test for normal stake then emergency withdraw and no-stake revert
- add contributor record in CONTRIBUTORS.json

## Verification
- npx hardhat test test\\MultiTokenStakingEmergencyWithdraw.test.js --config hardhat.issue195.isolated.config.js
  - result: 2 passing

Closes #195
/claim #195
