### PR TITLE
[API] Validate agent endpoint URL format and reachability

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,36 +1,123 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
+import ipaddress
+import socket
 from datetime import datetime
+from typing import Optional
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import AnyHttpUrl, BaseModel, TypeAdapter, ValidationError
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+_ENDPOINT_URL_ADAPTER = TypeAdapter(AnyHttpUrl)
+_ENDPOINT_TIMEOUT_SECONDS = 5.0
 
 
 class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
     description: Optional[str] = None
     model_type: str = "gpt-4"
+    endpoint: Optional[str] = None
     config: Optional[dict] = None
 
 
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    endpoint: Optional[str] = None
     config: Optional[dict] = None
+
+
+def _is_private_or_internal_host(hostname: str) -> bool:
+    normalized = hostname.strip("[]").lower()
+    if normalized == "localhost":
+        return True
+
+    try:
+        ip = ipaddress.ip_address(normalized)
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(normalized, None)
+        except socket.gaierror:
+            return False
+
+        for entry in resolved:
+            resolved_ip = ipaddress.ip_address(entry[4][0])
+            if (
+                resolved_ip.is_private
+                or resolved_ip.is_loopback
+                or resolved_ip.is_link_local
+                or resolved_ip.is_reserved
+                or resolved_ip.is_multicast
+                or resolved_ip.is_unspecified
+            ):
+                return True
+        return False
+
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+async def _verify_endpoint_reachable(url: str) -> None:
+    try:
+        async with httpx.AsyncClient(
+            timeout=_ENDPOINT_TIMEOUT_SECONDS, follow_redirects=True
+        ) as client:
+            await client.head(url)
+    except httpx.TimeoutException as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Endpoint URL timed out after {_ENDPOINT_TIMEOUT_SECONDS:.0f} seconds.",
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=400, detail=f"Endpoint URL is not reachable: {exc}") from exc
+
+
+async def _validate_endpoint(endpoint: str) -> str:
+    try:
+        normalized = str(_ENDPOINT_URL_ADAPTER.validate_python(endpoint))
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid endpoint URL format. Use a valid http:// or https:// URL.",
+        ) from exc
+
+    parsed = urlparse(normalized)
+    if not parsed.hostname:
+        raise HTTPException(status_code=400, detail="Invalid endpoint URL format. Missing hostname.")
+
+    if _is_private_or_internal_host(parsed.hostname):
+        raise HTTPException(
+            status_code=400,
+            detail="Endpoint URL must not target private or internal IP addresses.",
+        )
+
+    await _verify_endpoint_reachable(normalized)
+    return normalized
 
 
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    config = dict(agent.config or {})
+    if agent.endpoint:
+        config["endpoint"] = await _validate_endpoint(agent.endpoint)
+
     new_agent = Agent(
         name=agent.name,
         description=agent.description,
         model_type=agent.model_type,
-        config=agent.config or {},
+        config=config,
         owner_id=user["id"],
         created_at=datetime.utcnow(),
     )
@@ -71,7 +158,15 @@ async def update_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.owner_id != user["id"]:
         raise HTTPException(status_code=403, detail="Not the owner")
-    for field, value in update.dict(exclude_unset=True).items():
+
+    update_data = update.dict(exclude_unset=True)
+    endpoint = update_data.pop("endpoint", None)
+    if endpoint:
+        config = dict(agent.config or {})
+        config["endpoint"] = await _validate_endpoint(endpoint)
+        agent.config = config
+
+    for field, value in update_data.items():
         setattr(agent, field, value)
     db.commit()
     return agent

--- a/api/tests/test_agents_endpoint_validation.py
+++ b/api/tests/test_agents_endpoint_validation.py
@@ -1,0 +1,72 @@
+import asyncio
+import os
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.routes import agents
+
+
+def test_validate_endpoint_valid_url(monkeypatch):
+    seen = {}
+
+    async def fake_verify(url: str) -> None:
+        seen["url"] = url
+
+    monkeypatch.setattr(agents, "_verify_endpoint_reachable", fake_verify)
+
+    validated = asyncio.run(agents._validate_endpoint("https://example.com/agent"))
+    assert validated == "https://example.com/agent"
+    assert seen["url"] == validated
+
+
+def test_validate_endpoint_invalid_format(monkeypatch):
+    async def fail_if_called(_: str) -> None:
+        raise AssertionError("reachability check should not run for invalid URL format")
+
+    monkeypatch.setattr(agents, "_verify_endpoint_reachable", fail_if_called)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(agents._validate_endpoint("not-a-url"))
+
+    assert exc.value.status_code == 400
+    assert "Invalid endpoint URL format" in exc.value.detail
+
+
+def test_validate_endpoint_blocks_private_ip(monkeypatch):
+    async def fail_if_called(_: str) -> None:
+        raise AssertionError("reachability check should not run for private IP URL")
+
+    monkeypatch.setattr(agents, "_verify_endpoint_reachable", fail_if_called)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(agents._validate_endpoint("http://127.0.0.1:8080/agent"))
+
+    assert exc.value.status_code == 400
+    assert "private or internal IP" in exc.value.detail
+
+
+def test_verify_endpoint_reachable_timeout(monkeypatch):
+    class TimeoutClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def head(self, *_args, **_kwargs):
+            raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(agents.httpx, "AsyncClient", TimeoutClient)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(agents._verify_endpoint_reachable("https://example.com/agent"))
+
+    assert exc.value.status_code == 400
+    assert "timed out after 5 seconds" in exc.value.detail


### PR DESCRIPTION
## Summary
- add optional `endpoint` input support in `AgentCreate`/`AgentUpdate` while preserving existing payload compatibility
- validate endpoint format as `http/https`, block private/internal IP targets, and verify reachability with `HEAD` + 5s timeout
- persist validated endpoint into `agent.config["endpoint"]`
- add focused tests for valid URL, invalid format, private IP rejection, and timeout handling

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`
- `PYTHONPATH=F:\jiedan\OpenAgents-187`
- `pytest api/tests/test_agents_endpoint_validation.py -q`
- result: `4 passed`

Closes #187
/claim #187
