### PR TITLE
[API] Add OpenAPI auth schema docs and error response coverage

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,9 @@
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Any, Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.openapi.utils import get_openapi
+from pydantic import BaseModel, ConfigDict, Field
 
 app = FastAPI(
     title="OpenAgents API",
@@ -11,32 +13,160 @@ app = FastAPI(
 
 
 class AgentResponse(BaseModel):
-    agent_id: str
-    name: str
-    owner: str
-    endpoint: str
-    reputation: int
-    tasks_completed: int
-    registered_at: datetime
-    active: bool
+    agent_id: str = Field(..., examples=["agent_0xabc123"])
+    name: str = Field(..., examples=["Arbitrage Scout"])
+    owner: str = Field(..., examples=["0x9fBf2fD2e772e4F886e0B8C7b4F9d9A7fE5a2f33"])
+    endpoint: str = Field(..., examples=["https://agent.example.com/v1/infer"])
+    reputation: int = Field(..., examples=[97])
+    tasks_completed: int = Field(..., examples=[42])
+    registered_at: datetime = Field(..., examples=["2026-05-01T12:00:00Z"])
+    active: bool = Field(..., examples=[True])
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "agent_id": "agent_0xabc123",
+                "name": "Arbitrage Scout",
+                "owner": "0x9fBf2fD2e772e4F886e0B8C7b4F9d9A7fE5a2f33",
+                "endpoint": "https://agent.example.com/v1/infer",
+                "reputation": 97,
+                "tasks_completed": 42,
+                "registered_at": "2026-05-01T12:00:00Z",
+                "active": True,
+            }
+        }
+    )
 
 
 class TaskResponse(BaseModel):
-    task_id: int
-    creator: str
-    description: str
-    reward_wei: str
-    deadline: datetime
-    status: str
-    assigned_agent: Optional[str] = None
+    task_id: int = Field(..., examples=[101])
+    creator: str = Field(..., examples=["0xaD53bA7F218c5271d2A991267F35c9B86A1D0f1A"])
+    description: str = Field(..., examples=["Find best route for ETH/USDC swap"])
+    reward_wei: str = Field(..., examples=["250000000000000000"])
+    deadline: datetime = Field(..., examples=["2026-06-15T18:30:00Z"])
+    status: str = Field(..., examples=["open"])
+    assigned_agent: Optional[str] = Field(default=None, examples=["agent_0xabc123"])
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "task_id": 101,
+                "creator": "0xaD53bA7F218c5271d2A991267F35c9B86A1D0f1A",
+                "description": "Find best route for ETH/USDC swap",
+                "reward_wei": "250000000000000000",
+                "deadline": "2026-06-15T18:30:00Z",
+                "status": "open",
+                "assigned_agent": "agent_0xabc123",
+            }
+        }
+    )
 
 
 class LeaderboardEntry(BaseModel):
-    agent_id: str
-    name: str
-    reputation: int
-    tasks_completed: int
-    success_rate: float
+    agent_id: str = Field(..., examples=["agent_0xabc123"])
+    name: str = Field(..., examples=["Arbitrage Scout"])
+    reputation: int = Field(..., examples=[97])
+    tasks_completed: int = Field(..., examples=[42])
+    success_rate: float = Field(..., examples=[0.9767])
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "agent_id": "agent_0xabc123",
+                "name": "Arbitrage Scout",
+                "reputation": 97,
+                "tasks_completed": 42,
+                "success_rate": 0.9767,
+            }
+        }
+    )
+
+
+class ErrorResponse(BaseModel):
+    code: str = Field(..., examples=["unauthorized"])
+    message: str = Field(..., examples=["Missing or invalid authentication credentials"])
+    details: Optional[str] = Field(default=None, examples=["Provide Bearer token or X-API-Key"])
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "code": "unauthorized",
+                "message": "Missing or invalid authentication credentials",
+                "details": "Provide Bearer token or X-API-Key",
+            }
+        }
+    )
+
+
+class HealthResponse(BaseModel):
+    status: str = Field(..., examples=["ok"])
+    agents_indexed: int = Field(..., examples=[3])
+    tasks_indexed: int = Field(..., examples=[7])
+    timestamp: str = Field(..., examples=["2026-05-31T04:00:00Z"])
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": "ok",
+                "agents_indexed": 3,
+                "tasks_indexed": 7,
+                "timestamp": "2026-05-31T04:00:00Z",
+            }
+        }
+    )
+
+
+SECURITY_REQUIREMENTS = [{"BearerAuth": []}, {"ApiKeyAuth": []}]
+
+
+def _error_response(code: str, message: str, details: Optional[str] = None) -> dict[str, Any]:
+    return {
+        "model": ErrorResponse,
+        "content": {
+            "application/json": {
+                "example": {"code": code, "message": message, "details": details}
+            }
+        },
+    }
+
+
+COMMON_ERROR_RESPONSES = {
+    400: _error_response("bad_request", "Invalid query parameters"),
+    401: _error_response(
+        "unauthorized",
+        "Missing or invalid authentication credentials",
+        "Provide Bearer token or X-API-Key",
+    ),
+    403: _error_response("forbidden", "Authenticated but not allowed to access this resource"),
+    404: _error_response("not_found", "Resource not found"),
+    429: _error_response("rate_limited", "Too many requests. Retry later"),
+}
+
+
+def custom_openapi() -> dict[str, Any]:
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+    )
+    components = openapi_schema.setdefault("components", {})
+    security_schemes = components.setdefault("securitySchemes", {})
+    security_schemes["BearerAuth"] = {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT bearer token. Format: 'Authorization: Bearer <token>'.",
+    }
+    security_schemes["ApiKeyAuth"] = {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "API key header for machine-to-machine access.",
+    }
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 
 # In-memory store (placeholder for DB)
@@ -44,12 +174,17 @@ agents_cache: dict = {}
 tasks_cache: dict = {}
 
 
-@app.get("/agents", response_model=list[AgentResponse])
+@app.get(
+    "/agents",
+    response_model=list[AgentResponse],
+    responses=COMMON_ERROR_RESPONSES,
+    openapi_extra={"security": SECURITY_REQUIREMENTS},
+)
 async def list_agents(
-    active_only: bool = Query(True),
-    min_reputation: int = Query(0),
-    limit: int = Query(50, le=100),
-    offset: int = Query(0),
+    active_only: bool = Query(True, examples=[True]),
+    min_reputation: int = Query(0, examples=[10]),
+    limit: int = Query(50, le=100, examples=[25]),
+    offset: int = Query(0, examples=[0]),
 ):
     results = list(agents_cache.values())
     if active_only:
@@ -58,18 +193,28 @@ async def list_agents(
     return results[offset : offset + limit]
 
 
-@app.get("/agents/{agent_id}", response_model=AgentResponse)
+@app.get(
+    "/agents/{agent_id}",
+    response_model=AgentResponse,
+    responses=COMMON_ERROR_RESPONSES,
+    openapi_extra={"security": SECURITY_REQUIREMENTS},
+)
 async def get_agent(agent_id: str):
     if agent_id not in agents_cache:
         raise HTTPException(status_code=404, detail="Agent not found")
     return agents_cache[agent_id]
 
 
-@app.get("/tasks", response_model=list[TaskResponse])
+@app.get(
+    "/tasks",
+    response_model=list[TaskResponse],
+    responses=COMMON_ERROR_RESPONSES,
+    openapi_extra={"security": SECURITY_REQUIREMENTS},
+)
 async def list_tasks(
-    status: Optional[str] = Query(None),
-    limit: int = Query(50, le=100),
-    offset: int = Query(0),
+    status: Optional[str] = Query(None, examples=["open"]),
+    limit: int = Query(50, le=100, examples=[25]),
+    offset: int = Query(0, examples=[0]),
 ):
     results = list(tasks_cache.values())
     if status:
@@ -77,15 +222,25 @@ async def list_tasks(
     return results[offset : offset + limit]
 
 
-@app.get("/tasks/{task_id}", response_model=TaskResponse)
+@app.get(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    responses=COMMON_ERROR_RESPONSES,
+    openapi_extra={"security": SECURITY_REQUIREMENTS},
+)
 async def get_task(task_id: int):
     if task_id not in tasks_cache:
         raise HTTPException(status_code=404, detail="Task not found")
     return tasks_cache[task_id]
 
 
-@app.get("/leaderboard", response_model=list[LeaderboardEntry])
-async def leaderboard(limit: int = Query(20, le=50)):
+@app.get(
+    "/leaderboard",
+    response_model=list[LeaderboardEntry],
+    responses=COMMON_ERROR_RESPONSES,
+    openapi_extra={"security": SECURITY_REQUIREMENTS},
+)
+async def leaderboard(limit: int = Query(20, le=50, examples=[20])):
     entries = []
     for agent in agents_cache.values():
         completed = agent.get("tasks_completed", 0)
@@ -102,7 +257,7 @@ async def leaderboard(limit: int = Query(20, le=50)):
     return entries[:limit]
 
 
-@app.get("/health")
+@app.get("/health", response_model=HealthResponse)
 async def health():
     return {
         "status": "ok",

--- a/api/tests/test_openapi_schema.py
+++ b/api/tests/test_openapi_schema.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+PROTECTED_ROUTES = [
+    "/agents",
+    "/agents/{agent_id}",
+    "/tasks",
+    "/tasks/{task_id}",
+    "/leaderboard",
+]
+
+EXPECTED_SECURITY = [{"BearerAuth": []}, {"ApiKeyAuth": []}]
+EXPECTED_ERROR_CODES = {"400", "401", "403", "404", "429"}
+
+
+def test_openapi_includes_security_schemes():
+    schema = client.get("/openapi.json").json()
+    security_schemes = schema["components"]["securitySchemes"]
+
+    assert "BearerAuth" in security_schemes
+    assert "ApiKeyAuth" in security_schemes
+    assert security_schemes["BearerAuth"]["type"] == "http"
+    assert security_schemes["ApiKeyAuth"]["type"] == "apiKey"
+
+
+def test_protected_routes_have_security_and_error_responses():
+    schema = client.get("/openapi.json").json()
+
+    for route in PROTECTED_ROUTES:
+        operation = schema["paths"][route]["get"]
+        assert operation["security"] == EXPECTED_SECURITY
+        assert EXPECTED_ERROR_CODES.issubset(operation["responses"].keys())
+        for code in EXPECTED_ERROR_CODES:
+            response_schema = operation["responses"][code]["content"]["application/json"]["schema"]
+            assert response_schema["$ref"].endswith("/ErrorResponse")
+
+
+def test_openapi_models_include_examples():
+    schema = client.get("/openapi.json").json()
+    components = schema["components"]["schemas"]
+
+    for model_name in [
+        "AgentResponse",
+        "TaskResponse",
+        "LeaderboardEntry",
+        "ErrorResponse",
+        "HealthResponse",
+    ]:
+        assert "example" in components[model_name]
+


### PR DESCRIPTION
## Summary
- add custom OpenAPI schema generation with two auth schemes: JWT bearer and X-API-Key
- document security requirements on protected endpoints (/agents, /agents/{agent_id}, /tasks, /tasks/{task_id}, /leaderboard)
- add standardized error response schemas (400/401/403/404/429) and model examples
- add schema-focused tests for security schemes, endpoint security docs, and examples

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_openapi_schema.py -q
- result: 3 passed

Closes #185
/claim #185