### PR TITLE
Fix PrizeSplit handling for non-payable contract winners

### DIFF
--- a/contracts/lottery/PrizeSplit.sol
+++ b/contracts/lottery/PrizeSplit.sol
@@ -5,7 +5,10 @@ pragma solidity ^0.8.20;
 /// @notice Distributes prize pool among multiple winners with configurable shares
 /// @dev Winners claim their share after the admin finalizes the round
 contract PrizeSplit {
+    uint256 public constant CLAIM_WINDOW = 90 days;
+
     address public admin;
+    address payable public treasury;
     uint256 public totalPrize;
     uint256 public roundId;
 
@@ -13,6 +16,9 @@ contract PrizeSplit {
         address[] winners;
         uint256 prizePool;
         bool finalized;
+        uint256 claimDeadline;
+        uint256 claimedAmount;
+        bool reclaimed;
         mapping(address => uint256) shares;
         mapping(address => bool) claimed;
     }
@@ -22,6 +28,7 @@ contract PrizeSplit {
     event RoundFunded(uint256 indexed roundId, uint256 amount);
     event RoundFinalized(uint256 indexed roundId, uint256 winnerCount);
     event PrizeClaimed(address indexed winner, uint256 amount, uint256 indexed roundId);
+    event UnclaimedReclaimed(uint256 indexed roundId, uint256 amount, address indexed treasury);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -30,6 +37,7 @@ contract PrizeSplit {
 
     constructor() {
         admin = msg.sender;
+        treasury = payable(msg.sender);
     }
 
     function fundRound() external payable onlyAdmin {
@@ -55,25 +63,53 @@ contract PrizeSplit {
             round.shares[winners[i]] = sharePerWinner;
         }
 
+        round.claimDeadline = block.timestamp + CLAIM_WINDOW;
         round.finalized = true;
         emit RoundFinalized(_roundId, winners.length);
     }
 
-    // BUG: Reentrancy — state (claimed flag) is set after the external call,
-    // allowing a malicious contract to re-enter claimPrize and drain funds
     function claimPrize(uint256 _roundId) external {
+        _claimPrize(_roundId, payable(msg.sender));
+    }
+
+    function claimPrizeTo(uint256 _roundId, address payable recipient) external {
+        _claimPrize(_roundId, recipient);
+    }
+
+    function reclaimUnclaimed(uint256 _roundId) external onlyAdmin {
         Round storage round = rounds[_roundId];
         require(round.finalized, "Not finalized");
+        require(block.timestamp > round.claimDeadline, "Claim period active");
+        require(!round.reclaimed, "Already reclaimed");
+
+        uint256 amount = round.prizePool - round.claimedAmount;
+        round.reclaimed = true;
+
+        (bool sent, ) = treasury.call{value: amount}("");
+        require(sent, "Treasury transfer failed");
+
+        emit UnclaimedReclaimed(_roundId, amount, treasury);
+    }
+
+    function getClaimDeadline(uint256 _roundId) external view returns (uint256) {
+        return rounds[_roundId].claimDeadline;
+    }
+
+    function _claimPrize(uint256 _roundId, address payable recipient) internal {
+        Round storage round = rounds[_roundId];
+        require(round.finalized, "Not finalized");
+        require(block.timestamp <= round.claimDeadline, "Claim period over");
         require(round.shares[msg.sender] > 0, "No share");
         require(!round.claimed[msg.sender], "Already claimed");
+        require(recipient != address(0), "Invalid recipient");
 
         uint256 amount = round.shares[msg.sender];
 
-        (bool sent, ) = msg.sender.call{value: amount}("");
-        require(sent, "Transfer failed");
-
-        // State updated after external call — reentrancy window
         round.claimed[msg.sender] = true;
+        round.claimedAmount += amount;
+
+        (bool sent, ) = recipient.call{value: amount}("");
+        require(sent, "Transfer failed");
 
         emit PrizeClaimed(msg.sender, amount, _roundId);
     }

--- a/contracts/lottery/test/NonPayableWinner.sol
+++ b/contracts/lottery/test/NonPayableWinner.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IPrizeSplit {
+    function claimPrizeTo(uint256 _roundId, address payable recipient) external;
+}
+
+contract NonPayableWinner {
+    function claimTo(address prizeSplit, uint256 roundId, address payable recipient) external {
+        IPrizeSplit(prizeSplit).claimPrizeTo(roundId, recipient);
+    }
+}

--- a/test/PrizeSplit.issue189.test.js
+++ b/test/PrizeSplit.issue189.test.js
@@ -1,0 +1,80 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+describe("PrizeSplit issue #189", function () {
+  const NINETY_DAYS = 90 * 24 * 60 * 60;
+  const ROUND_ID = 1;
+
+  let admin;
+  let eoaWinner;
+  let altRecipient;
+  let otherWinner;
+  let prizeSplit;
+  let nonPayableWinner;
+
+  beforeEach(async function () {
+    [admin, eoaWinner, altRecipient, otherWinner] = await ethers.getSigners();
+
+    const PrizeSplit = await ethers.getContractFactory("PrizeSplit");
+    prizeSplit = await PrizeSplit.deploy();
+    await prizeSplit.waitForDeployment();
+
+    const NonPayableWinner = await ethers.getContractFactory("NonPayableWinner");
+    nonPayableWinner = await NonPayableWinner.deploy();
+    await nonPayableWinner.waitForDeployment();
+  });
+
+  async function setupRoundWithTwoWinners() {
+    const prizePool = ethers.parseEther("1");
+    const nonPayableWinnerAddress = await nonPayableWinner.getAddress();
+    await prizeSplit.fundRound({ value: prizePool });
+    await prizeSplit.finalizeRound(ROUND_ID, [nonPayableWinnerAddress, eoaWinner.address]);
+    return { prizePool, share: prizePool / 2n };
+  }
+
+  it("allows a non-payable contract winner to claim to an alternate recipient", async function () {
+    const { share } = await setupRoundWithTwoWinners();
+
+    await prizeSplit.connect(eoaWinner).claimPrize(ROUND_ID);
+    expect(await prizeSplit.isClaimed(ROUND_ID, eoaWinner.address)).to.equal(true);
+
+    const before = await ethers.provider.getBalance(altRecipient.address);
+    await nonPayableWinner.claimTo(await prizeSplit.getAddress(), ROUND_ID, altRecipient.address);
+    const after = await ethers.provider.getBalance(altRecipient.address);
+
+    expect(after - before).to.equal(share);
+    expect(await prizeSplit.isClaimed(ROUND_ID, await nonPayableWinner.getAddress())).to.equal(true);
+  });
+
+  it("enforces a 90-day claim deadline", async function () {
+    await setupRoundWithTwoWinners();
+
+    await network.provider.send("evm_increaseTime", [NINETY_DAYS + 1]);
+    await network.provider.send("evm_mine");
+
+    await expect(prizeSplit.connect(eoaWinner).claimPrize(ROUND_ID)).to.be.revertedWith(
+      "Claim period over"
+    );
+  });
+
+  it("allows treasury reclaim of unclaimed prizes after the deadline", async function () {
+    const prizePool = ethers.parseEther("3");
+    await prizeSplit.fundRound({ value: prizePool });
+    await prizeSplit.finalizeRound(ROUND_ID, [eoaWinner.address, otherWinner.address]);
+
+    const share = prizePool / 2n;
+    await prizeSplit.connect(eoaWinner).claimPrize(ROUND_ID);
+
+    await network.provider.send("evm_increaseTime", [NINETY_DAYS + 1]);
+    await network.provider.send("evm_mine");
+
+    const before = await ethers.provider.getBalance(admin.address);
+    const tx = await prizeSplit.reclaimUnclaimed(ROUND_ID);
+    const receipt = await tx.wait();
+    const gas = receipt.gasUsed * receipt.gasPrice;
+    const after = await ethers.provider.getBalance(admin.address);
+
+    expect(after + gas - before).to.equal(share);
+    expect(await ethers.provider.getBalance(await prizeSplit.getAddress())).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add claimPrizeTo(roundId, recipient) so a winner contract without eceive/fallback can redirect payout to a payable recipient
- keep winner-by-winner pull claims and ensure one winner failure does not block other winners
- add a 90-day claim deadline per finalized round
- add eclaimUnclaimed(roundId) to move expired, unclaimed funds to treasury
- add focused tests for contract-winner claim redirection, claim deadline, and treasury reclaim

## Verification
- 
px hardhat test test/PrizeSplit.issue189.test.js --config hardhat.issue189.config.js
- Result: 3 passing (using a temporary local hardhat.issue189.config.js scoped to contracts/lottery, not committed)

Closes #189
/claim #189