### PR TITLE
[API] Structured error responses with error codes and request_id (fix #202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ cd api && pip install -r requirements.txt && uvicorn main:app
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## API Error Contract
+
+All API error responses follow:
+
+```json
+{
+  "code": "VALIDATION_ERROR|NOT_FOUND|AUTH_FAILED|RATE_LIMITED|INTERNAL_ERROR",
+  "message": "string",
+  "details": {},
+  "request_id": "string"
+}
+```

--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,18 @@
-from fastapi import FastAPI, HTTPException, Query
+from uuid import uuid4
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
 app = FastAPI(
     title="OpenAgents API",
-    description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
+    description=(
+        "Off-chain indexer and agent discovery API for the OpenAgents protocol.\n\n"
+        "Error codes: VALIDATION_ERROR, NOT_FOUND, AUTH_FAILED, RATE_LIMITED, INTERNAL_ERROR."
+    ),
     version="0.1.0",
 )
 
@@ -42,6 +49,103 @@ class LeaderboardEntry(BaseModel):
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+
+ERROR_CODE_MAP = {
+    401: "AUTH_FAILED",
+    403: "AUTH_FAILED",
+    404: "NOT_FOUND",
+    422: "VALIDATION_ERROR",
+    429: "RATE_LIMITED",
+}
+
+
+def _get_request_id(request: Request) -> str:
+    request_id = getattr(request.state, "request_id", None)
+    if request_id:
+        return request_id
+    return str(uuid4())
+
+
+def _error_response(
+    request: Request,
+    status_code: int,
+    message: str,
+    details: dict,
+) -> JSONResponse:
+    request_id = _get_request_id(request)
+    payload = {
+        "code": ERROR_CODE_MAP.get(status_code, "INTERNAL_ERROR"),
+        "message": message,
+        "details": details,
+        "request_id": request_id,
+    }
+    return JSONResponse(
+        status_code=status_code,
+        content=payload,
+        headers={"X-Request-ID": request_id},
+    )
+
+
+@app.middleware("http")
+async def add_request_id(request: Request, call_next):
+    request_id = request.headers.get("X-Request-ID") or str(uuid4())
+    request.state.request_id = request_id
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    fields = []
+    for err in exc.errors():
+        loc = [str(part) for part in err.get("loc", []) if part != "body"]
+        fields.append(
+            {
+                "field": ".".join(loc) if loc else "unknown",
+                "message": err.get("msg", "Invalid value"),
+                "type": err.get("type", "validation_error"),
+            }
+        )
+    return _error_response(
+        request=request,
+        status_code=422,
+        message="Request validation failed",
+        details={"fields": fields},
+    )
+
+
+@app.exception_handler(HTTPException)
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(
+    request: Request, exc: HTTPException | StarletteHTTPException
+):
+    detail = exc.detail
+    if isinstance(detail, str):
+        message = detail
+        details = {}
+    elif isinstance(detail, dict):
+        message = str(detail.get("message", "Request failed"))
+        details = detail
+    else:
+        message = "Request failed"
+        details = {"error": detail}
+    return _error_response(
+        request=request,
+        status_code=exc.status_code,
+        message=message,
+        details=details,
+    )
+
+
+@app.exception_handler(Exception)
+async def internal_exception_handler(request: Request, exc: Exception):
+    return _error_response(
+        request=request,
+        status_code=500,
+        message="Internal server error",
+        details={"error": "unhandled_exception"},
+    )
 
 
 @app.get("/agents", response_model=list[AgentResponse])

--- a/api/tests/test_error_responses.py
+++ b/api/tests/test_error_responses.py
@@ -1,0 +1,82 @@
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+def _ensure_test_routes() -> None:
+    route_paths = {route.path for route in app.routes}
+
+    if "/_test/auth-failed" not in route_paths:
+        @app.get("/_test/auth-failed")
+        async def auth_failed():
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+    if "/_test/rate-limited" not in route_paths:
+        @app.get("/_test/rate-limited")
+        async def rate_limited():
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    if "/_test/internal-error" not in route_paths:
+        @app.get("/_test/internal-error")
+        async def internal_error():
+            raise RuntimeError("boom")
+
+
+_ensure_test_routes()
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def assert_error_schema(payload: dict, expected_code: str) -> None:
+    assert payload["code"] == expected_code
+    assert isinstance(payload["message"], str)
+    assert isinstance(payload["details"], dict)
+    assert isinstance(payload["request_id"], str)
+    assert payload["request_id"]
+
+
+def test_validation_error_has_field_level_details():
+    response = client.get("/agents", params={"limit": 101})
+
+    assert response.status_code == 422
+    data = response.json()
+    assert_error_schema(data, "VALIDATION_ERROR")
+    assert isinstance(data["details"].get("fields"), list)
+    assert any(field["field"].endswith("limit") for field in data["details"]["fields"])
+    assert response.headers["X-Request-ID"] == data["request_id"]
+
+
+def test_not_found_error_schema():
+    response = client.get("/agents/missing-agent")
+
+    assert response.status_code == 404
+    data = response.json()
+    assert_error_schema(data, "NOT_FOUND")
+    assert response.headers["X-Request-ID"] == data["request_id"]
+
+
+def test_auth_failed_error_schema():
+    response = client.get("/_test/auth-failed")
+
+    assert response.status_code == 401
+    data = response.json()
+    assert_error_schema(data, "AUTH_FAILED")
+    assert response.headers["X-Request-ID"] == data["request_id"]
+
+
+def test_rate_limited_error_schema():
+    response = client.get("/_test/rate-limited")
+
+    assert response.status_code == 429
+    data = response.json()
+    assert_error_schema(data, "RATE_LIMITED")
+    assert response.headers["X-Request-ID"] == data["request_id"]
+
+
+def test_internal_error_schema():
+    response = client.get("/_test/internal-error")
+
+    assert response.status_code == 500
+    data = response.json()
+    assert_error_schema(data, "INTERNAL_ERROR")
+    assert response.headers["X-Request-ID"] == data["request_id"]


### PR DESCRIPTION
## Summary
- add centralized FastAPI exception handling with a single error schema
- map API failures to fixed error codes: VALIDATION_ERROR, NOT_FOUND, AUTH_FAILED, RATE_LIMITED, INTERNAL_ERROR
- include request_id in every error payload and X-Request-ID header
- add focused API tests for all error codes and validation field details
- document the error response contract in README

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_error_responses.py -q

Closes #202
/claim #202