### PR TITLE
[Solidity] Add secure gas sponsorship relay for agent task actions

### DIFF
--- a/contracts/TaskRouter.sol
+++ b/contracts/TaskRouter.sol
@@ -5,6 +5,9 @@ import "./AgentRegistry.sol";
 
 contract TaskRouter {
     AgentRegistry public registry;
+    uint256 private constant MIN_GAS_OVERHEAD = 40_000;
+    uint256 private constant SECP256K1N_HALF =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
 
     enum TaskStatus { Open, Assigned, Completed, Disputed, Cancelled }
 
@@ -21,11 +24,17 @@ contract TaskRouter {
     mapping(uint256 => Task) public tasks;
     uint256 public taskCount;
     uint256 public platformFee; // basis points
+    mapping(address => uint256) public gasStake;
+    mapping(address => uint256) public nonces;
+    address private _relayedSender;
 
     event TaskCreated(uint256 indexed taskId, address indexed creator, uint256 reward);
     event TaskAssigned(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskCompleted(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskDisputed(uint256 indexed taskId);
+    event GasStakeDeposited(address indexed agent, uint256 amount);
+    event GasStakeWithdrawn(address indexed agent, uint256 amount);
+    event RelayedExecution(address indexed relayer, address indexed agent, uint256 nonce, uint256 reimbursement);
 
     constructor(address _registry, uint256 _platformFee) {
         registry = AgentRegistry(_registry);
@@ -58,7 +67,7 @@ contract TaskRouter {
 
         AgentRegistry.Agent memory agent = registry.getAgent(agentId);
         require(agent.active, "Agent not active");
-        require(agent.owner == msg.sender, "Not agent owner");
+        require(agent.owner == _msgSender(), "Not agent owner");
 
         task.assignedAgent = agentId;
         task.status = TaskStatus.Assigned;
@@ -71,7 +80,7 @@ contract TaskRouter {
         require(task.status == TaskStatus.Assigned, "Not assigned");
 
         AgentRegistry.Agent memory agent = registry.getAgent(task.assignedAgent);
-        require(agent.owner == msg.sender, "Not assigned agent owner");
+        require(agent.owner == _msgSender(), "Not assigned agent owner");
 
         task.result = result;
         task.status = TaskStatus.Completed;
@@ -79,7 +88,7 @@ contract TaskRouter {
         uint256 fee = task.reward * platformFee / 10000;
         uint256 payout = task.reward - fee;
 
-        (bool success, ) = msg.sender.call{value: payout}("");
+        (bool success, ) = _msgSender().call{value: payout}("");
         require(success, "Payout failed");
 
         emit TaskCompleted(taskId, task.assignedAgent);
@@ -103,5 +112,120 @@ contract TaskRouter {
 
         task.status = TaskStatus.Disputed;
         emit TaskDisputed(taskId);
+    }
+
+    function stakeForGas() external payable {
+        require(msg.value > 0, "Stake required");
+        gasStake[msg.sender] += msg.value;
+        emit GasStakeDeposited(msg.sender, msg.value);
+    }
+
+    function withdrawGasStake(uint256 amount) external {
+        require(amount > 0, "Amount required");
+        uint256 currentStake = gasStake[msg.sender];
+        require(currentStake >= amount, "Insufficient gas stake");
+
+        gasStake[msg.sender] = currentStake - amount;
+        (bool success, ) = msg.sender.call{value: amount}("");
+        require(success, "Withdraw failed");
+
+        emit GasStakeWithdrawn(msg.sender, amount);
+    }
+
+    function executeOnBehalf(address agent, bytes calldata callData, bytes calldata signature) external {
+        require(agent != address(0), "Invalid agent");
+        require(callData.length >= 4, "Invalid calldata");
+        require(_relayedSender == address(0), "Relay in progress");
+
+        bytes4 selector = _selectorFromCalldata(callData);
+        require(selector == this.assignTask.selector || selector == this.completeTask.selector, "Relay selector not allowed");
+
+        uint256 nonce = nonces[agent];
+        _validateRelaySignature(agent, nonce, callData, signature);
+
+        uint256 gasAtStart = gasleft();
+        nonces[agent] = nonce + 1;
+        _executeRelayedCall(agent, callData);
+
+        uint256 reimbursement = _reimburseRelayer(agent, gasAtStart);
+
+        emit RelayedExecution(msg.sender, agent, nonce, reimbursement);
+    }
+
+    function _msgSender() internal view returns (address) {
+        if (msg.sender == address(this) && _relayedSender != address(0)) {
+            return _relayedSender;
+        }
+        return msg.sender;
+    }
+
+    function _recoverSigner(bytes32 digest, bytes calldata signature) internal pure returns (address) {
+        require(signature.length == 65, "Invalid signature length");
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+
+        require(uint256(s) <= SECP256K1N_HALF, "Invalid s");
+        require(v == 27 || v == 28, "Invalid v");
+
+        address signer = ecrecover(digest, v, r, s);
+        require(signer != address(0), "Invalid signer");
+        return signer;
+    }
+
+    function _selectorFromCalldata(bytes calldata callData) internal pure returns (bytes4 selector) {
+        assembly {
+            selector := calldataload(callData.offset)
+        }
+    }
+
+    function _validateRelaySignature(
+        address agent,
+        uint256 nonce,
+        bytes calldata callData,
+        bytes calldata signature
+    ) internal view {
+        bytes32 digest = keccak256(abi.encodePacked(address(this), block.chainid, agent, nonce, keccak256(callData)));
+        bytes32 ethSignedDigest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", digest));
+        address signer = _recoverSigner(ethSignedDigest, signature);
+        require(signer == agent, "Invalid signature");
+    }
+
+    function _executeRelayedCall(address agent, bytes calldata callData) internal {
+        _relayedSender = agent;
+        (bool success, bytes memory returnData) = address(this).call(callData);
+        _relayedSender = address(0);
+
+        if (!success) {
+            _revertWithReason(returnData);
+        }
+    }
+
+    function _reimburseRelayer(address agent, uint256 gasAtStart) internal returns (uint256 reimbursement) {
+        uint256 gasUsed = gasAtStart - gasleft() + MIN_GAS_OVERHEAD;
+        reimbursement = gasUsed * tx.gasprice;
+
+        uint256 stakeBalance = gasStake[agent];
+        require(stakeBalance >= reimbursement, "Insufficient gas stake");
+        gasStake[agent] = stakeBalance - reimbursement;
+
+        (bool paid, ) = msg.sender.call{value: reimbursement}("");
+        require(paid, "Relay reimbursement failed");
+    }
+
+    function _revertWithReason(bytes memory returnData) private pure {
+        if (returnData.length < 68) {
+            revert("Relayed call failed");
+        }
+        assembly {
+            returnData := add(returnData, 0x04)
+        }
+        revert(abi.decode(returnData, (string)));
     }
 }

--- a/test/TaskRouter.relay.test.js
+++ b/test/TaskRouter.relay.test.js
@@ -1,0 +1,162 @@
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+function compileRelayContracts() {
+  const root = path.resolve(__dirname, "..");
+  const sources = {
+    "contracts/TaskRouter.sol": {
+      content: fs.readFileSync(path.join(root, "contracts", "TaskRouter.sol"), "utf8")
+    },
+    "contracts/AgentRegistry.sol": {
+      content: fs.readFileSync(path.join(root, "contracts", "AgentRegistry.sol"), "utf8")
+    },
+    "@openzeppelin/contracts/access/Ownable.sol": {
+      content: fs.readFileSync(
+        path.join(root, "node_modules", "@openzeppelin", "contracts", "access", "Ownable.sol"),
+        "utf8"
+      )
+    },
+    "@openzeppelin/contracts/utils/Context.sol": {
+      content: fs.readFileSync(
+        path.join(root, "node_modules", "@openzeppelin", "contracts", "utils", "Context.sol"),
+        "utf8"
+      )
+    }
+  };
+
+  const input = {
+    language: "Solidity",
+    sources,
+    settings: {
+      optimizer: { enabled: false, runs: 200 },
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"]
+        }
+      }
+    }
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  if (output.errors) {
+    const errors = output.errors.filter((entry) => entry.severity === "error");
+    if (errors.length > 0) {
+      throw new Error(errors.map((entry) => entry.formattedMessage).join("\n"));
+    }
+  }
+
+  return {
+    agentRegistry: output.contracts["contracts/AgentRegistry.sol"].AgentRegistry,
+    taskRouter: output.contracts["contracts/TaskRouter.sol"].TaskRouter
+  };
+}
+
+describe("TaskRouter gas sponsorship relay", function () {
+  let registry;
+  let router;
+  let creator;
+  let agentOwner;
+  let relayer;
+  let agentId;
+
+  async function signRelayCall(signer, callData) {
+    const nonce = await router.nonces(signer.address);
+    const network = await ethers.provider.getNetwork();
+    const digest = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "address", "uint256", "bytes32"],
+      [await router.getAddress(), network.chainId, signer.address, nonce, ethers.keccak256(callData)]
+    );
+    return signer.signMessage(ethers.getBytes(digest));
+  }
+
+  beforeEach(async function () {
+    const [deployer, creatorSigner, agentOwnerSigner, relayerSigner] = await ethers.getSigners();
+    creator = creatorSigner;
+    agentOwner = agentOwnerSigner;
+    relayer = relayerSigner;
+
+    const compiled = compileRelayContracts();
+
+    const AgentRegistryFactory = new ethers.ContractFactory(
+      compiled.agentRegistry.abi,
+      `0x${compiled.agentRegistry.evm.bytecode.object}`,
+      deployer
+    );
+    registry = await AgentRegistryFactory.deploy(0);
+    await registry.waitForDeployment();
+
+    const TaskRouterFactory = new ethers.ContractFactory(
+      compiled.taskRouter.abi,
+      `0x${compiled.taskRouter.evm.bytecode.object}`,
+      deployer
+    );
+    router = await TaskRouterFactory.deploy(await registry.getAddress(), 0);
+    await router.waitForDeployment();
+
+    await registry.connect(agentOwner).registerAgent("agent-1", "https://agent.example");
+    agentId = await registry.ownerAgents(agentOwner.address, 0);
+
+    const latest = await ethers.provider.getBlock("latest");
+    const deadline = latest.timestamp + 3600;
+    await router.connect(creator).createTask("relayable task", deadline, {
+      value: ethers.parseEther("1")
+    });
+  });
+
+  it("sponsored execution: relayer can assign task for agent owner and gets reimbursed", async function () {
+    await router.connect(agentOwner).stakeForGas({ value: ethers.parseEther("0.05") });
+
+    const callData = router.interface.encodeFunctionData("assignTask", [0, agentId]);
+    const signature = await signRelayCall(agentOwner, callData);
+
+    const stakeBefore = await router.gasStake(agentOwner.address);
+    const tx = await router.connect(relayer).executeOnBehalf(agentOwner.address, callData, signature);
+    const receipt = await tx.wait();
+
+    const stakeAfter = await router.gasStake(agentOwner.address);
+    expect(stakeAfter).to.be.lt(stakeBefore);
+
+    const task = await router.tasks(0);
+    expect(task.status).to.equal(1n);
+    expect(task.assignedAgent).to.equal(agentId);
+
+    const relayed = receipt.logs
+      .map((log) => {
+        try {
+          return router.interface.parseLog(log);
+        } catch (error) {
+          return null;
+        }
+      })
+      .find((eventLog) => eventLog && eventLog.name === "RelayedExecution");
+
+    expect(relayed).to.not.equal(undefined);
+    expect(relayed.args.reimbursement).to.be.gt(0n);
+    expect(relayed.args.relayer).to.equal(relayer.address);
+  });
+
+  it("replay prevention: same signature cannot be reused", async function () {
+    await router.connect(agentOwner).stakeForGas({ value: ethers.parseEther("0.05") });
+
+    const callData = router.interface.encodeFunctionData("assignTask", [0, agentId]);
+    const signature = await signRelayCall(agentOwner, callData);
+
+    await router.connect(relayer).executeOnBehalf(agentOwner.address, callData, signature);
+
+    await expect(
+      router.connect(relayer).executeOnBehalf(agentOwner.address, callData, signature)
+    ).to.be.revertedWith("Invalid signature");
+  });
+
+  it("insufficient stake: relay reverts when agent stake cannot cover reimbursement", async function () {
+    const callData = router.interface.encodeFunctionData("assignTask", [0, agentId]);
+    const signature = await signRelayCall(agentOwner, callData);
+
+    await expect(
+      router.connect(relayer).executeOnBehalf(agentOwner.address, callData, signature)
+    ).to.be.revertedWith("Insufficient gas stake");
+  });
+});


### PR DESCRIPTION
## Summary
- add `executeOnBehalf(address agent, bytes calldata callData, bytes calldata signature)` with per-agent nonce replay protection
- verify signatures against the agent address and restrict relay targets to agent task actions (`assignTask`, `completeTask`)
- add gas stake deposit/withdraw and relayer reimbursement from agent gas stake
- add targeted relay tests for sponsored execution, replay prevention, and insufficient stake

## Validation
- `npx hardhat test --no-compile test/TaskRouter.relay.test.js`

Closes #183

/claim #183
