### PR TITLE
[Codex] Add AgentRegistry batch registration for gas-efficient onboarding

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract AgentRegistry is Ownable {
+    uint256 public constant MAX_BATCH_SIZE = 50;
+
     struct Agent {
         address owner;
         string name;
@@ -53,6 +55,45 @@ contract AgentRegistry is Ownable {
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
+    }
+
+    function batchRegister(
+        string[] calldata names,
+        string[] calldata endpoints
+    ) external payable returns (bytes32[] memory registeredIds) {
+        uint256 count = names.length;
+        require(count == endpoints.length, "Length mismatch");
+        require(count > 0 && count <= MAX_BATCH_SIZE, "Invalid batch size");
+
+        uint256 totalFee = registrationFee * count;
+        require(msg.value >= totalFee, "Insufficient fee");
+
+        registeredIds = new bytes32[](count);
+        uint256 timestamp = block.timestamp;
+
+        for (uint256 i = 0; i < count; i++) {
+            string calldata name = names[i];
+            require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
+
+            bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, timestamp, i));
+            require(agents[agentId].registeredAt == 0, "Agent exists");
+
+            agents[agentId] = Agent({
+                owner: msg.sender,
+                name: name,
+                endpoint: endpoints[i],
+                reputation: 100,
+                tasksCompleted: 0,
+                registeredAt: timestamp,
+                active: true
+            });
+
+            ownerAgents[msg.sender].push(agentId);
+            agentIds.push(agentId);
+            registeredIds[i] = agentId;
+
+            emit AgentRegistered(agentId, msg.sender, name);
+        }
     }
 
     function deactivateAgent(bytes32 agentId) external {

--- a/test/AgentRegistryBatchRegister.test.js
+++ b/test/AgentRegistryBatchRegister.test.js
@@ -1,0 +1,85 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry.batchRegister", function () {
+  const REGISTRATION_FEE = ethers.parseEther("0.01");
+
+  async function deployRegistry() {
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    const registry = await AgentRegistry.deploy(REGISTRATION_FEE);
+    await registry.waitForDeployment();
+    return registry;
+  }
+
+  function getRegisteredEvents(registry, receipt) {
+    return receipt.logs
+      .map((log) => {
+        try {
+          return registry.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .filter((event) => event && event.name === "AgentRegistered");
+  }
+
+  it("registers a batch of 1 agent with one transaction", async function () {
+    const [, user] = await ethers.getSigners();
+    const registry = await deployRegistry();
+    const names = ["agent-one"];
+    const endpoints = ["https://agent.one"];
+
+    const tx = await registry
+      .connect(user)
+      .batchRegister(names, endpoints, { value: REGISTRATION_FEE });
+    const receipt = await tx.wait();
+    const events = getRegisteredEvents(registry, receipt);
+
+    expect(events).to.have.lengthOf(1);
+    const agentId = events[0].args.agentId;
+
+    expect(await registry.getActiveAgentCount()).to.equal(1n);
+    expect(await ethers.provider.getBalance(await registry.getAddress())).to.equal(
+      REGISTRATION_FEE
+    );
+
+    const agent = await registry.getAgent(agentId);
+    expect(agent.owner).to.equal(user.address);
+    expect(agent.name).to.equal("agent-one");
+    expect(agent.endpoint).to.equal("https://agent.one");
+    expect(agent.active).to.equal(true);
+  });
+
+  it("registers 50 agents in one transaction with unique IDs and events", async function () {
+    const [, user] = await ethers.getSigners();
+    const registry = await deployRegistry();
+
+    const names = Array.from({ length: 50 }, (_, i) => `agent-${i + 1}`);
+    const endpoints = Array.from({ length: 50 }, (_, i) => `https://agent-${i + 1}.example`);
+    const totalFee = REGISTRATION_FEE * 50n;
+
+    const tx = await registry.connect(user).batchRegister(names, endpoints, { value: totalFee });
+    const receipt = await tx.wait();
+    const events = getRegisteredEvents(registry, receipt);
+
+    expect(events).to.have.lengthOf(50);
+
+    const ids = events.map((event) => event.args.agentId);
+    expect(new Set(ids).size).to.equal(50);
+    expect(await registry.getActiveAgentCount()).to.equal(50n);
+    expect(await ethers.provider.getBalance(await registry.getAddress())).to.equal(totalFee);
+  });
+
+  it("reverts when names/endpoints array lengths mismatch", async function () {
+    const [, user] = await ethers.getSigners();
+    const registry = await deployRegistry();
+
+    await expect(
+      registry
+        .connect(user)
+        .batchRegister(["agent-a", "agent-b"], ["https://agent-a.example"], {
+          value: REGISTRATION_FEE * 2n,
+        })
+    ).to.be.revertedWith("Length mismatch");
+  });
+});


### PR DESCRIPTION
## Summary
- add `batchRegister(string[] names, string[] endpoints)` to `AgentRegistry` for one-transaction multi-agent onboarding
- enforce length match and max batch size 50
- collect total fee once as `registrationFee * count`
- emit one `AgentRegistered` event per registered agent and return all IDs
- add focused tests for batch size 1, batch size 50, and array length mismatch

## Verification
- `npx hardhat test test/AgentRegistryBatchRegister.test.js --config hardhat.issue182.local.config.js`
  - `3 passing`

Closes #182

/claim #182
