### PR TITLE
fix(lottery): add cancellation refund flow for RandomLottery

### DIFF
--- a/contracts/lottery/RandomLottery.sol
+++ b/contracts/lottery/RandomLottery.sol
@@ -9,12 +9,18 @@ contract RandomLottery {
     uint256 public ticketPrice;
     uint256 public roundEnd;
     uint256 public currentRound;
+    uint256 public constant MIN_PARTICIPANTS = 2;
+    bool public roundCancelled;
+    uint256 public pendingRefundPool;
 
     address[] public players;
     mapping(uint256 => address) public roundWinners;
+    mapping(uint256 => mapping(address => uint256)) public contributions;
 
     event TicketPurchased(address indexed player, uint256 round);
     event RoundStarted(uint256 indexed round, uint256 endTime);
+    event LotteryCancelled(uint256 indexed round, uint256 refundPool);
+    event Refunded(address indexed player, uint256 amount, uint256 indexed round);
     event WinnerSelected(address indexed winner, uint256 prize, uint256 round);
 
     modifier onlyOwner() {
@@ -29,21 +35,28 @@ contract RandomLottery {
 
     function startRound(uint256 duration) external onlyOwner {
         require(roundEnd == 0 || block.timestamp > roundEnd, "Round active");
+        require(!roundCancelled || pendingRefundPool == 0, "Pending refunds");
         delete players;
+        roundCancelled = false;
         currentRound++;
         roundEnd = block.timestamp + duration;
         emit RoundStarted(currentRound, roundEnd);
     }
 
     function buyTicket() external payable {
+        require(!roundCancelled, "Round cancelled");
         require(block.timestamp < roundEnd, "Round ended");
         require(msg.value == ticketPrice, "Wrong ticket price");
         players.push(msg.sender);
+        contributions[currentRound][msg.sender] += msg.value;
+        pendingRefundPool += msg.value;
         emit TicketPurchased(msg.sender, currentRound);
     }
 
     function drawWinner() external onlyOwner {
+        require(!roundCancelled, "Round cancelled");
         require(block.timestamp >= roundEnd, "Round not ended");
+        require(players.length >= MIN_PARTICIPANTS, "Not enough participants");
 
         // BUG: prevrandao is manipulable by validators — validators can influence
         // the randomness value, making the lottery outcome predictable/riggable
@@ -57,6 +70,7 @@ contract RandomLottery {
         roundWinners[currentRound] = winner;
 
         uint256 prize = address(this).balance;
+        pendingRefundPool = 0;
         roundEnd = 0;
 
         // BUG: Winner can be a contract that rejects ETH (no receive/fallback),
@@ -65,6 +79,30 @@ contract RandomLottery {
         require(sent, "Transfer failed");
 
         emit WinnerSelected(winner, prize, currentRound);
+    }
+
+    function cancelLottery() external {
+        require(!roundCancelled, "Already cancelled");
+        require(roundEnd != 0, "No active round");
+        require(block.timestamp >= roundEnd, "Round not ended");
+        require(players.length < MIN_PARTICIPANTS, "Enough participants");
+        roundCancelled = true;
+        roundEnd = 0;
+        emit LotteryCancelled(currentRound, pendingRefundPool);
+    }
+
+    function refund() external {
+        require(roundCancelled, "Round not cancelled");
+        uint256 amount = contributions[currentRound][msg.sender];
+        require(amount > 0, "Nothing to refund");
+
+        contributions[currentRound][msg.sender] = 0;
+        pendingRefundPool -= amount;
+
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        require(sent, "Refund failed");
+
+        emit Refunded(msg.sender, amount, currentRound);
     }
 
     function getPlayers() external view returns (address[] memory) {

--- a/test/RandomLottery.refund.test.js
+++ b/test/RandomLottery.refund.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("RandomLottery refund flow", function () {
+  let lottery;
+  let owner, alice, bob;
+  const ticketPrice = ethers.parseEther("1");
+
+  async function endRound(seconds = 3601) {
+    await ethers.provider.send("evm_increaseTime", [seconds]);
+    await ethers.provider.send("evm_mine");
+  }
+
+  beforeEach(async function () {
+    [owner, alice, bob] = await ethers.getSigners();
+    const RandomLottery = await ethers.getContractFactory("RandomLottery");
+    lottery = await RandomLottery.deploy(ticketPrice);
+    await lottery.waitForDeployment();
+  });
+
+  it("cancels after deadline when minimum participants are not reached", async function () {
+    await lottery.startRound(3600);
+    await lottery.connect(alice).buyTicket({ value: ticketPrice });
+
+    await endRound();
+
+    await expect(lottery.cancelLottery())
+      .to.emit(lottery, "LotteryCancelled")
+      .withArgs(1n, ticketPrice);
+
+    expect(await lottery.roundCancelled()).to.equal(true);
+    expect(await lottery.roundEnd()).to.equal(0n);
+  });
+
+  it("refunds exact contribution after cancellation and prevents double refund", async function () {
+    await lottery.startRound(3600);
+    await lottery.connect(alice).buyTicket({ value: ticketPrice });
+
+    await endRound();
+    await lottery.cancelLottery();
+
+    const round = await lottery.currentRound();
+    const contributed = await lottery.contributions(round, alice.address);
+    expect(contributed).to.equal(ticketPrice);
+
+    await expect(lottery.connect(alice).refund())
+      .to.emit(lottery, "Refunded")
+      .withArgs(alice.address, ticketPrice, round);
+
+    expect(await lottery.contributions(round, alice.address)).to.equal(0n);
+    expect(await lottery.pendingRefundPool()).to.equal(0n);
+    expect(await lottery.getPoolSize()).to.equal(0n);
+
+    await expect(lottery.connect(alice).refund()).to.be.revertedWith("Nothing to refund");
+  });
+
+  it("does not allow refunds when lottery is active or completed", async function () {
+    await lottery.startRound(3600);
+    await lottery.connect(alice).buyTicket({ value: ticketPrice });
+
+    await expect(lottery.connect(alice).refund()).to.be.revertedWith("Round not cancelled");
+
+    await lottery.connect(bob).buyTicket({ value: ticketPrice });
+    await endRound();
+    await lottery.drawWinner();
+
+    await expect(lottery.connect(alice).refund()).to.be.revertedWith("Round not cancelled");
+  });
+});


### PR DESCRIPTION
## Summary
- add cancellation flow for rounds that end below minimum participants
- add participant pull-refund flow after cancellation with per-round contribution tracking
- block new rounds while cancelled-round refunds remain pending
- add focused tests for cancel/refund/double-refund and refund state gating

## Validation
- `npx hardhat test test/RandomLottery.refund.test.js --config hardhat.randomlottery.config.js`
- result: 3 passing

Closes #176
/claim #176
