### PR TITLE
Fix PaymentEscrow createEscrow zero/fot amount handling

### DIFF
--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -33,20 +33,24 @@ contract PaymentEscrow is Ownable {
         require(payee != address(0), "Invalid payee");
         require(amount > 0, "Amount must be > 0");
 
-        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        IERC20 erc20 = IERC20(token);
+        uint256 balanceBefore = erc20.balanceOf(address(this));
+        require(erc20.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+        uint256 receivedAmount = erc20.balanceOf(address(this)) - balanceBefore;
+        require(receivedAmount > 0, "Amount must be > 0");
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
             payer: msg.sender,
             payee: payee,
             token: token,
-            amount: amount,
+            amount: receivedAmount,
             releaseTime: block.timestamp + lockDuration,
             released: false,
             refunded: false
         });
 
-        emit EscrowCreated(escrowId, msg.sender, amount);
+        emit EscrowCreated(escrowId, msg.sender, receivedAmount);
         return escrowId;
     }
 

--- a/contracts/token/MockFeeOnTransferToken.sol
+++ b/contracts/token/MockFeeOnTransferToken.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferToken is ERC20 {
+    uint256 public immutable feeBps;
+    address public immutable feeCollector;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 feeBps_,
+        address feeCollector_
+    ) ERC20(name_, symbol_) {
+        require(feeBps_ <= 10000, "Invalid fee");
+        if (feeBps_ > 0) {
+            require(feeCollector_ != address(0), "Invalid collector");
+        }
+        feeBps = feeBps_;
+        feeCollector = feeCollector_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 fee = (value * feeBps) / 10000;
+        uint256 amountAfterFee = value - fee;
+
+        super._update(from, to, amountAfterFee);
+        if (fee > 0) {
+            super._update(from, feeCollector, fee);
+        }
+    }
+}

--- a/test/PaymentEscrow.test.js
+++ b/test/PaymentEscrow.test.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PaymentEscrow", function () {
+  let escrow;
+  let payer;
+  let payee;
+  let feeCollector;
+
+  beforeEach(async function () {
+    [, payer, payee, feeCollector] = await ethers.getSigners();
+    const PaymentEscrow = await ethers.getContractFactory("PaymentEscrow");
+    escrow = await PaymentEscrow.deploy();
+    await escrow.waitForDeployment();
+  });
+
+  async function deployToken(feeBps) {
+    const Token = await ethers.getContractFactory("MockFeeOnTransferToken");
+    const token = await Token.deploy("Mock", "MOCK", feeBps, feeCollector.address);
+    await token.waitForDeployment();
+    return token;
+  }
+
+  it("rejects zero amount", async function () {
+    const token = await deployToken(0);
+    await token.mint(payer.address, 1000n);
+    await token.connect(payer).approve(escrow.target, 1000n);
+
+    await expect(
+      escrow.connect(payer).createEscrow(payee.address, token.target, 0n, 0)
+    ).to.be.revertedWith("Amount must be > 0");
+  });
+
+  it("stores full amount for standard ERC20", async function () {
+    const token = await deployToken(0);
+    const amount = ethers.parseUnits("100", 18);
+
+    await token.mint(payer.address, amount);
+    await token.connect(payer).approve(escrow.target, amount);
+
+    await expect(
+      escrow.connect(payer).createEscrow(payee.address, token.target, amount, 3600)
+    )
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0n, payer.address, amount);
+
+    const stored = await escrow.escrows(0n);
+    expect(stored.amount).to.equal(amount);
+    expect(await token.balanceOf(escrow.target)).to.equal(amount);
+  });
+
+  it("stores actual received amount for fee-on-transfer token", async function () {
+    const token = await deployToken(500); // 5%
+    const amount = ethers.parseUnits("100", 18);
+    const expectedReceived = (amount * 9500n) / 10000n;
+
+    await token.mint(payer.address, amount);
+    await token.connect(payer).approve(escrow.target, amount);
+
+    await expect(
+      escrow.connect(payer).createEscrow(payee.address, token.target, amount, 3600)
+    )
+      .to.emit(escrow, "EscrowCreated")
+      .withArgs(0n, payer.address, expectedReceived);
+
+    const stored = await escrow.escrows(0n);
+    expect(stored.amount).to.equal(expectedReceived);
+    expect(await token.balanceOf(escrow.target)).to.equal(expectedReceived);
+  });
+});


### PR DESCRIPTION
## Summary
- harden `PaymentEscrow.createEscrow` with balance-delta accounting for fee-on-transfer ERC20s
- keep zero-amount rejection in place and reject zero actual receipt
- store and emit the actual received token amount in escrow state/events
- add focused tests for zero amount, normal ERC20, and fee-on-transfer ERC20

## Testing
- `npx hardhat test test/PaymentEscrow.test.js --config .tmp-hardhat-179.config.js`
- result: 3 passing

Closes #179
/claim #179