### PR TITLE
[API] Add admin audit log for write actions

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, Header, HTTPException, Query, Request
 from pydantic import BaseModel
-from typing import Optional
+from typing import Any, Optional
 from datetime import datetime
 
 app = FastAPI(
@@ -39,9 +39,61 @@ class LeaderboardEntry(BaseModel):
     success_rate: float
 
 
+class AdminSettingUpdate(BaseModel):
+    value: Any
+
+
+class AdminUserRoleUpdate(BaseModel):
+    role: str
+
+
+class AuditLog(BaseModel):
+    id: int
+    action: str
+    actor: str
+    target: str
+    before: Optional[Any] = None
+    after: Optional[Any] = None
+    timestamp: datetime
+    ip: str
+
+
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+admin_settings: dict[str, Any] = {}
+admin_users: dict[str, dict[str, Any]] = {}
+audit_logs: list[AuditLog] = []
+_audit_log_seq = 0
+
+
+def _next_audit_id() -> int:
+    global _audit_log_seq
+    _audit_log_seq += 1
+    return _audit_log_seq
+
+
+def _request_ip(request: Request) -> str:
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _append_audit_log(
+    *, action: str, actor: str, target: str, before: Any, after: Any, ip: str
+) -> AuditLog:
+    log = AuditLog(
+        id=_next_audit_id(),
+        action=action,
+        actor=actor,
+        target=target,
+        before=before,
+        after=after,
+        timestamp=datetime.utcnow(),
+        ip=ip,
+    )
+    audit_logs.append(log)
+    return log
 
 
 @app.get("/agents", response_model=list[AgentResponse])
@@ -110,3 +162,66 @@ async def health():
         "tasks_indexed": len(tasks_cache),
         "timestamp": datetime.utcnow().isoformat(),
     }
+
+
+@app.put("/admin/settings/{setting_key}")
+async def update_admin_setting(
+    setting_key: str,
+    update: AdminSettingUpdate,
+    request: Request,
+    actor: str = Header(..., alias="X-Admin-Actor"),
+):
+    before_value = admin_settings.get(setting_key)
+    admin_settings[setting_key] = update.value
+    _append_audit_log(
+        action="settings.update",
+        actor=actor,
+        target=f"settings:{setting_key}",
+        before=before_value,
+        after=update.value,
+        ip=_request_ip(request),
+    )
+    return {"setting": setting_key, "value": update.value}
+
+
+@app.put("/admin/users/{user_id}/role")
+async def update_admin_user_role(
+    user_id: str,
+    update: AdminUserRoleUpdate,
+    request: Request,
+    actor: str = Header(..., alias="X-Admin-Actor"),
+):
+    previous = admin_users.get(user_id)
+    before_value = dict(previous) if previous else None
+    updated_user = {"user_id": user_id, "role": update.role}
+    admin_users[user_id] = updated_user
+    _append_audit_log(
+        action="user.role.update",
+        actor=actor,
+        target=f"user:{user_id}",
+        before=before_value,
+        after=updated_user,
+        ip=_request_ip(request),
+    )
+    return updated_user
+
+
+@app.get("/admin/audit-log", response_model=list[AuditLog])
+async def list_admin_audit_logs(
+    actor: Optional[str] = Query(None),
+    action: Optional[str] = Query(None),
+    start_date: Optional[datetime] = Query(None),
+    end_date: Optional[datetime] = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    results = audit_logs
+    if actor:
+        results = [log for log in results if log.actor == actor]
+    if action:
+        results = [log for log in results if log.action == action]
+    if start_date:
+        results = [log for log in results if log.timestamp >= start_date]
+    if end_date:
+        results = [log for log in results if log.timestamp <= end_date]
+    return results[offset : offset + limit]

--- a/api/tests/test_admin_audit_log.py
+++ b/api/tests/test_admin_audit_log.py
@@ -1,0 +1,94 @@
+import time
+
+from fastapi.testclient import TestClient
+
+from api.main import admin_settings, admin_users, app, audit_logs
+
+
+client = TestClient(app)
+
+
+def setup_function():
+    admin_settings.clear()
+    admin_users.clear()
+    audit_logs.clear()
+
+
+def test_admin_write_actions_create_audit_logs():
+    settings_resp = client.put(
+        "/admin/settings/max_agents",
+        json={"value": 25},
+        headers={"X-Admin-Actor": "alice"},
+    )
+    assert settings_resp.status_code == 200
+
+    role_resp = client.put(
+        "/admin/users/user-1/role",
+        json={"role": "moderator"},
+        headers={"X-Admin-Actor": "alice"},
+    )
+    assert role_resp.status_code == 200
+
+    logs_resp = client.get("/admin/audit-log")
+    assert logs_resp.status_code == 200
+    logs = logs_resp.json()
+    assert len(logs) == 2
+
+    assert logs[0]["action"] == "settings.update"
+    assert logs[0]["actor"] == "alice"
+    assert logs[0]["target"] == "settings:max_agents"
+    assert logs[0]["before"] is None
+    assert logs[0]["after"] == 25
+    assert logs[0]["ip"]
+
+    assert logs[1]["action"] == "user.role.update"
+    assert logs[1]["before"] is None
+    assert logs[1]["after"] == {"user_id": "user-1", "role": "moderator"}
+
+
+def test_audit_log_supports_actor_action_and_date_filters():
+    client.put(
+        "/admin/settings/feature_flag",
+        json={"value": True},
+        headers={"X-Admin-Actor": "alice"},
+    )
+    time.sleep(0.01)
+    client.put(
+        "/admin/users/user-2/role",
+        json={"role": "admin"},
+        headers={"X-Admin-Actor": "bob"},
+    )
+
+    all_logs = client.get("/admin/audit-log").json()
+    first_ts = all_logs[0]["timestamp"]
+
+    by_actor = client.get("/admin/audit-log", params={"actor": "alice"}).json()
+    assert len(by_actor) == 1
+    assert by_actor[0]["actor"] == "alice"
+
+    by_action = client.get(
+        "/admin/audit-log", params={"action": "user.role.update"}
+    ).json()
+    assert len(by_action) == 1
+    assert by_action[0]["action"] == "user.role.update"
+
+    by_date = client.get(
+        "/admin/audit-log",
+        params={"start_date": first_ts, "end_date": first_ts},
+    ).json()
+    assert len(by_date) == 1
+    assert by_date[0]["timestamp"] == first_ts
+
+
+def test_audit_log_records_are_immutable_via_api():
+    client.put(
+        "/admin/settings/rate_limit",
+        json={"value": 100},
+        headers={"X-Admin-Actor": "alice"},
+    )
+
+    put_resp = client.put("/admin/audit-log", json={"actor": "mallory"})
+    delete_resp = client.delete("/admin/audit-log")
+
+    assert put_resp.status_code == 405
+    assert delete_resp.status_code == 405


### PR DESCRIPTION
## Summary
- add append-only admin audit log model and storage in API runtime
- log admin write actions for settings updates and user role updates with actor, target, before/after, timestamp, and ip
- add GET /admin/audit-log with actor/action/date filters plus pagination
- add targeted tests for creation, filtering, and immutability (no update/delete route)

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_admin_audit_log.py -q
- result: 3 passed

Closes #184
/claim #184