### PR TITLE
[API] Validate agent endpoint URL format and safety checks

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,18 +1,107 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
+from datetime import datetime
+import ipaddress
+import socket
+from typing import Optional, Union
+from urllib.parse import urlparse
+
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
+ENDPOINT_REACHABILITY_TIMEOUT_SECONDS = 5.0
+
+
+def _validate_endpoint_url_format(endpoint: str):
+    parsed = urlparse(endpoint.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must be a valid http/https URL",
+        )
+    if parsed.username or parsed.password:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must not include URL credentials",
+        )
+    return parsed
+
+
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _resolve_hostname_addresses(hostname: str) -> list[IPAddress]:
+    try:
+        return [ipaddress.ip_address(hostname)]
+    except ValueError:
+        try:
+            addrinfo = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+        except socket.gaierror as exc:
+            raise HTTPException(
+                status_code=422,
+                detail="Agent endpoint hostname could not be resolved",
+            ) from exc
+        resolved = []
+        for _, _, _, _, sockaddr in addrinfo:
+            resolved.append(ipaddress.ip_address(sockaddr[0]))
+        return resolved
+
+
+def _is_internal_address(address: IPAddress) -> bool:
+    return (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+async def validate_agent_endpoint(endpoint: str) -> str:
+    parsed = _validate_endpoint_url_format(endpoint)
+    resolved_addresses = _resolve_hostname_addresses(parsed.hostname)
+    if any(_is_internal_address(address) for address in resolved_addresses):
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must not resolve to a private/internal IP",
+        )
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(ENDPOINT_REACHABILITY_TIMEOUT_SECONDS),
+            follow_redirects=True,
+        ) as client:
+            response = await client.head(endpoint)
+    except httpx.TimeoutException as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint is unreachable (request timed out)",
+        ) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint is unreachable",
+        ) from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint is unreachable",
+        )
+
+    return endpoint
+
 
 class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    endpoint: str
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
@@ -26,18 +115,27 @@ class AgentUpdate(BaseModel):
 
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    validated_endpoint = await validate_agent_endpoint(agent.endpoint)
+    config = dict(agent.config or {})
+    config["endpoint"] = validated_endpoint
+
     new_agent = Agent(
         name=agent.name,
         description=agent.description,
         model_type=agent.model_type,
-        config=agent.config or {},
+        config=config,
         owner_id=user["id"],
         created_at=datetime.utcnow(),
     )
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {
+        "id": new_agent.id,
+        "name": new_agent.name,
+        "owner": user["address"],
+        "endpoint": validated_endpoint,
+    }
 
 
 @router.get("/")

--- a/api/tests/test_agent_endpoint_validation.py
+++ b/api/tests/test_agent_endpoint_validation.py
@@ -1,0 +1,80 @@
+import asyncio
+import ipaddress
+import os
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.routes import agents
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+class _SuccessClient:
+    def __init__(self, timeout=None, follow_redirects=False):
+        self.timeout = timeout
+        self.follow_redirects = follow_redirects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def head(self, url: str):
+        return _DummyResponse(200)
+
+
+class _TimeoutClient(_SuccessClient):
+    async def head(self, url: str):
+        raise httpx.TimeoutException("timed out")
+
+
+def test_validate_agent_endpoint_accepts_valid_http_url(monkeypatch):
+    monkeypatch.setattr(
+        agents,
+        "_resolve_hostname_addresses",
+        lambda hostname: [ipaddress.ip_address("93.184.216.34")],
+    )
+    monkeypatch.setattr(agents.httpx, "AsyncClient", _SuccessClient)
+
+    validated = asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert validated == "https://example.com/agent"
+
+
+def test_validate_agent_endpoint_rejects_invalid_url_format():
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("not-a-url"))
+
+    assert exc_info.value.status_code == 422
+    assert "valid http/https URL" in exc_info.value.detail
+
+
+def test_validate_agent_endpoint_rejects_private_ip():
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("http://127.0.0.1/agent"))
+
+    assert exc_info.value.status_code == 422
+    assert "private/internal IP" in exc_info.value.detail
+
+
+def test_validate_agent_endpoint_rejects_timeout(monkeypatch):
+    monkeypatch.setattr(
+        agents,
+        "_resolve_hostname_addresses",
+        lambda hostname: [ipaddress.ip_address("93.184.216.34")],
+    )
+    monkeypatch.setattr(agents.httpx, "AsyncClient", _TimeoutClient)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert exc_info.value.status_code == 422
+    assert "timed out" in exc_info.value.detail


### PR DESCRIPTION
## Summary\n- add strict endpoint URL validation for agent creation (http/https only, no embedded credentials)\n- block endpoints resolving to private/internal IP ranges (including 127.x and ::1)\n- verify endpoint reachability with HEAD and a 5-second timeout before storing\n- store only the validated endpoint in Agent.config.endpoint\n- add focused tests for valid URL, invalid format, private IP, and timeout\n\n## Testing\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_agent_endpoint_validation.py -q\n\nCloses #173\n/claim #173