### PR TITLE
Add Permit2 support to staking, AMM swap, and lending deposit

### DIFF
--- a/contracts/dex/AMMPool.sol
+++ b/contracts/dex/AMMPool.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "../interfaces/IPermit2.sol";
+
 interface IERC20 {
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
     function transfer(address to, uint256 amount) external returns (bool);
@@ -11,6 +13,8 @@ interface IERC20 {
 /// @notice Constant product (x*y=k) automated market maker pool
 /// @dev Supports adding/removing liquidity and token swaps with a fee
 contract AMMPool {
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
 
@@ -103,6 +107,60 @@ contract AMMPool {
         }
 
         emit Swap(msg.sender, tokenIn, amountIn, amountOut);
+    }
+
+    /// @notice Swap tokens using a Permit2 signature for tokenIn transfer.
+    /// @param owner Address that signed the Permit2 message and pays tokenIn.
+    /// @param tokenIn Input token address (tokenA or tokenB).
+    /// @param amountIn Input amount.
+    /// @param minAmountOut Minimum accepted output amount.
+    /// @param nonce Unordered nonce used in the Permit2 signature.
+    /// @param deadline Expiration timestamp for the Permit2 signature.
+    /// @param signature Permit2 signature payload.
+    function swapWithPermit2(
+        address owner,
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external returns (uint256 amountOut) {
+        require(owner != address(0), "Invalid owner");
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+        require(amountIn > 0, "Zero input");
+
+        IPermit2(PERMIT2).permitTransferFrom(
+            IPermit2.PermitTransferFrom({
+                permitted: IPermit2.TokenPermissions({token: tokenIn, amount: amountIn}),
+                nonce: nonce,
+                deadline: deadline
+            }),
+            IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: amountIn}),
+            owner,
+            signature
+        );
+
+        bool isA = tokenIn == address(tokenA);
+        (uint256 resIn, uint256 resOut) = isA ? (reserveA, reserveB) : (reserveB, reserveA);
+
+        uint256 amountInWithFee = amountIn * (10000 - FEE_BPS);
+        amountOut = (amountInWithFee * resOut) / (resIn * 10000 + amountInWithFee);
+
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+
+        IERC20 tOut = isA ? tokenB : tokenA;
+        require(tOut.transfer(owner, amountOut), "Transfer out failed");
+
+        if (isA) {
+            reserveA += amountIn;
+            reserveB -= amountOut;
+        } else {
+            reserveB += amountIn;
+            reserveA -= amountOut;
+        }
+
+        emit Swap(owner, tokenIn, amountIn, amountOut);
     }
 
     function _sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/contracts/interfaces/IPermit2.sol
+++ b/contracts/interfaces/IPermit2.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IPermit2 {
+    struct TokenPermissions {
+        address token;
+        uint256 amount;
+    }
+
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    struct SignatureTransferDetails {
+        address to;
+        uint256 requestedAmount;
+    }
+
+    function permitTransferFrom(
+        PermitTransferFrom memory permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
+}

--- a/contracts/lending/LendingPool.sol
+++ b/contracts/lending/LendingPool.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "../interfaces/IPermit2.sol";
+
 interface IPriceFeed {
     function getPrice(address token) external view returns (uint256);
 }
@@ -15,6 +17,8 @@ interface IERC20 {
 /// @notice Collateralized lending pool supporting deposit, borrow, repay, and liquidation
 /// @dev Uses an external price feed oracle for collateral valuation
 contract LendingPool {
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
     IPriceFeed public oracle;
     IERC20 public collateralToken;
     IERC20 public borrowToken;
@@ -51,6 +55,38 @@ contract LendingPool {
         positions[msg.sender].collateralAmount += amount;
         totalDeposits += amount;
         emit Deposited(msg.sender, amount);
+    }
+
+    /// @notice Deposit collateral using Permit2 signature transfer.
+    /// @param owner Address that signed the Permit2 message and provides collateral.
+    /// @param amount Collateral amount to deposit.
+    /// @param nonce Unordered nonce used in the Permit2 signature.
+    /// @param deadline Expiration timestamp for the Permit2 signature.
+    /// @param signature Permit2 signature payload.
+    function depositWithPermit2(
+        address owner,
+        uint256 amount,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external {
+        require(owner != address(0), "Invalid owner");
+        require(amount > 0, "Zero amount");
+
+        IPermit2(PERMIT2).permitTransferFrom(
+            IPermit2.PermitTransferFrom({
+                permitted: IPermit2.TokenPermissions({token: address(collateralToken), amount: amount}),
+                nonce: nonce,
+                deadline: deadline
+            }),
+            IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: amount}),
+            owner,
+            signature
+        );
+
+        positions[owner].collateralAmount += amount;
+        totalDeposits += amount;
+        emit Deposited(owner, amount);
     }
 
     function borrow(uint256 amount) external {

--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -4,12 +4,15 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../interfaces/IPermit2.sol";
 
 /// @title StakingRewards
 /// @notice Synthetix-style staking rewards distribution contract.
 /// @dev Users stake an ERC20 token and earn rewards over a fixed duration.
 contract StakingRewards is ReentrancyGuard {
     using SafeERC20 for IERC20;
+
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
     IERC20 public immutable stakingToken;
     IERC20 public immutable rewardsToken;
@@ -88,6 +91,38 @@ contract StakingRewards is ReentrancyGuard {
         _balances[msg.sender] += amount;
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);
         emit Staked(msg.sender, amount);
+    }
+
+    /// @notice Stake using a Permit2 signature instead of pre-approving this contract.
+    /// @param staker Address that signed the Permit2 message and provides staking tokens.
+    /// @param amount Amount of tokens to stake.
+    /// @param nonce Unordered nonce used in the Permit2 signature.
+    /// @param deadline Expiration timestamp for the Permit2 signature.
+    /// @param signature Permit2 signature payload.
+    function stakeWithPermit2(
+        address staker,
+        uint256 amount,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external nonReentrant updateReward(staker) {
+        require(staker != address(0), "Invalid owner");
+        require(amount > 0, "Cannot stake 0");
+
+        IPermit2(PERMIT2).permitTransferFrom(
+            IPermit2.PermitTransferFrom({
+                permitted: IPermit2.TokenPermissions({token: address(stakingToken), amount: amount}),
+                nonce: nonce,
+                deadline: deadline
+            }),
+            IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: amount}),
+            staker,
+            signature
+        );
+
+        _totalSupply += amount;
+        _balances[staker] += amount;
+        emit Staked(staker, amount);
     }
 
     /// @notice Withdraw staked tokens.

--- a/contracts/test/MockPermit2.sol
+++ b/contracts/test/MockPermit2.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/IPermit2.sol";
+
+interface IERC20Like {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+contract MockPermit2 is IPermit2 {
+    function permitTransferFrom(
+        PermitTransferFrom memory permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external override {
+        require(signature.length > 0, "Invalid signature");
+        require(block.timestamp <= permit.deadline, "Permit expired");
+        require(transferDetails.requestedAmount <= permit.permitted.amount, "Invalid amount");
+        require(IERC20Like(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount), "Transfer failed");
+    }
+}

--- a/contracts/test/MockPriceFeed.sol
+++ b/contracts/test/MockPriceFeed.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockPriceFeed {
+    uint256 public price = 1e18;
+
+    function setPrice(uint256 newPrice) external {
+        price = newPrice;
+    }
+
+    function getPrice(address) external view returns (uint256) {
+        return price;
+    }
+}

--- a/test/Permit2Support.test.js
+++ b/test/Permit2Support.test.js
@@ -1,0 +1,132 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+const PERMIT2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+
+describe("Permit2 support", function () {
+  let owner;
+  let user;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const MockPermit2 = await ethers.getContractFactory("MockPermit2");
+    const mockPermit2 = await MockPermit2.deploy();
+    await mockPermit2.waitForDeployment();
+
+    const runtimeCode = await ethers.provider.getCode(await mockPermit2.getAddress());
+    await network.provider.send("hardhat_setCode", [PERMIT2, runtimeCode]);
+  });
+
+  it("supports permit2 stake and keeps fallback approve flow", async function () {
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const stakingToken = await AgentToken.deploy("Stake", "STK", 0);
+    const rewardToken = await AgentToken.deploy("Reward", "RWD", 0);
+    await stakingToken.waitForDeployment();
+    await rewardToken.waitForDeployment();
+
+    const StakingRewards = await ethers.getContractFactory("StakingRewards");
+    const stakingRewards = await StakingRewards.deploy(
+      await stakingToken.getAddress(),
+      await rewardToken.getAddress()
+    );
+    await stakingRewards.waitForDeployment();
+
+    const permitStakeAmount = ethers.parseEther("10");
+    const fallbackStakeAmount = ethers.parseEther("5");
+
+    await stakingToken.mint(user.address, permitStakeAmount + fallbackStakeAmount);
+    await rewardToken.mint(await stakingRewards.getAddress(), ethers.parseEther("100"));
+
+    await stakingToken.connect(user).approve(PERMIT2, permitStakeAmount);
+    await stakingRewards.connect(user).stakeWithPermit2(
+      user.address,
+      permitStakeAmount,
+      1,
+      Math.floor(Date.now() / 1000) + 3600,
+      "0x11"
+    );
+
+    expect(await stakingRewards.balanceOf(user.address)).to.equal(permitStakeAmount);
+
+    await stakingToken.connect(user).approve(await stakingRewards.getAddress(), fallbackStakeAmount);
+    await stakingRewards.connect(user).stake(fallbackStakeAmount);
+
+    expect(await stakingRewards.balanceOf(user.address)).to.equal(
+      permitStakeAmount + fallbackStakeAmount
+    );
+  });
+
+  it("supports permit2 swap in AMMPool", async function () {
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const tokenA = await AgentToken.deploy("TokenA", "TKA", 0);
+    const tokenB = await AgentToken.deploy("TokenB", "TKB", 0);
+    await tokenA.waitForDeployment();
+    await tokenB.waitForDeployment();
+
+    const AMMPool = await ethers.getContractFactory("AMMPool");
+    const pool = await AMMPool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    await pool.waitForDeployment();
+
+    const lpA = ethers.parseEther("100");
+    const lpB = ethers.parseEther("100");
+    await tokenA.mint(owner.address, lpA);
+    await tokenB.mint(owner.address, lpB);
+    await tokenA.approve(await pool.getAddress(), lpA);
+    await tokenB.approve(await pool.getAddress(), lpB);
+    await pool.addLiquidity(lpA, lpB);
+
+    const amountIn = ethers.parseEther("10");
+    const balanceBBefore = await tokenB.balanceOf(user.address);
+    await tokenA.mint(user.address, amountIn);
+    await tokenA.connect(user).approve(PERMIT2, amountIn);
+
+    await pool.connect(user).swapWithPermit2(
+      user.address,
+      await tokenA.getAddress(),
+      amountIn,
+      0,
+      2,
+      Math.floor(Date.now() / 1000) + 3600,
+      "0x22"
+    );
+
+    const balanceBAfter = await tokenB.balanceOf(user.address);
+    expect(balanceBAfter).to.be.gt(balanceBBefore);
+  });
+
+  it("supports permit2 collateral deposit in LendingPool", async function () {
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const collateralToken = await AgentToken.deploy("Collateral", "COL", 0);
+    const borrowToken = await AgentToken.deploy("Borrow", "BRW", 0);
+    await collateralToken.waitForDeployment();
+    await borrowToken.waitForDeployment();
+
+    const MockPriceFeed = await ethers.getContractFactory("MockPriceFeed");
+    const oracle = await MockPriceFeed.deploy();
+    await oracle.waitForDeployment();
+
+    const LendingPool = await ethers.getContractFactory("LendingPool");
+    const pool = await LendingPool.deploy(
+      await oracle.getAddress(),
+      await collateralToken.getAddress(),
+      await borrowToken.getAddress()
+    );
+    await pool.waitForDeployment();
+
+    const amount = ethers.parseEther("15");
+    await collateralToken.mint(user.address, amount);
+    await collateralToken.connect(user).approve(PERMIT2, amount);
+
+    await pool.connect(user).depositWithPermit2(
+      user.address,
+      amount,
+      3,
+      Math.floor(Date.now() / 1000) + 3600,
+      "0x33"
+    );
+
+    const position = await pool.getPosition(user.address);
+    expect(position[0]).to.equal(amount);
+  });
+});


### PR DESCRIPTION
## Summary
- add canonical Permit2 interface and wire permit2 signature-transfer entrypoints into `StakingRewards`, `AMMPool`, and `LendingPool`
- preserve existing approve + `transferFrom` flows unchanged for backward compatibility
- add focused tests for permit2 staking/swap/deposit paths and fallback approve stake path

## Implementation
- `StakingRewards.stakeWithPermit2(...)`
- `AMMPool.swapWithPermit2(...)`
- `LendingPool.depositWithPermit2(...)`
- canonical Permit2 address: `0x000000000022D473030F116dDEE9F6B43aC78BA3`

## Tests
- `npx hardhat test --config .permit2-test/hardhat.config.js .permit2-test/test/Permit2Support.test.js`
- Result: `3 passing`

Closes #175

/claim #175
