### PR TITLE
[API] Add structured error responses with error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ npx hardhat test
 cd api && pip install -r requirements.txt && uvicorn main:app
 ```
 
+## API Error Codes
+
+Structured API errors use this schema:
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Request validation failed",
+  "details": {},
+  "request_id": "a2f9d580-4e56-4d6d-9c73-46986b8c84de"
+}
+```
+
+Supported error codes:
+
+- `VALIDATION_ERROR` — invalid input or request validation failure
+- `NOT_FOUND` — requested resource does not exist
+- `AUTH_FAILED` — authentication or authorization failure
+- `RATE_LIMITED` — request rejected by API rate limiting
+- `INTERNAL_ERROR` — unexpected server error
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/api/error_responses.py
+++ b/api/error_responses.py
@@ -1,0 +1,45 @@
+"""Shared structured API error response helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Request
+
+VALIDATION_ERROR = "VALIDATION_ERROR"
+NOT_FOUND = "NOT_FOUND"
+AUTH_FAILED = "AUTH_FAILED"
+RATE_LIMITED = "RATE_LIMITED"
+INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+def get_request_id(request: Request) -> str:
+    return getattr(request.state, "request_id", "unknown")
+
+
+def map_status_to_code(status_code: int) -> str:
+    if status_code in (400, 422):
+        return VALIDATION_ERROR
+    if status_code == 404:
+        return NOT_FOUND
+    if status_code in (401, 403):
+        return AUTH_FAILED
+    if status_code == 429:
+        return RATE_LIMITED
+    return INTERNAL_ERROR
+
+
+def make_error_payload(
+    *,
+    code: str,
+    message: str,
+    details: dict[str, Any],
+    request: Request,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "message": message,
+        "details": details,
+        "request_id": get_request_id(request),
+    }
+

--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,87 @@
-from fastapi import FastAPI, HTTPException, Query
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+
+from .error_responses import (
+    INTERNAL_ERROR,
+    VALIDATION_ERROR,
+    make_error_payload,
+    map_status_to_code,
+)
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+
+@app.middleware("http")
+async def attach_request_id(request: Request, call_next):
+    request_id = request.headers.get("X-Request-ID") or str(uuid4())
+    request.state.request_id = request_id
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    field_errors = []
+    for error in exc.errors():
+        loc = error.get("loc", [])
+        field = ".".join(str(part) for part in loc if part != "body")
+        field_errors.append(
+            {
+                "field": field or "request",
+                "message": error.get("msg", "Invalid value"),
+                "type": error.get("type", "validation_error"),
+            }
+        )
+    return JSONResponse(
+        status_code=422,
+        content=make_error_payload(
+            code=VALIDATION_ERROR,
+            message="Request validation failed",
+            details={"fields": field_errors},
+            request=request,
+        ),
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    code = map_status_to_code(exc.status_code)
+    detail = exc.detail
+    details = detail if isinstance(detail, dict) else {"reason": detail}
+    message = detail if isinstance(detail, str) else "Request failed"
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=make_error_payload(
+            code=code,
+            message=message,
+            details=details,
+            request=request,
+        ),
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, _: Exception):
+    return JSONResponse(
+        status_code=500,
+        content=make_error_payload(
+            code=INTERNAL_ERROR,
+            message="Internal server error",
+            details={"reason": "Unhandled exception"},
+            request=request,
+        ),
+    )
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -2,10 +2,12 @@
 
 import time
 from collections import defaultdict
-from fastapi import Request, HTTPException
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from typing import Dict, Tuple
+
+from ..error_responses import RATE_LIMITED, make_error_payload
 
 
 class RateLimitConfig:
@@ -65,12 +67,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         is_limited, value = self._is_rate_limited(client_ip)
 
         if is_limited:
+            request_id = request.headers.get("X-Request-ID", "unknown")
+            request.state.request_id = request_id
             return JSONResponse(
                 status_code=429,
-                content={
-                    "error": "Rate limit exceeded",
-                    "retry_after": value,
-                },
+                content=make_error_payload(
+                    code=RATE_LIMITED,
+                    message="Rate limit exceeded",
+                    details={"retry_after": value},
+                    request=request,
+                ),
                 headers={"Retry-After": str(value)},
             )
 

--- a/api/tests/test_error_responses.py
+++ b/api/tests/test_error_responses.py
@@ -1,0 +1,103 @@
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware.ratelimit import RateLimitConfig, RateLimitMiddleware, _request_counts
+
+
+def _assert_error_shape(payload: dict) -> None:
+    assert "code" in payload
+    assert "message" in payload
+    assert "details" in payload
+    assert "request_id" in payload
+    assert isinstance(payload["details"], dict)
+    assert isinstance(payload["request_id"], str)
+    assert payload["request_id"]
+
+
+def test_not_found_is_structured_with_code_and_request_id():
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/agents/nonexistent")
+
+    assert response.status_code == 404
+    payload = response.json()
+    _assert_error_shape(payload)
+    assert payload["code"] == "NOT_FOUND"
+
+
+def test_validation_error_includes_field_level_details():
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/agents", params={"limit": 101})
+
+    assert response.status_code == 422
+    payload = response.json()
+    _assert_error_shape(payload)
+    assert payload["code"] == "VALIDATION_ERROR"
+    assert "fields" in payload["details"]
+    assert any(field["field"] == "query.limit" for field in payload["details"]["fields"])
+
+
+def test_auth_failed_is_mapped_from_401():
+    path = f"/_test_auth_failed_{uuid4().hex}"
+
+    @app.get(path)
+    async def _auth_failed_route():
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get(path)
+
+    assert response.status_code == 401
+    payload = response.json()
+    _assert_error_shape(payload)
+    assert payload["code"] == "AUTH_FAILED"
+
+
+def test_internal_error_is_structured():
+    path = f"/_test_internal_error_{uuid4().hex}"
+
+    @app.get(path)
+    async def _internal_error_route():
+        raise RuntimeError("boom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get(path)
+
+    assert response.status_code == 500
+    payload = response.json()
+    _assert_error_shape(payload)
+    assert payload["code"] == "INTERNAL_ERROR"
+
+
+def test_rate_limited_is_structured():
+    _request_counts.clear()
+    rate_app = FastAPI()
+
+    @rate_app.middleware("http")
+    async def attach_request_id(request, call_next):
+        request_id = request.headers.get("X-Request-ID") or str(uuid4())
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+    rate_app.add_middleware(
+        RateLimitMiddleware,
+        config=RateLimitConfig(requests_per_window=1, window_seconds=60),
+    )
+
+    @rate_app.get("/limited")
+    async def limited():
+        return {"ok": True}
+
+    client = TestClient(rate_app, raise_server_exceptions=False)
+    assert client.get("/limited").status_code == 200
+
+    response = client.get("/limited")
+    assert response.status_code == 429
+    payload = response.json()
+    _assert_error_shape(payload)
+    assert payload["code"] == "RATE_LIMITED"
+    assert "retry_after" in payload["details"]


### PR DESCRIPTION
## Summary\n- add centralized structured error payload helpers (code, message, details, equest_id)\n- add global FastAPI exception handlers for validation/http/internal errors\n- return structured RATE_LIMITED payload from rate limit middleware\n- add targeted tests for all required error codes and validation field-level details\n- document supported error codes in README\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest api/tests/test_error_responses.py -q\n\nCloses #202\n/claim #202