### PR TITLE
Fix #177: support API key auth alongside JWT

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,11 +3,20 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+from .models.database import init_db
+from .routes.auth import router as auth_router
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+app.include_router(auth_router)
+
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,11 +1,17 @@
-"""JWT authentication middleware for the OpenAgents API."""
+"""JWT and API key authentication middleware for the OpenAgents API."""
 
-import jwt
+import hashlib
 import os
-from fastapi import Request, HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import secrets
 from datetime import datetime, timedelta
 from typing import Optional
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from ..models.database import APIKey, get_db
 
 # BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
 # crashing the entire application on startup
@@ -14,7 +20,7 @@ JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
@@ -43,9 +49,43 @@ def decode_token(token: str) -> dict:
         raise HTTPException(status_code=401, detail="Invalid token")
 
 
+def hash_api_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def generate_api_key() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def authenticate_api_key(raw_key: str, db: Session) -> Optional[dict]:
+    key_hash = hash_api_key(raw_key)
+    key_record = db.query(APIKey).filter(APIKey.key_hash == key_hash).first()
+    if not key_record:
+        return None
+
+    user = key_record.user
+    return {
+        "id": str(key_record.user_id),
+        "address": getattr(user, "address", None),
+        "roles": [],
+    }
+
+
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    db: Session = Depends(get_db),
 ) -> dict:
+    raw_api_key = request.headers.get("X-API-Key")
+    if raw_api_key:
+        user_data = authenticate_api_key(raw_api_key, db)
+        if not user_data:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+        return user_data
+
+    if not credentials:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
     token = credentials.credentials
     payload = decode_token(token)
 
@@ -71,6 +111,7 @@ def require_role(role: str):
         if role not in user.get("roles", []):
             raise HTTPException(status_code=403, detail=f"Role '{role}' required")
         return user
+
     return role_checker
 
 

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -1,6 +1,7 @@
 """Rate limiting middleware for the OpenAgents API."""
 
 import time
+import hashlib
 from collections import defaultdict
 from fastapi import Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -12,10 +13,16 @@ class RateLimitConfig:
     def __init__(
         self,
         requests_per_window: int = 100,
+        jwt_requests_per_window: int = 100,
+        api_key_requests_per_window: int = 300,
+        anonymous_requests_per_window: int = 60,
         window_seconds: int = 60,
         burst_limit: int = 20,
     ):
         self.requests_per_window = requests_per_window
+        self.jwt_requests_per_window = jwt_requests_per_window
+        self.api_key_requests_per_window = api_key_requests_per_window
+        self.anonymous_requests_per_window = anonymous_requests_per_window
         self.window_seconds = window_seconds
         self.burst_limit = burst_limit
 
@@ -57,12 +64,28 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         remaining = self.config.requests_per_window - count - 1
         return False, remaining
 
+    def _resolve_bucket(self, request: Request, client_ip: str) -> Tuple[str, int]:
+        api_key = request.headers.get("X-API-Key")
+        if api_key:
+            key_digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+            return f"api_key:{key_digest}", self.config.api_key_requests_per_window
+
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            return f"jwt:{client_ip}", self.config.jwt_requests_per_window
+
+        return f"anon:{client_ip}", self.config.anonymous_requests_per_window
+
     async def dispatch(self, request: Request, call_next):
         if request.url.path.startswith("/health"):
             return await call_next(request)
 
         client_ip = self._get_client_ip(request)
-        is_limited, value = self._is_rate_limited(client_ip)
+        bucket, bucket_limit = self._resolve_bucket(request, client_ip)
+        original_limit = self.config.requests_per_window
+        self.config.requests_per_window = bucket_limit
+        is_limited, value = self._is_rate_limited(bucket)
+        self.config.requests_per_window = original_limit
 
         if is_limited:
             return JSONResponse(
@@ -76,7 +99,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         response.headers["X-RateLimit-Remaining"] = str(value)
-        response.headers["X-RateLimit-Limit"] = str(self.config.requests_per_window)
+        response.headers["X-RateLimit-Limit"] = str(bucket_limit)
         return response
 
 

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -34,6 +34,7 @@ class User(Base):
     created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
 
     agents = relationship("Agent", back_populates="owner")
+    api_keys = relationship("APIKey", back_populates="user", cascade="all, delete-orphan")
 
 
 class Agent(Base):
@@ -84,6 +85,18 @@ class Payment(Base):
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class APIKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    name = Column(String(128), nullable=True)
+    key_hash = Column(String(64), unique=True, nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="api_keys")
 
 
 def init_db():

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -1,0 +1,62 @@
+"""Authentication routes for API key management."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..middleware.auth import (
+    generate_api_key,
+    get_current_user,
+    hash_api_key,
+)
+from ..models.database import APIKey, get_db
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class APIKeyCreateRequest(BaseModel):
+    name: str | None = None
+
+
+@router.post("/api-keys")
+async def create_api_key(
+    payload: APIKeyCreateRequest,
+    user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        user_id = int(user["id"])
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="Cannot create API key for this user")
+
+    raw_key = generate_api_key()
+    key_record = APIKey(
+        user_id=user_id,
+        name=payload.name,
+        key_hash=hash_api_key(raw_key),
+    )
+    db.add(key_record)
+    db.commit()
+    db.refresh(key_record)
+
+    return {"id": key_record.id, "name": key_record.name, "api_key": raw_key}
+
+
+@router.delete("/api-keys/{key_id}")
+async def revoke_api_key(
+    key_id: int,
+    user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        user_id = int(user["id"])
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="Cannot revoke API key for this user")
+
+    key_record = db.query(APIKey).filter(APIKey.id == key_id, APIKey.user_id == user_id).first()
+    if not key_record:
+        raise HTTPException(status_code=404, detail="API key not found")
+
+    db.delete(key_record)
+    db.commit()
+    return {"revoked": True}

--- a/api/tests/test_auth_api_key.py
+++ b/api/tests/test_auth_api_key.py
@@ -1,0 +1,101 @@
+import hashlib
+import importlib
+import os
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_test_client(tmp_path):
+    os.environ["JWT_SECRET"] = "test-jwt-secret"
+    os.environ["DATABASE_URL"] = f"sqlite:///{(tmp_path / 'auth_test.db').as_posix()}"
+
+    db_mod = importlib.import_module("api.models.database")
+    db_mod = importlib.reload(db_mod)
+
+    auth_mod = importlib.import_module("api.middleware.auth")
+    auth_mod = importlib.reload(auth_mod)
+
+    auth_routes_mod = importlib.import_module("api.routes.auth")
+    auth_routes_mod = importlib.reload(auth_routes_mod)
+
+    db_mod.init_db()
+
+    app = FastAPI()
+    app.include_router(auth_routes_mod.router)
+
+    @app.get("/protected")
+    async def protected(user=Depends(auth_mod.get_current_user)):
+        return user
+
+    return TestClient(app), db_mod, auth_mod
+
+
+def _create_user(db_mod):
+    with db_mod.SessionLocal() as db:
+        user = db_mod.User(address="0x1111111111111111111111111111111111111111", username="tester")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user.id
+
+
+def test_jwt_auth_works(tmp_path):
+    client, _, auth_mod = _build_test_client(tmp_path)
+    token = auth_mod.create_access_token(
+        {"sub": "42", "address": "0xabc0000000000000000000000000000000000000", "roles": ["user"]}
+    )
+
+    response = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.json()["id"] == "42"
+
+
+def test_api_key_auth_works_and_is_hashed(tmp_path):
+    client, db_mod, auth_mod = _build_test_client(tmp_path)
+    user_id = _create_user(db_mod)
+    token = auth_mod.create_access_token({"sub": str(user_id), "address": "0x1111111111111111111111111111111111111111"})
+
+    create_resp = client.post(
+        "/auth/api-keys",
+        json={"name": "ci-key"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert create_resp.status_code == 200
+    payload = create_resp.json()
+    raw_key = payload["api_key"]
+    key_id = payload["id"]
+
+    with db_mod.SessionLocal() as db:
+        key_row = db.query(db_mod.APIKey).filter(db_mod.APIKey.id == key_id).first()
+        assert key_row is not None
+        assert key_row.key_hash == hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+        assert key_row.key_hash != raw_key
+
+    protected_resp = client.get("/protected", headers={"X-API-Key": raw_key})
+    assert protected_resp.status_code == 200
+    assert protected_resp.json()["id"] == str(user_id)
+
+
+def test_revoked_api_key_fails_auth_immediately(tmp_path):
+    client, db_mod, auth_mod = _build_test_client(tmp_path)
+    user_id = _create_user(db_mod)
+    token = auth_mod.create_access_token({"sub": str(user_id), "address": "0x1111111111111111111111111111111111111111"})
+
+    create_resp = client.post(
+        "/auth/api-keys",
+        json={"name": "temp-key"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert create_resp.status_code == 200
+    payload = create_resp.json()
+    key_id = payload["id"]
+    raw_key = payload["api_key"]
+
+    revoke_resp = client.delete(f"/auth/api-keys/{key_id}", headers={"Authorization": f"Bearer {token}"})
+    assert revoke_resp.status_code == 200
+    assert revoke_resp.json()["revoked"] is True
+
+    protected_resp = client.get("/protected", headers={"X-API-Key": raw_key})
+    assert protected_resp.status_code == 401
+    assert protected_resp.json()["detail"] == "Invalid API key"


### PR DESCRIPTION
Closes #177

This PR implements the minimal auth fix for #177:
- Support X-API-Key as an alternative auth path alongside JWT bearer tokens.
- Store API keys as SHA-256 hashes in the database.
- Add POST /auth/api-keys to generate keys (returns raw key once).
- Add DELETE /auth/api-keys/{key_id} to revoke keys.
- Apply separate rate-limit buckets for API key vs JWT vs anonymous traffic.
- Add focused tests for JWT auth, API key auth + hash storage, and revocation.

Tested:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_auth_api_key.py -q
- result: 3 passed

/claim #177