### PR TITLE
[SDK] Add deployContract helper with confirmation and receipt metadata

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,19 @@ export interface AgentConfig {
   routerAddress: string;
 }
 
+export interface DeployContractOptions {
+  confirmations?: number;
+  overrides?: ethers.Overrides;
+}
+
+export interface DeployContractResult {
+  contract: ethers.BaseContract;
+  address: string;
+  txHash: string;
+  gasUsed: bigint;
+  receipt: ethers.TransactionReceipt;
+}
+
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
@@ -87,5 +100,41 @@ export class OpenAgentsSDK {
     }
 
     return openTasks;
+  }
+
+  async deployContract(
+    abi: ethers.InterfaceAbi,
+    bytecode: ethers.BytesLike,
+    args: readonly unknown[] = [],
+    options: DeployContractOptions = {}
+  ): Promise<DeployContractResult> {
+    const factory = new ethers.ContractFactory(abi, bytecode, this.signer);
+    const deployParams =
+      options.overrides !== undefined
+        ? [...args, options.overrides]
+        : [...args];
+
+    const contract = await factory.deploy(...deployParams);
+    await contract.waitForDeployment();
+
+    const deploymentTx = contract.deploymentTransaction();
+    if (!deploymentTx) {
+      throw new Error("Deployment transaction is unavailable");
+    }
+
+    const confirmationBlocks = options.confirmations ?? 1;
+    const receipt = await deploymentTx.wait(confirmationBlocks);
+    if (!receipt) {
+      throw new Error("Deployment receipt is unavailable");
+    }
+
+    const address = await contract.getAddress();
+    return {
+      contract,
+      address,
+      txHash: receipt.hash,
+      gasUsed: receipt.gasUsed,
+      receipt,
+    };
   }
 }

--- a/test/SDKDeployHelpers.test.js
+++ b/test/SDKDeployHelpers.test.js
@@ -1,0 +1,113 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("ethers");
+
+const { OpenAgentsSDK } = require("./tmp-sdk/index.js");
+
+const ORIGINAL_CONTRACT_FACTORY_DESCRIPTOR = Object.getOwnPropertyDescriptor(
+  ethers,
+  "ContractFactory"
+);
+
+function createSdkWithSigner(signer) {
+  const sdk = Object.create(OpenAgentsSDK.prototype);
+  sdk.signer = signer;
+  return sdk;
+}
+
+async function run() {
+  const deployCalls = [];
+  const waitCalls = [];
+  const deploymentReceipts = [
+    {
+      hash: "0xaaa",
+      gasUsed: 21000n,
+      blockNumber: 111,
+      contractAddress: "0x00000000000000000000000000000000000000a1",
+    },
+    {
+      hash: "0xbbb",
+      gasUsed: 43000n,
+      blockNumber: 112,
+      contractAddress: "0x00000000000000000000000000000000000000b2",
+    },
+  ];
+
+  const deployments = [
+    {
+      address: "0x00000000000000000000000000000000000000a1",
+      receipt: deploymentReceipts[0],
+    },
+    {
+      address: "0x00000000000000000000000000000000000000b2",
+      receipt: deploymentReceipts[1],
+    },
+  ];
+  let deploymentIndex = 0;
+
+  class MockContractFactory {
+    constructor(abi, bytecode, signer) {
+      this.abi = abi;
+      this.bytecode = bytecode;
+      this.signer = signer;
+    }
+
+    async deploy(...params) {
+      const current = deployments[deploymentIndex];
+      deploymentIndex += 1;
+      deployCalls.push(params);
+
+      return {
+        waitForDeployment: async () => {},
+        deploymentTransaction: () => ({
+          wait: async (confirmations) => {
+            waitCalls.push(confirmations);
+            return current.receipt;
+          },
+        }),
+        getAddress: async () => current.address,
+      };
+    }
+  }
+
+  Object.defineProperty(ethers, "ContractFactory", {
+    value: MockContractFactory,
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  });
+
+  try {
+    const abi = ["constructor(uint256 value, string name)"];
+    const bytecode = "0x6000600055";
+    const signer = { name: "mock-signer" };
+    const sdk = createSdkWithSigner(signer);
+
+    const firstResult = await sdk.deployContract(abi, bytecode, [7, "alpha"]);
+    assert.equal(firstResult.address, deployments[0].address);
+    assert.equal(firstResult.txHash, deploymentReceipts[0].hash);
+    assert.equal(firstResult.gasUsed, deploymentReceipts[0].gasUsed);
+    assert.equal(firstResult.receipt.blockNumber, deploymentReceipts[0].blockNumber);
+    assert.deepEqual(deployCalls[0], [7, "alpha"]);
+    assert.equal(waitCalls[0], 1);
+
+    const overrides = { gasLimit: 500000n, value: 100n };
+    const secondResult = await sdk.deployContract(abi, bytecode, [9, "beta"], {
+      confirmations: 3,
+      overrides,
+    });
+    assert.equal(secondResult.address, deployments[1].address);
+    assert.equal(secondResult.txHash, deploymentReceipts[1].hash);
+    assert.equal(secondResult.gasUsed, deploymentReceipts[1].gasUsed);
+    assert.deepEqual(deployCalls[1], [9, "beta", overrides]);
+    assert.equal(waitCalls[1], 3);
+
+    console.log("SDK deploy helper tests passed");
+  } finally {
+    Object.defineProperty(ethers, "ContractFactory", ORIGINAL_CONTRACT_FACTORY_DESCRIPTOR);
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add deployContract(abi, bytecode, args, options?) to OpenAgentsSDK
- wait for deployment + configurable confirmation blocks (options.confirmations, default 1)
- return deployed contract instance and deployment metadata (ddress, 	xHash, gasUsed, eceipt)
- add focused SDK deploy helper test covering constructor args, confirmation waiting, and receipt fields

## Verification
- 
px tsc --pretty false --target ES2020 --module commonjs --moduleResolution node --ignoreDeprecations 6.0 --types node --outDir test/tmp-sdk sdk/src/index.ts; node test/SDKDeployHelpers.test.js

Closes #199

/claim #199
💳 Payment: USDC | 0xa925FdD65a0f34bb415Bae1c57536Be33AbCfA92 | Base