### PR TITLE
[Codex] Fix InterestRateModel parameter change events and getter

### DIFF
--- a/contracts/lending/InterestRateModel.sol
+++ b/contracts/lending/InterestRateModel.sol
@@ -19,6 +19,23 @@ contract InterestRateModel {
     address public admin;
 
     event RateParamsUpdated(uint256 baseRate, uint256 multiplier, uint256 jumpMultiplier, uint256 kink);
+    event RateParametersUpdated(
+        uint256 oldBaseRate,
+        uint256 newBaseRate,
+        uint256 oldMultiplier,
+        uint256 newMultiplier,
+        uint256 oldJumpMultiplier,
+        uint256 newJumpMultiplier,
+        uint256 oldKink,
+        uint256 newKink
+    );
+
+    struct RateParameters {
+        uint256 baseRate;
+        uint256 multiplier;
+        uint256 jumpMultiplier;
+        uint256 kink;
+    }
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -44,11 +61,36 @@ contract InterestRateModel {
         uint256 _jumpMultiplier,
         uint256 _kink
     ) external onlyAdmin {
+        uint256 oldBaseRate = baseRate;
+        uint256 oldMultiplier = multiplier;
+        uint256 oldJumpMultiplier = jumpMultiplier;
+        uint256 oldKink = kink;
+
         baseRate = _baseRate;
         multiplier = _multiplier;
         jumpMultiplier = _jumpMultiplier;
         kink = _kink;
+
         emit RateParamsUpdated(_baseRate, _multiplier, _jumpMultiplier, _kink);
+        emit RateParametersUpdated(
+            oldBaseRate,
+            _baseRate,
+            oldMultiplier,
+            _multiplier,
+            oldJumpMultiplier,
+            _jumpMultiplier,
+            oldKink,
+            _kink
+        );
+    }
+
+    function getParameters() external view returns (RateParameters memory params) {
+        params = RateParameters({
+            baseRate: baseRate,
+            multiplier: multiplier,
+            jumpMultiplier: jumpMultiplier,
+            kink: kink
+        });
     }
 
     function getUtilization(uint256 totalBorrowed, uint256 totalDeposits) public pure returns (uint256) {

--- a/test/lending/InterestRateModel.events.test.js
+++ b/test/lending/InterestRateModel.events.test.js
@@ -1,0 +1,60 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("InterestRateModel", function () {
+  it("emits both compatibility and detailed parameter update events", async function () {
+    const InterestRateModel = await ethers.getContractFactory("InterestRateModel");
+    const irm = await InterestRateModel.deploy(100, 200, 300, 400);
+    await irm.waitForDeployment();
+
+    const tx = await irm.updateParams(1000, 2000, 3000, 4000);
+    const receipt = await tx.wait();
+
+    const decodedLogs = receipt.logs
+      .map((log) => {
+        try {
+          return irm.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    const compatibilityEvent = decodedLogs.find((item) => item.name === "RateParamsUpdated");
+    expect(compatibilityEvent).to.not.equal(undefined);
+    expect(compatibilityEvent.args.baseRate).to.equal(1000n);
+    expect(compatibilityEvent.args.multiplier).to.equal(2000n);
+    expect(compatibilityEvent.args.jumpMultiplier).to.equal(3000n);
+    expect(compatibilityEvent.args.kink).to.equal(4000n);
+
+    const detailedEvent = decodedLogs.find((item) => item.name === "RateParametersUpdated");
+    expect(detailedEvent).to.not.equal(undefined);
+    expect(detailedEvent.args.oldBaseRate).to.equal(100n);
+    expect(detailedEvent.args.newBaseRate).to.equal(1000n);
+    expect(detailedEvent.args.oldMultiplier).to.equal(200n);
+    expect(detailedEvent.args.newMultiplier).to.equal(2000n);
+    expect(detailedEvent.args.oldJumpMultiplier).to.equal(300n);
+    expect(detailedEvent.args.newJumpMultiplier).to.equal(3000n);
+    expect(detailedEvent.args.oldKink).to.equal(400n);
+    expect(detailedEvent.args.newKink).to.equal(4000n);
+  });
+
+  it("returns all current parameters via getParameters()", async function () {
+    const InterestRateModel = await ethers.getContractFactory("InterestRateModel");
+    const irm = await InterestRateModel.deploy(11, 22, 33, 44);
+    await irm.waitForDeployment();
+
+    let params = await irm.getParameters();
+    expect(params.baseRate).to.equal(11n);
+    expect(params.multiplier).to.equal(22n);
+    expect(params.jumpMultiplier).to.equal(33n);
+    expect(params.kink).to.equal(44n);
+
+    await irm.updateParams(111, 222, 333, 444);
+    params = await irm.getParameters();
+    expect(params.baseRate).to.equal(111n);
+    expect(params.multiplier).to.equal(222n);
+    expect(params.jumpMultiplier).to.equal(333n);
+    expect(params.kink).to.equal(444n);
+  });
+});


### PR DESCRIPTION
Closes #193

/claim #193

## Summary
- Add `RateParametersUpdated` event with old/new values for all rate params.
- Keep emitting legacy `RateParamsUpdated` event for backward compatibility.
- Add `getParameters()` view to return all active parameters in one call.
- Add focused tests for event emission and getter behavior.

## Verification
- `npx hardhat test test/lending/InterestRateModel.events.test.js --config hardhat.issue193.config.js` (temporary local config with lending-only source/test paths)
  - Result: 2 passing