### PR TITLE
[API] Auto-refund expired escrows via /payments/process-expired

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -6,7 +6,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
-from datetime import datetime
+from datetime import datetime, timedelta
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
@@ -84,6 +84,13 @@ class Payment(Base):
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+    @property
+    def expired_at(self):
+        """Escrow expiry time (30-day grace period after release/creation time)."""
+        if not self.created_at:
+            return None
+        return self.created_at + timedelta(days=30)
 
 
 def init_db():

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -3,12 +3,15 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
+import logging
 
 from ..models.database import get_db, Payment, Task
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/payments", tags=["payments"])
+logger = logging.getLogger(__name__)
+ESCROW_REFUND_GRACE_DAYS = 30
 
 
 class EscrowDeposit(BaseModel):
@@ -103,4 +106,35 @@ async def payment_history(
     return {
         "sent": [{"id": p.id, "amount": p.amount, "status": p.status} for p in sent],
         "received": [{"id": p.id, "amount": p.amount, "status": p.status} for p in received],
+    }
+
+
+@router.post("/process-expired")
+async def process_expired_escrows(db=Depends(get_db)):
+    now = datetime.utcnow()
+    expiry_cutoff = now - timedelta(days=ESCROW_REFUND_GRACE_DAYS)
+    expired_escrows = (
+        db.query(Payment)
+        .filter(Payment.status == "escrowed", Payment.created_at <= expiry_cutoff)
+        .all()
+    )
+
+    refunded_ids = []
+    for escrow in expired_escrows:
+        escrow.status = "refunded"
+        escrow.to_address = escrow.from_address
+        escrow.claimed_at = now
+        refunded_ids.append(escrow.id)
+        logger.info(
+            "Auto-refunded expired escrow id=%s timestamp=%s",
+            escrow.id,
+            now.isoformat(),
+        )
+
+    db.commit()
+    return {
+        "processed": len(expired_escrows),
+        "refunded": len(expired_escrows),
+        "refunded_payment_ids": refunded_ids,
+        "processed_at": now.isoformat(),
     }

--- a/api/tests/test_payments_process_expired.py
+++ b/api/tests/test_payments_process_expired.py
@@ -1,0 +1,124 @@
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.models.database import Base, Payment, Task, User
+from api.routes import payments
+
+
+def _make_client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    app = FastAPI()
+    app.include_router(payments.router)
+
+    def override_get_db():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[payments.get_db] = override_get_db
+    return TestClient(app), SessionLocal, engine
+
+
+def _create_escrow(session, created_at: datetime):
+    address = f"0x{uuid.uuid4().hex[:40]}"
+    user = User(address=address, username=f"user-{uuid.uuid4().hex[:8]}")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    task = Task(
+        title="test task",
+        description="task",
+        reward_amount=1.0,
+        status="open",
+        creator_id=user.id,
+    )
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+
+    payment = Payment(
+        task_id=task.id,
+        from_address=address,
+        amount=1.0,
+        status="escrowed",
+        created_at=created_at,
+    )
+    session.add(payment)
+    session.commit()
+    session.refresh(payment)
+    return payment.id, address
+
+
+def test_process_expired_fresh_escrow_not_affected():
+    client, SessionLocal, engine = _make_client()
+    try:
+        session = SessionLocal()
+        fresh_id, _ = _create_escrow(session, datetime.utcnow() - timedelta(days=5))
+        session.close()
+
+        response = client.post("/payments/process-expired")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["processed"] == 0
+        assert payload["refunded_payment_ids"] == []
+
+        verify = SessionLocal()
+        fresh = verify.get(Payment, fresh_id)
+        assert fresh.status == "escrowed"
+        assert fresh.to_address is None
+        verify.close()
+    finally:
+        client.close()
+        engine.dispose()
+
+
+def test_process_expired_refunds_expired_escrow_and_logs(caplog):
+    client, SessionLocal, engine = _make_client()
+    try:
+        session = SessionLocal()
+        expired_id, expired_from = _create_escrow(
+            session, datetime.utcnow() - timedelta(days=31)
+        )
+        _create_escrow(session, datetime.utcnow() - timedelta(days=10))
+        session.close()
+
+        with caplog.at_level(logging.INFO, logger="api.routes.payments"):
+            response = client.post("/payments/process-expired")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["processed"] == 1
+        assert payload["refunded_payment_ids"] == [expired_id]
+
+        verify = SessionLocal()
+        expired = verify.get(Payment, expired_id)
+        assert expired.status == "refunded"
+        assert expired.to_address == expired_from
+        assert expired.claimed_at is not None
+        verify.close()
+
+        assert f"id={expired_id}" in caplog.text
+        assert "timestamp=" in caplog.text
+    finally:
+        client.close()
+        engine.dispose()


### PR DESCRIPTION
## Summary
- add POST /payments/process-expired to batch refund escrow payments older than 30 days
- add Payment.expired_at computed field (created_at + 30 days)
- log each auto-refund action with escrow id and timestamp
- add minimal API tests for fresh escrow unchanged + expired escrow refunded

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 JWT_SECRET=test-secret python -m pytest api/tests/test_payments_process_expired.py -q
- Result: 2 passed

Closes #197
/claim #197