### PR TITLE
[Solidity] Add gas sponsorship relay for TaskRouter (#190)

### DIFF
--- a/contracts/TaskRouter.sol
+++ b/contracts/TaskRouter.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "./AgentRegistry.sol";
 
 contract TaskRouter {
+    using ECDSA for bytes32;
+
     AgentRegistry public registry;
 
     enum TaskStatus { Open, Assigned, Completed, Disputed, Cancelled }
@@ -19,13 +22,21 @@ contract TaskRouter {
     }
 
     mapping(uint256 => Task) public tasks;
+    mapping(address => uint256) public stakeBalances;
+    mapping(address => uint256) public nonces;
+
     uint256 public taskCount;
     uint256 public platformFee; // basis points
+
+    uint256 private constant RELAY_OVERHEAD = 45000;
 
     event TaskCreated(uint256 indexed taskId, address indexed creator, uint256 reward);
     event TaskAssigned(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskCompleted(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskDisputed(uint256 indexed taskId);
+    event StakeDeposited(address indexed agent, uint256 amount);
+    event StakeWithdrawn(address indexed agent, uint256 amount);
+    event RelayExecuted(address indexed agent, address indexed relayer, uint256 indexed nonce, uint256 reimbursement);
 
     constructor(address _registry, uint256 _platformFee) {
         registry = AgentRegistry(_registry);
@@ -33,32 +44,117 @@ contract TaskRouter {
     }
 
     function createTask(string calldata description, uint256 deadline) external payable returns (uint256) {
-        require(msg.value > 0, "Reward required");
+        return _createTask(description, deadline, msg.value, msg.sender);
+    }
+
+    function assignTask(uint256 taskId, bytes32 agentId) external {
+        _assignTask(taskId, agentId, msg.sender);
+    }
+
+    function completeTask(uint256 taskId, bytes calldata result) external {
+        _completeTask(taskId, result, msg.sender);
+    }
+
+    function cancelTask(uint256 taskId) external {
+        _cancelTask(taskId, msg.sender);
+    }
+
+    function disputeTask(uint256 taskId) external {
+        _disputeTask(taskId, msg.sender);
+    }
+
+    function depositStake() external payable {
+        require(msg.value > 0, "Stake required");
+        stakeBalances[msg.sender] += msg.value;
+        emit StakeDeposited(msg.sender, msg.value);
+    }
+
+    function withdrawStake(uint256 amount) external {
+        require(amount > 0, "Amount required");
+        require(stakeBalances[msg.sender] >= amount, "Insufficient stake");
+
+        stakeBalances[msg.sender] -= amount;
+        (bool success, ) = msg.sender.call{value: amount}("");
+        require(success, "Withdraw failed");
+
+        emit StakeWithdrawn(msg.sender, amount);
+    }
+
+    function executeOnBehalf(address agent, bytes calldata data, bytes calldata signature) external returns (bytes memory) {
+        require(agent != address(0), "Invalid agent");
+
+        uint256 gasStart = gasleft();
+        uint256 nonce = nonces[agent];
+        _verifySignature(agent, data, nonce, signature);
+
+        nonces[agent] = nonce + 1;
+
+        bytes4 selector;
+        assembly {
+            selector := calldataload(data.offset)
+        }
+
+        if (selector == this.assignTask.selector) {
+            (uint256 taskId, bytes32 agentId) = abi.decode(data[4:], (uint256, bytes32));
+            _assignTask(taskId, agentId, agent);
+        } else if (selector == this.completeTask.selector) {
+            (uint256 taskId, bytes memory result) = abi.decode(data[4:], (uint256, bytes));
+            _completeTask(taskId, result, agent);
+        } else if (selector == this.disputeTask.selector) {
+            (uint256 taskId) = abi.decode(data[4:], (uint256));
+            _disputeTask(taskId, agent);
+        } else if (selector == this.cancelTask.selector) {
+            (uint256 taskId) = abi.decode(data[4:], (uint256));
+            _cancelTask(taskId, agent);
+        } else {
+            revert("Unsupported call");
+        }
+
+        uint256 gasUsed = gasStart - gasleft() + RELAY_OVERHEAD;
+        uint256 reimbursement = gasUsed * tx.gasprice;
+        require(stakeBalances[agent] >= reimbursement, "Insufficient stake");
+
+        stakeBalances[agent] -= reimbursement;
+        (bool refunded, ) = msg.sender.call{value: reimbursement}("");
+        require(refunded, "Reimburse failed");
+
+        emit RelayExecuted(agent, msg.sender, nonce, reimbursement);
+
+        return "";
+    }
+
+    function _createTask(
+        string calldata description,
+        uint256 deadline,
+        uint256 reward,
+        address creator
+    ) internal returns (uint256) {
+        require(reward > 0, "Reward required");
         require(deadline > block.timestamp, "Invalid deadline");
 
         uint256 taskId = taskCount++;
         tasks[taskId] = Task({
-            creator: msg.sender,
+            creator: creator,
             assignedAgent: bytes32(0),
             description: description,
-            reward: msg.value,
+            reward: reward,
             deadline: deadline,
             status: TaskStatus.Open,
             result: ""
         });
 
-        emit TaskCreated(taskId, msg.sender, msg.value);
+        emit TaskCreated(taskId, creator, reward);
         return taskId;
     }
 
-    function assignTask(uint256 taskId, bytes32 agentId) external {
+    function _assignTask(uint256 taskId, bytes32 agentId, address actor) internal {
         Task storage task = tasks[taskId];
         require(task.status == TaskStatus.Open, "Not open");
         require(block.timestamp < task.deadline, "Deadline passed");
 
         AgentRegistry.Agent memory agent = registry.getAgent(agentId);
         require(agent.active, "Agent not active");
-        require(agent.owner == msg.sender, "Not agent owner");
+        require(agent.owner == actor, "Not agent owner");
 
         task.assignedAgent = agentId;
         task.status = TaskStatus.Assigned;
@@ -66,12 +162,12 @@ contract TaskRouter {
         emit TaskAssigned(taskId, agentId);
     }
 
-    function completeTask(uint256 taskId, bytes calldata result) external {
+    function _completeTask(uint256 taskId, bytes memory result, address actor) internal {
         Task storage task = tasks[taskId];
         require(task.status == TaskStatus.Assigned, "Not assigned");
 
         AgentRegistry.Agent memory agent = registry.getAgent(task.assignedAgent);
-        require(agent.owner == msg.sender, "Not assigned agent owner");
+        require(agent.owner == actor, "Not assigned agent owner");
 
         task.result = result;
         task.status = TaskStatus.Completed;
@@ -79,29 +175,37 @@ contract TaskRouter {
         uint256 fee = task.reward * platformFee / 10000;
         uint256 payout = task.reward - fee;
 
-        (bool success, ) = msg.sender.call{value: payout}("");
+        (bool success, ) = actor.call{value: payout}("");
         require(success, "Payout failed");
 
         emit TaskCompleted(taskId, task.assignedAgent);
     }
 
-    function cancelTask(uint256 taskId) external {
+    function _cancelTask(uint256 taskId, address actor) internal {
         Task storage task = tasks[taskId];
-        require(task.creator == msg.sender, "Not creator");
+        require(task.creator == actor, "Not creator");
         require(task.status == TaskStatus.Open, "Cannot cancel");
 
         task.status = TaskStatus.Cancelled;
-        (bool success, ) = msg.sender.call{value: task.reward}("");
+        (bool success, ) = actor.call{value: task.reward}("");
         require(success, "Refund failed");
     }
 
-    function disputeTask(uint256 taskId) external {
+    function _disputeTask(uint256 taskId, address actor) internal {
         Task storage task = tasks[taskId];
-        require(task.creator == msg.sender, "Not creator");
+        require(task.creator == actor, "Not creator");
         require(task.status == TaskStatus.Assigned, "Not assigned");
         require(block.timestamp > task.deadline, "Deadline not passed");
 
         task.status = TaskStatus.Disputed;
         emit TaskDisputed(taskId);
+    }
+
+    function _verifySignature(address agent, bytes calldata data, uint256 nonce, bytes calldata signature) internal view {
+        bytes32 messageHash = keccak256(abi.encode(address(this), block.chainid, agent, nonce, keccak256(data)));
+        bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+
+        address signer = digest.recover(signature);
+        require(signer == agent, "Invalid signature");
     }
 }

--- a/contracts_relay/TaskRouterEntry.sol
+++ b/contracts_relay/TaskRouterEntry.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../contracts/TaskRouter.sol";

--- a/hardhat.relay.config.js
+++ b/hardhat.relay.config.js
@@ -1,0 +1,22 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: {
+    version: "0.8.20",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  paths: {
+    sources: "./contracts_relay",
+    tests: "./test",
+    cache: "./cache-relay",
+    artifacts: "./artifacts-relay",
+  },
+  networks: {
+    hardhat: {},
+  },
+};

--- a/test/TaskRouterRelay.test.js
+++ b/test/TaskRouterRelay.test.js
@@ -1,0 +1,101 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("TaskRouter relay", function () {
+  let registry;
+  let router;
+  let creator;
+  let agentOwner;
+  let relayer;
+  let agentId;
+
+  async function signRelayCall(agentSigner, agentAddress, nonce, data) {
+    const network = await ethers.provider.getNetwork();
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address", "uint256", "address", "uint256", "bytes32"],
+      [router.target, network.chainId, agentAddress, nonce, ethers.keccak256(data)]
+    );
+    const relayHash = ethers.keccak256(encoded);
+
+    return agentSigner.signMessage(ethers.getBytes(relayHash));
+  }
+
+  beforeEach(async function () {
+    [creator, agentOwner, relayer] = await ethers.getSigners();
+
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    registry = await AgentRegistry.deploy(0);
+    await registry.waitForDeployment();
+
+    const TaskRouter = await ethers.getContractFactory("TaskRouter");
+    router = await TaskRouter.deploy(registry.target, 0);
+    await router.waitForDeployment();
+
+    const tx = await registry.connect(agentOwner).registerAgent("agent-1", "https://agent.local", { value: 0 });
+    const receipt = await tx.wait();
+    const evt = receipt.logs.find((log) => log.fragment && log.fragment.name === "AgentRegistered");
+    agentId = evt.args.agentId;
+
+    const latest = await ethers.provider.getBlock("latest");
+    const deadline = Number(latest.timestamp) + 3600;
+    await router.connect(creator).createTask("relay task", deadline, { value: ethers.parseEther("1") });
+  });
+
+  it("supports sponsored execution and reimburses relayer", async function () {
+    await router.connect(agentOwner).depositStake({ value: ethers.parseEther("1") });
+
+    const data = router.interface.encodeFunctionData("assignTask", [0n, agentId]);
+    const nonce = await router.nonces(agentOwner.address);
+    const signature = await signRelayCall(agentOwner, agentOwner.address, nonce, data);
+
+    const stakeBefore = await router.stakeBalances(agentOwner.address);
+    const relayerBalanceBefore = await ethers.provider.getBalance(relayer.address);
+
+    const tx = await router.connect(relayer).executeOnBehalf(agentOwner.address, data, signature);
+    const receipt = await tx.wait();
+
+    const relayerBalanceAfter = await ethers.provider.getBalance(relayer.address);
+    const stakeAfter = await router.stakeBalances(agentOwner.address);
+    const task = await router.tasks(0);
+
+    const relayEvent = receipt.logs.find((log) => log.fragment && log.fragment.name === "RelayExecuted");
+    expect(relayEvent).to.not.equal(undefined);
+
+    const reimbursement = relayEvent.args.reimbursement;
+    const gasPaid = receipt.gasUsed * receipt.gasPrice;
+    const expectedRelayerAfter = relayerBalanceBefore - gasPaid + reimbursement;
+
+    expect(task.status).to.equal(1n);
+    expect(task.assignedAgent).to.equal(agentId);
+    expect(reimbursement).to.be.gt(0n);
+    expect(stakeBefore - stakeAfter).to.equal(reimbursement);
+    expect(relayerBalanceAfter).to.equal(expectedRelayerAfter);
+  });
+
+  it("prevents replay with nonce-based signature checks", async function () {
+    await router.connect(agentOwner).depositStake({ value: ethers.parseEther("1") });
+
+    const data = router.interface.encodeFunctionData("assignTask", [0n, agentId]);
+    const nonce = await router.nonces(agentOwner.address);
+    const signature = await signRelayCall(agentOwner, agentOwner.address, nonce, data);
+
+    await router.connect(relayer).executeOnBehalf(agentOwner.address, data, signature);
+
+    await expect(
+      router.connect(relayer).executeOnBehalf(agentOwner.address, data, signature)
+    ).to.be.revertedWith("Invalid signature");
+  });
+
+  it("reverts when sponsored account stake cannot cover gas reimbursement", async function () {
+    const data = router.interface.encodeFunctionData("assignTask", [0n, agentId]);
+    const nonce = await router.nonces(agentOwner.address);
+    const signature = await signRelayCall(agentOwner, agentOwner.address, nonce, data);
+
+    await expect(
+      router.connect(relayer).executeOnBehalf(agentOwner.address, data, signature)
+    ).to.be.revertedWith("Insufficient stake");
+
+    const task = await router.tasks(0);
+    expect(task.status).to.equal(0n);
+  });
+});


### PR DESCRIPTION
## Summary
- add `executeOnBehalf(agent, data, signature)` relay path in `TaskRouter`
- verify agent signatures over `(router, chainId, agent, nonce, calldataHash)` and enforce per-agent nonces
- add sponsor stake accounting (`depositStake`, `withdrawStake`) and reimburse relayer gas from sponsor stake
- keep existing direct call flow (`assignTask`, `completeTask`, etc.) backwards compatible via shared internal functions
- add focused relay tests for sponsored execution, replay prevention, and insufficient stake

## Test
- `npx hardhat test test/TaskRouterRelay.test.js --config hardhat.relay.config.js`

Closes #190
/claim #190
