### PR TITLE
fix(staking): add emergencyWithdraw to MultiTokenStaking

### DIFF
--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -37,6 +37,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
+    event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
 
     // BUG: Missing zero-address validation — rewardToken can be set to address(0),
     // causing all reward transfers to silently burn tokens or revert unpredictably.
@@ -130,6 +131,24 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
         user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
         emit Withdraw(msg.sender, pid, amount);
+    }
+
+    /// @notice Emergency withdraw staked tokens without claiming rewards.
+    /// @param pid Pool ID.
+    function emergencyWithdraw(uint256 pid) external nonReentrant {
+        PoolInfo storage pool = poolInfo[pid];
+        UserInfo storage user = userInfo[pid][msg.sender];
+
+        uint256 amount = user.amount;
+        user.amount = 0;
+        user.rewardDebt = 0;
+
+        if (amount > 0) {
+            pool.totalStaked -= amount;
+            pool.stakeToken.safeTransfer(msg.sender, amount);
+        }
+
+        emit EmergencyWithdraw(msg.sender, pid, amount);
     }
 
     /// @notice View pending rewards for a user in a pool.

--- a/test/MultiTokenStaking.emergencyWithdraw.test.js
+++ b/test/MultiTokenStaking.emergencyWithdraw.test.js
@@ -1,0 +1,51 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MultiTokenStaking emergencyWithdraw", function () {
+  let owner, staker;
+  let stakeToken, rewardToken, staking;
+
+  beforeEach(async function () {
+    [owner, staker] = await ethers.getSigners();
+
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    stakeToken = await AgentToken.deploy("Stake Token", "STK", ethers.parseEther("1000000"));
+    rewardToken = await AgentToken.deploy("Reward Token", "RWD", ethers.parseEther("1000000"));
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    staking = await MultiTokenStaking.deploy(await rewardToken.getAddress(), ethers.parseEther("1"));
+
+    await staking.addPool(100, await stakeToken.getAddress());
+    await rewardToken.transfer(await staking.getAddress(), ethers.parseEther("100000"));
+    await stakeToken.transfer(staker.address, ethers.parseEther("1000"));
+  });
+
+  it("returns staked tokens without distributing rewards and resets accounting", async function () {
+    const amount = ethers.parseEther("100");
+    await stakeToken.connect(staker).approve(await staking.getAddress(), amount);
+    await staking.connect(staker).deposit(0, amount);
+
+    await ethers.provider.send("evm_increaseTime", [3600]);
+    await ethers.provider.send("evm_mine", []);
+
+    const pending = await staking.pendingReward(0, staker.address);
+    expect(pending).to.be.gt(0n);
+
+    const rewardBalanceBefore = await rewardToken.balanceOf(staker.address);
+    const stakeBalanceBefore = await stakeToken.balanceOf(staker.address);
+
+    await expect(staking.connect(staker).emergencyWithdraw(0))
+      .to.emit(staking, "EmergencyWithdraw")
+      .withArgs(staker.address, 0, amount);
+
+    const user = await staking.userInfo(0, staker.address);
+    const pool = await staking.poolInfo(0);
+
+    expect(user.amount).to.equal(0n);
+    expect(user.rewardDebt).to.equal(0n);
+    expect(pool.totalStaked).to.equal(0n);
+    expect(await rewardToken.balanceOf(staker.address)).to.equal(rewardBalanceBefore);
+    expect(await stakeToken.balanceOf(staker.address)).to.equal(stakeBalanceBefore + amount);
+    expect(await staking.pendingReward(0, staker.address)).to.equal(0n);
+  });
+});


### PR DESCRIPTION
## Summary
- add EmergencyWithdraw event to MultiTokenStaking
- add mergencyWithdraw(uint256 pid) to return principal without rewards
- reset user mount and ewardDebt, decrement pool 	otalStaked, and transfer staked token back
- add a focused test covering stake -> accrue rewards -> emergencyWithdraw path

## Validation
- 
px hardhat test --config hardhat.issue195.config.js (isolated issue-195 harness with only required contracts)
- result: 1 passing

Closes #195
/claim #195