### PR TITLE
[API] Add immutable admin audit log endpoints (pre-audit)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,9 @@
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
+from copy import deepcopy
 from datetime import datetime
+from typing import Any, Optional
+
+from fastapi import FastAPI, Header, HTTPException, Query, Request
+from pydantic import BaseModel
 
 app = FastAPI(
     title="OpenAgents API",
@@ -39,9 +41,67 @@ class LeaderboardEntry(BaseModel):
     success_rate: float
 
 
+class AdminParameterUpdate(BaseModel):
+    value: Any
+
+
+class AdminUserUpdate(BaseModel):
+    username: Optional[str] = None
+    active: Optional[bool] = None
+    roles: Optional[list[str]] = None
+
+
+class AuditLogEntry(BaseModel):
+    id: int
+    action: str
+    actor: str
+    target: str
+    before: Optional[Any] = None
+    after: Optional[Any] = None
+    timestamp: datetime
+    ip: str
+
+
+class AuditLogListResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    records: list[AuditLogEntry]
+
+
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+users_cache: dict = {}
+admin_parameters: dict = {}
+audit_logs: list[dict[str, Any]] = []
+audit_log_seq = 0
+
+
+def _record_audit(
+    *,
+    action: str,
+    actor: str,
+    target: str,
+    before: Optional[Any],
+    after: Optional[Any],
+    request: Request,
+) -> dict[str, Any]:
+    global audit_log_seq
+    audit_log_seq += 1
+    ip = request.client.host if request.client else "unknown"
+    record = {
+        "id": audit_log_seq,
+        "action": action,
+        "actor": actor,
+        "target": target,
+        "before": deepcopy(before),
+        "after": deepcopy(after),
+        "timestamp": datetime.utcnow(),
+        "ip": ip,
+    }
+    audit_logs.append(record)
+    return record
 
 
 @app.get("/agents", response_model=list[AgentResponse])
@@ -110,3 +170,85 @@ async def health():
         "tasks_indexed": len(tasks_cache),
         "timestamp": datetime.utcnow().isoformat(),
     }
+
+
+@app.put("/admin/parameters/{parameter_name}")
+async def update_admin_parameter(
+    parameter_name: str,
+    payload: AdminParameterUpdate,
+    request: Request,
+    actor: str = Header(..., alias="X-Admin-Actor"),
+):
+    before = deepcopy(admin_parameters.get(parameter_name))
+    admin_parameters[parameter_name] = payload.value
+    after = deepcopy(admin_parameters[parameter_name])
+    record = _record_audit(
+        action="parameter_update",
+        actor=actor,
+        target=f"parameter:{parameter_name}",
+        before=before,
+        after=after,
+        request=request,
+    )
+    return {
+        "parameter": parameter_name,
+        "value": admin_parameters[parameter_name],
+        "audit_id": record["id"],
+    }
+
+
+@app.put("/admin/users/{user_id}")
+async def upsert_admin_user(
+    user_id: str,
+    payload: AdminUserUpdate,
+    request: Request,
+    actor: str = Header(..., alias="X-Admin-Actor"),
+):
+    before = deepcopy(users_cache.get(user_id))
+    current = deepcopy(users_cache.get(user_id, {"user_id": user_id, "active": True, "roles": []}))
+    updates = payload.model_dump(exclude_unset=True)
+    for field, value in updates.items():
+        current[field] = value
+    current["user_id"] = user_id
+    users_cache[user_id] = current
+    after = deepcopy(current)
+    record = _record_audit(
+        action="user_update",
+        actor=actor,
+        target=f"user:{user_id}",
+        before=before,
+        after=after,
+        request=request,
+    )
+    return {"user": users_cache[user_id], "audit_id": record["id"]}
+
+
+@app.get("/admin/audit-log", response_model=AuditLogListResponse)
+async def list_admin_audit_log(
+    actor: Optional[str] = Query(None),
+    action: Optional[str] = Query(None),
+    start_date: Optional[datetime] = Query(None),
+    end_date: Optional[datetime] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    records = audit_logs
+    if actor:
+        records = [record for record in records if record["actor"] == actor]
+    if action:
+        records = [record for record in records if record["action"] == action]
+    if start_date:
+        records = [record for record in records if record["timestamp"] >= start_date]
+    if end_date:
+        records = [record for record in records if record["timestamp"] <= end_date]
+    return {
+        "total": len(records),
+        "limit": limit,
+        "offset": offset,
+        "records": records[offset : offset + limit],
+    }
+
+
+@app.api_route("/admin/audit-log/{audit_id}", methods=["PUT", "PATCH", "DELETE"])
+async def reject_audit_log_mutation(audit_id: int):
+    raise HTTPException(status_code=405, detail="Audit log records are immutable")

--- a/api/tests/test_admin_audit_log.py
+++ b/api/tests/test_admin_audit_log.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from api import main
+
+
+client = TestClient(main.app)
+
+
+def setup_function():
+    main.admin_parameters.clear()
+    main.users_cache.clear()
+    main.audit_logs.clear()
+    main.audit_log_seq = 0
+
+
+def test_admin_actions_create_audit_records_with_before_after():
+    first = client.put(
+        "/admin/parameters/maxAgents",
+        json={"value": 10},
+        headers={"X-Admin-Actor": "alice"},
+    )
+    assert first.status_code == 200
+
+    second = client.put(
+        "/admin/parameters/maxAgents",
+        json={"value": 12},
+        headers={"X-Admin-Actor": "alice"},
+    )
+    assert second.status_code == 200
+
+    third = client.put(
+        "/admin/users/u-1",
+        json={"active": False, "roles": ["moderator"]},
+        headers={"X-Admin-Actor": "bob"},
+    )
+    assert third.status_code == 200
+
+    logs = client.get("/admin/audit-log").json()["records"]
+    assert len(logs) == 3
+
+    parameter_update = logs[1]
+    assert parameter_update["action"] == "parameter_update"
+    assert parameter_update["before"] == 10
+    assert parameter_update["after"] == 12
+    assert parameter_update["ip"] == "testclient"
+
+
+def test_admin_audit_log_filters_by_actor_action_and_date_range():
+    client.put(
+        "/admin/parameters/feeBps",
+        json={"value": 200},
+        headers={"X-Admin-Actor": "alice"},
+    )
+    client.put(
+        "/admin/users/u-2",
+        json={"active": False},
+        headers={"X-Admin-Actor": "bob"},
+    )
+
+    filtered = client.get("/admin/audit-log?actor=alice&action=parameter_update").json()
+    assert filtered["total"] == 1
+    assert filtered["records"][0]["target"] == "parameter:feeBps"
+
+    second_ts = datetime.fromisoformat(main.audit_logs[1]["timestamp"].isoformat())
+    start_date = (second_ts - timedelta(seconds=1)).isoformat()
+    end_date = (second_ts + timedelta(seconds=1)).isoformat()
+
+    by_range = client.get(
+        f"/admin/audit-log?start_date={start_date}&end_date={end_date}&action=user_update"
+    ).json()
+    assert by_range["total"] == 1
+    assert by_range["records"][0]["actor"] == "bob"
+
+
+def test_admin_audit_log_is_immutable():
+    client.put(
+        "/admin/parameters/maxTasks",
+        json={"value": 5},
+        headers={"X-Admin-Actor": "alice"},
+    )
+
+    patch_resp = client.patch("/admin/audit-log/1", json={"action": "tampered"})
+    delete_resp = client.delete("/admin/audit-log/1")
+
+    assert patch_resp.status_code == 405
+    assert delete_resp.status_code == 405
+
+    logs = client.get("/admin/audit-log").json()["records"]
+    assert len(logs) == 1
+    assert logs[0]["action"] == "parameter_update"


### PR DESCRIPTION
## Summary\n- add in-memory AuditLogEntry model + shared recorder for admin write actions\n- add admin write endpoints that capture actor, target, before/after values, timestamp, and ip\n- add GET /admin/audit-log with pagination and actor/action/date-range filters\n- enforce audit-record immutability via explicit 405 mutation guard\n- add focused API tests for creation, filtering, and immutability\n\n## Verification\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_admin_audit_log.py -q\n- result: 3 passed\n\nCloses #184\n/claim #184