### PR TITLE
Add AgentRegistry batchRegister (up to 50) with minimal AC tests

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -32,27 +32,22 @@ contract AgentRegistry is Ownable {
 
     function registerAgent(string calldata name, string calldata endpoint) external payable returns (bytes32) {
         require(msg.value >= registrationFee, "Insufficient fee");
-        require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
+        return _registerAgent(msg.sender, name, endpoint, 0);
+    }
 
-        bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp));
+    function batchRegister(string[] calldata names, string[] calldata endpoints) external payable returns (bytes32[] memory) {
+        uint256 count = names.length;
+        require(count == endpoints.length, "Length mismatch");
+        require(count > 0 && count <= 50, "Invalid batch size");
 
-        require(agents[agentId].registeredAt == 0, "Agent exists");
+        uint256 totalFee = registrationFee * count;
+        require(msg.value >= totalFee, "Insufficient fee");
 
-        agents[agentId] = Agent({
-            owner: msg.sender,
-            name: name,
-            endpoint: endpoint,
-            reputation: 100,
-            tasksCompleted: 0,
-            registeredAt: block.timestamp,
-            active: true
-        });
-
-        ownerAgents[msg.sender].push(agentId);
-        agentIds.push(agentId);
-
-        emit AgentRegistered(agentId, msg.sender, name);
-        return agentId;
+        bytes32[] memory registeredIds = new bytes32[](count);
+        for (uint256 i = 0; i < count; i++) {
+            registeredIds[i] = _registerAgent(msg.sender, names[i], endpoints[i], i);
+        }
+        return registeredIds;
     }
 
     function deactivateAgent(bytes32 agentId) external {
@@ -92,5 +87,29 @@ contract AgentRegistry is Ownable {
     function withdrawFees() external onlyOwner {
         (bool success, ) = owner().call{value: address(this).balance}("");
         require(success, "Withdraw failed");
+    }
+
+    function _registerAgent(address agentOwner, string memory name, string memory endpoint, uint256 salt) internal returns (bytes32) {
+        require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
+
+        bytes32 agentId = keccak256(
+            abi.encodePacked(agentOwner, name, endpoint, block.timestamp, salt, agentIds.length)
+        );
+        require(agents[agentId].registeredAt == 0, "Agent exists");
+
+        agents[agentId] = Agent({
+            owner: agentOwner,
+            name: name,
+            endpoint: endpoint,
+            reputation: 100,
+            tasksCompleted: 0,
+            registeredAt: block.timestamp,
+            active: true
+        });
+
+        ownerAgents[agentOwner].push(agentId);
+        agentIds.push(agentId);
+        emit AgentRegistered(agentId, agentOwner, name);
+        return agentId;
     }
 }

--- a/test/AgentRegistry.batch.test.js
+++ b/test/AgentRegistry.batch.test.js
@@ -1,0 +1,81 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentRegistry batchRegister", function () {
+  const REGISTRATION_FEE = 1_000n;
+  let registry;
+  let user;
+
+  beforeEach(async function () {
+    [, user] = await ethers.getSigners();
+    const AgentRegistry = await ethers.getContractFactory("AgentRegistry");
+    registry = await AgentRegistry.deploy(REGISTRATION_FEE);
+    await registry.waitForDeployment();
+  });
+
+  function getRegisteredEvents(receipt) {
+    const eventTopic = registry.interface.getEvent("AgentRegistered").topicHash;
+    return receipt.logs.filter(
+      (log) => log.address === registry.target && log.topics[0] === eventTopic
+    );
+  }
+
+  it("registers a batch of 1 agent", async function () {
+    const names = ["agent-1"];
+    const endpoints = ["https://agent-1.local"];
+
+    const tx = await registry
+      .connect(user)
+      .batchRegister(names, endpoints, { value: REGISTRATION_FEE });
+    const receipt = await tx.wait();
+    const events = getRegisteredEvents(receipt);
+
+    expect(events.length).to.equal(1);
+
+    const parsed = registry.interface.parseLog(events[0]);
+    const agentId = parsed.args.agentId;
+
+    const agent = await registry.getAgent(agentId);
+    expect(agent.owner).to.equal(user.address);
+    expect(agent.name).to.equal(names[0]);
+    expect(agent.endpoint).to.equal(endpoints[0]);
+    expect(await ethers.provider.getBalance(registry.target)).to.equal(REGISTRATION_FEE);
+  });
+
+  it("registers a batch of 50 agents with unique IDs and events", async function () {
+    const count = 50;
+    const names = Array.from({ length: count }, (_, i) => `agent-${i + 1}`);
+    const endpoints = Array.from(
+      { length: count },
+      (_, i) => `https://agent-${i + 1}.local`
+    );
+    const totalFee = REGISTRATION_FEE * BigInt(count);
+
+    const tx = await registry
+      .connect(user)
+      .batchRegister(names, endpoints, { value: totalFee });
+    const receipt = await tx.wait();
+    const events = getRegisteredEvents(receipt);
+
+    expect(events.length).to.equal(count);
+
+    const ids = events.map((eventLog) => registry.interface.parseLog(eventLog).args.agentId);
+    expect(new Set(ids).size).to.equal(count);
+
+    const firstAgent = await registry.getAgent(ids[0]);
+    const lastAgent = await registry.getAgent(ids[count - 1]);
+    expect(firstAgent.name).to.equal(names[0]);
+    expect(lastAgent.name).to.equal(names[count - 1]);
+    expect(await ethers.provider.getBalance(registry.target)).to.equal(totalFee);
+  });
+
+  it("reverts on array length mismatch", async function () {
+    await expect(
+      registry.connect(user).batchRegister(
+        ["agent-1", "agent-2"],
+        ["https://agent-1.local"],
+        { value: REGISTRATION_FEE * 2n }
+      )
+    ).to.be.revertedWith("Length mismatch");
+  });
+});


### PR DESCRIPTION
## Summary
- add `batchRegister(string[] names, string[] endpoints)` to `AgentRegistry`
- enforce length match and batch size limit (`1..50`)
- collect total fee once via `registrationFee * count`
- emit one `AgentRegistered` event per registered agent
- reuse shared `_registerAgent` internal path for single/batch registration

## Tests
- `npx hardhat test --config hardhat.test182.config.js test/AgentRegistry.batch.test.js`
- result: 3 passing

Closes #182
/claim #182
