### PR TITLE
[API] Validate agent endpoint URL format and block internal targets

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,8 +1,13 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, Union
 from datetime import datetime
 
 from ..models.database import get_db, Agent
@@ -13,6 +18,7 @@ router = APIRouter(prefix="/agents", tags=["agents"])
 
 class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    endpoint: str
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
@@ -24,13 +30,83 @@ class AgentUpdate(BaseModel):
     config: Optional[dict] = None
 
 
+def _is_internal_ip(ip_value: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> bool:
+    return (
+        ip_value.is_private
+        or ip_value.is_loopback
+        or ip_value.is_link_local
+        or ip_value.is_reserved
+        or ip_value.is_multicast
+    )
+
+
+async def validate_agent_endpoint(endpoint: str) -> str:
+    normalized = endpoint.strip()
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid endpoint URL format. Use a full http:// or https:// URL.",
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise HTTPException(status_code=400, detail="Endpoint URL must include a hostname.")
+
+    try:
+        direct_ip = ipaddress.ip_address(hostname)
+        if _is_internal_ip(direct_ip):
+            raise HTTPException(
+                status_code=400,
+                detail="Endpoint URL points to a private or internal IP address.",
+            )
+    except ValueError:
+        if hostname.lower() == "localhost":
+            raise HTTPException(
+                status_code=400,
+                detail="Endpoint URL points to a private or internal IP address.",
+            )
+        try:
+            resolved_hosts = socket.getaddrinfo(hostname, None)
+        except socket.gaierror:
+            raise HTTPException(status_code=400, detail="Endpoint hostname could not be resolved.")
+
+        for _, _, _, _, sockaddr in resolved_hosts:
+            resolved_ip = ipaddress.ip_address(sockaddr[0].split("%")[0])
+            if _is_internal_ip(resolved_ip):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Endpoint URL points to a private or internal IP address.",
+                )
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            await client.head(normalized)
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=400,
+            detail="Endpoint URL check timed out after 5 seconds.",
+        )
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Endpoint URL is not reachable: {exc.__class__.__name__}.",
+        )
+
+    return normalized
+
+
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    validated_endpoint = await validate_agent_endpoint(agent.endpoint)
+    config = dict(agent.config or {})
+    config["endpoint"] = validated_endpoint
+
     new_agent = Agent(
         name=agent.name,
         description=agent.description,
         model_type=agent.model_type,
-        config=agent.config or {},
+        config=config,
         owner_id=user["id"],
         created_at=datetime.utcnow(),
     )

--- a/api/tests/test_agents_endpoint_validation.py
+++ b/api/tests/test_agents_endpoint_validation.py
@@ -1,0 +1,114 @@
+import asyncio
+import os
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.routes import agents
+from api.routes.agents import AgentCreate, create_agent, validate_agent_endpoint
+
+
+class _HeadOkClient:
+    def __init__(self, *args, **kwargs):
+        self.called_url = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def head(self, url):
+        self.called_url = url
+        return object()
+
+
+class _HeadTimeoutClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def head(self, url):
+        raise httpx.ReadTimeout("timed out")
+
+
+def _public_dns_result(*args, **kwargs):
+    return [(0, 0, 0, "", ("93.184.216.34", 0))]
+
+
+def test_validate_agent_endpoint_accepts_valid_url(monkeypatch):
+    monkeypatch.setattr(agents.socket, "getaddrinfo", _public_dns_result)
+    monkeypatch.setattr(agents.httpx, "AsyncClient", _HeadOkClient)
+
+    result = asyncio.run(validate_agent_endpoint("https://example.com/agent"))
+
+    assert result == "https://example.com/agent"
+
+
+def test_validate_agent_endpoint_rejects_invalid_format():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(validate_agent_endpoint("example.com/no-scheme"))
+
+    assert exc.value.status_code == 400
+    assert "Invalid endpoint URL format" in exc.value.detail
+
+
+def test_validate_agent_endpoint_rejects_private_ip():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(validate_agent_endpoint("http://127.0.0.1:8000/agent"))
+
+    assert exc.value.status_code == 400
+    assert "private or internal IP" in exc.value.detail
+
+
+def test_validate_agent_endpoint_rejects_head_timeout(monkeypatch):
+    monkeypatch.setattr(agents.socket, "getaddrinfo", _public_dns_result)
+    monkeypatch.setattr(agents.httpx, "AsyncClient", _HeadTimeoutClient)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(validate_agent_endpoint("https://example.com/agent"))
+
+    assert exc.value.status_code == 400
+    assert "timed out" in exc.value.detail
+
+
+class _FakeDB:
+    def __init__(self):
+        self.added = None
+
+    def add(self, obj):
+        self.added = obj
+        obj.id = 1
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+
+def test_create_agent_stores_validated_endpoint(monkeypatch):
+    async def _fake_validate(endpoint):
+        return "https://validated.example/agent"
+
+    monkeypatch.setattr(agents, "validate_agent_endpoint", _fake_validate)
+    db = _FakeDB()
+    payload = AgentCreate(
+        name="worker-1",
+        endpoint="https://example.com/raw",
+        config={"temperature": 0.1},
+    )
+
+    response = asyncio.run(create_agent(payload, user={"id": 11, "address": "0xabc"}, db=db))
+
+    assert response["id"] == 1
+    assert db.added.config["endpoint"] == "https://validated.example/agent"
+    assert db.added.config["temperature"] == 0.1


### PR DESCRIPTION
## Summary
- validate agent endpoint format (http/https URL required)
- block private/internal targets (private/loopback/link-local/reserved/multicast, localhost, and DNS-resolved internal IPs)
- verify reachability with HEAD request (5s timeout) before persisting
- store the validated endpoint in agent config
- add focused tests for valid URL, invalid format, private IP, timeout, and persistence path

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q api/tests/test_agents_endpoint_validation.py

Closes #187
/claim #187