### PR TITLE
Fix unchecked ERC20 transfer return handling in TaskRouter v2

### DIFF
--- a/contracts/TaskRouter.sol
+++ b/contracts/TaskRouter.sol
@@ -2,9 +2,14 @@
 pragma solidity ^0.8.20;
 
 import "./AgentRegistry.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract TaskRouter {
+    using SafeERC20 for IERC20;
+
     AgentRegistry public registry;
+    address public owner;
 
     enum TaskStatus { Open, Assigned, Completed, Disputed, Cancelled }
 
@@ -13,12 +18,15 @@ contract TaskRouter {
         bytes32 assignedAgent;
         string description;
         uint256 reward;
+        address rewardToken;
         uint256 deadline;
         TaskStatus status;
         bytes result;
     }
 
     mapping(uint256 => Task) public tasks;
+    mapping(address => uint256) public tokenFees;
+    uint256 public nativeFees;
     uint256 public taskCount;
     uint256 public platformFee; // basis points
 
@@ -30,6 +38,12 @@ contract TaskRouter {
     constructor(address _registry, uint256 _platformFee) {
         registry = AgentRegistry(_registry);
         platformFee = _platformFee;
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
     }
 
     function createTask(string calldata description, uint256 deadline) external payable returns (uint256) {
@@ -42,12 +56,41 @@ contract TaskRouter {
             assignedAgent: bytes32(0),
             description: description,
             reward: msg.value,
+            rewardToken: address(0),
             deadline: deadline,
             status: TaskStatus.Open,
             result: ""
         });
 
         emit TaskCreated(taskId, msg.sender, msg.value);
+        return taskId;
+    }
+
+    function createTaskWithToken(
+        address token,
+        uint256 amount,
+        string calldata description,
+        uint256 deadline
+    ) external returns (uint256) {
+        require(token != address(0), "Invalid token");
+        require(amount > 0, "Reward required");
+        require(deadline > block.timestamp, "Invalid deadline");
+
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+        uint256 taskId = taskCount++;
+        tasks[taskId] = Task({
+            creator: msg.sender,
+            assignedAgent: bytes32(0),
+            description: description,
+            reward: amount,
+            rewardToken: token,
+            deadline: deadline,
+            status: TaskStatus.Open,
+            result: ""
+        });
+
+        emit TaskCreated(taskId, msg.sender, amount);
         return taskId;
     }
 
@@ -79,8 +122,14 @@ contract TaskRouter {
         uint256 fee = task.reward * platformFee / 10000;
         uint256 payout = task.reward - fee;
 
-        (bool success, ) = msg.sender.call{value: payout}("");
-        require(success, "Payout failed");
+        if (task.rewardToken == address(0)) {
+            (bool success, ) = msg.sender.call{value: payout}("");
+            require(success, "Payout failed");
+            nativeFees += fee;
+        } else {
+            IERC20(task.rewardToken).safeTransfer(msg.sender, payout);
+            tokenFees[task.rewardToken] += fee;
+        }
 
         emit TaskCompleted(taskId, task.assignedAgent);
     }
@@ -91,8 +140,12 @@ contract TaskRouter {
         require(task.status == TaskStatus.Open, "Cannot cancel");
 
         task.status = TaskStatus.Cancelled;
-        (bool success, ) = msg.sender.call{value: task.reward}("");
-        require(success, "Refund failed");
+        if (task.rewardToken == address(0)) {
+            (bool success, ) = msg.sender.call{value: task.reward}("");
+            require(success, "Refund failed");
+        } else {
+            IERC20(task.rewardToken).safeTransfer(msg.sender, task.reward);
+        }
     }
 
     function disputeTask(uint256 taskId) external {
@@ -103,5 +156,19 @@ contract TaskRouter {
 
         task.status = TaskStatus.Disputed;
         emit TaskDisputed(taskId);
+    }
+
+    function withdrawFees(address token) external onlyOwner {
+        if (token == address(0)) {
+            uint256 nativeAmount = nativeFees;
+            nativeFees = 0;
+            (bool success, ) = owner.call{value: nativeAmount}("");
+            require(success, "Withdraw failed");
+            return;
+        }
+
+        uint256 tokenAmount = tokenFees[token];
+        tokenFees[token] = 0;
+        IERC20(token).safeTransfer(owner, tokenAmount);
     }
 }

--- a/contracts/mocks/MockFalseERC20.sol
+++ b/contracts/mocks/MockFalseERC20.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockFalseERC20 {
+    string public name = "MockFalseERC20";
+    string public symbol = "MFT";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    bool public failTransfers;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function setFailTransfers(bool shouldFail) external {
+        failTransfers = shouldFail;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        if (failTransfers) {
+            return false;
+        }
+
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (failTransfers) {
+            return false;
+        }
+
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "insufficient allowance");
+        require(balanceOf[from] >= amount, "insufficient balance");
+
+        allowance[from][msg.sender] = allowed - amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/test/TaskRouter.safeTransfer.test.js
+++ b/test/TaskRouter.safeTransfer.test.js
@@ -1,0 +1,59 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const ARTIFACT_DIR = path.join(__dirname, "..", "build-issue181");
+
+function loadArtifact(prefix) {
+  const abi = JSON.parse(fs.readFileSync(path.join(ARTIFACT_DIR, `${prefix}.abi`), "utf8"));
+  const bytecode = `0x${fs.readFileSync(path.join(ARTIFACT_DIR, `${prefix}.bin`), "utf8")}`;
+  return { abi, bytecode };
+}
+
+describe("TaskRouter - ERC20 payout safety", function () {
+  it("reverts completeTask when ERC20 transfer returns false", async function () {
+    const [owner, creator, agentOwner] = await ethers.getSigners();
+
+    const agentRegistryArtifact = loadArtifact("contracts_AgentRegistry_sol_AgentRegistry");
+    const taskRouterArtifact = loadArtifact("contracts_TaskRouter_sol_TaskRouter");
+    const mockTokenArtifact = loadArtifact("contracts_mocks_MockFalseERC20_sol_MockFalseERC20");
+
+    const AgentRegistryFactory = new ethers.ContractFactory(agentRegistryArtifact.abi, agentRegistryArtifact.bytecode, owner);
+    const registry = await AgentRegistryFactory.deploy(0);
+    await registry.waitForDeployment();
+
+    const TaskRouterFactory = new ethers.ContractFactory(taskRouterArtifact.abi, taskRouterArtifact.bytecode, owner);
+    const taskRouter = await TaskRouterFactory.deploy(await registry.getAddress(), 500);
+    await taskRouter.waitForDeployment();
+
+    const MockTokenFactory = new ethers.ContractFactory(mockTokenArtifact.abi, mockTokenArtifact.bytecode, owner);
+    const token = await MockTokenFactory.deploy();
+    await token.waitForDeployment();
+
+    const reward = 1_000n;
+    await token.mint(creator.address, reward);
+    await token.connect(creator).approve(await taskRouter.getAddress(), reward);
+
+    const latest = await ethers.provider.getBlock("latest");
+    const deadline = BigInt(latest.timestamp) + 3600n;
+
+    await taskRouter.connect(creator).createTaskWithToken(
+      await token.getAddress(),
+      reward,
+      "erc20-task",
+      deadline
+    );
+
+    await registry.connect(agentOwner).registerAgent("agent-a", "https://agent", { value: 0 });
+    const agentId = await registry.ownerAgents(agentOwner.address, 0);
+
+    await taskRouter.connect(agentOwner).assignTask(0, agentId);
+    await token.setFailTransfers(true);
+
+    await expect(taskRouter.connect(agentOwner).completeTask(0, "0x1234")).to.be.reverted;
+
+    const task = await taskRouter.tasks(0);
+    expect(task.status).to.equal(1n); // Assigned
+  });
+});


### PR DESCRIPTION
## Summary\n- integrate OpenZeppelin SafeERC20 into TaskRouter\n- add token-based task path (createTaskWithToken) while keeping existing native-ETH flow compatible\n- ensure token payout/refund/fee withdrawal all use safeTransfer/safeTransferFrom\n- add regression test with a non-reverting ERC20 mock that returns alse\n\n## Validation\n- 
px solcjs --bin --abi --base-path . --include-path node_modules --output-dir build-issue181 contracts/AgentRegistry.sol contracts/TaskRouter.sol contracts/mocks/MockFalseERC20.sol\n- 
px hardhat test --no-compile test/TaskRouter.safeTransfer.test.js\n\nCloses #181\n/claim #181