### PR TITLE
[c53d] Add immutable admin audit log for admin write actions

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,13 @@ app = FastAPI(
     version="0.1.0",
 )
 
+try:
+    from .routes.admin import router as admin_router
+except ImportError:  # pragma: no cover
+    from routes.admin import router as admin_router
+
+app.include_router(admin_router)
+
 
 class AgentResponse(BaseModel):
     agent_id: str

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, event,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -84,6 +84,29 @@ class Payment(Base):
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    action = Column(String(128), nullable=False, index=True)
+    actor = Column(String(128), nullable=False, index=True)
+    target = Column(String(256), nullable=False)
+    before_values = Column(JSON, nullable=True)
+    after_values = Column(JSON, nullable=True)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    ip = Column(String(45), nullable=True)
+
+
+@event.listens_for(AuditLog, "before_update")
+def _prevent_audit_log_update(mapper, connection, target):  # pragma: no cover
+    raise ValueError("Audit log records are immutable")
+
+
+@event.listens_for(AuditLog, "before_delete")
+def _prevent_audit_log_delete(mapper, connection, target):  # pragma: no cover
+    raise ValueError("Audit log records are immutable")
 
 
 def init_db():

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,0 +1,175 @@
+"""Admin endpoints with immutable audit logging."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+try:
+    from ..models.database import AuditLog, Agent, User, get_db
+except ImportError:  # pragma: no cover
+    from models.database import AuditLog, Agent, User, get_db
+
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class AdminUserUpdate(BaseModel):
+    username: Optional[str] = None
+
+
+class AdminAgentUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    model_type: Optional[str] = None
+    config: Optional[dict] = None
+
+
+def require_admin_actor(request: Request) -> str:
+    actor = request.headers.get("X-Admin-Actor")
+    role = request.headers.get("X-Admin-Role", "")
+    if not actor:
+        raise HTTPException(status_code=401, detail="Missing X-Admin-Actor header")
+    if role.lower() != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return actor
+
+
+def _write_audit_log(
+    *,
+    db,
+    action: str,
+    actor: str,
+    target: str,
+    before_values: Optional[dict],
+    after_values: Optional[dict],
+    ip: Optional[str],
+) -> None:
+    log = AuditLog(
+        action=action,
+        actor=actor,
+        target=target,
+        before_values=before_values,
+        after_values=after_values,
+        timestamp=datetime.utcnow(),
+        ip=ip,
+    )
+    db.add(log)
+
+
+@router.patch("/users/{user_id}")
+async def admin_update_user(
+    user_id: int,
+    update: AdminUserUpdate,
+    request: Request,
+    actor: str = Depends(require_admin_actor),
+    db=Depends(get_db),
+):
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    updates = update.dict(exclude_unset=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    before = {"username": user.username}
+    for field, value in updates.items():
+        setattr(user, field, value)
+    after = {"username": user.username}
+
+    _write_audit_log(
+        db=db,
+        action="user.update",
+        actor=actor,
+        target=f"user:{user.id}",
+        before_values=before,
+        after_values=after,
+        ip=request.client.host if request.client else None,
+    )
+    db.commit()
+    db.refresh(user)
+    return {"id": user.id, "username": user.username}
+
+
+@router.patch("/agents/{agent_id}")
+async def admin_update_agent(
+    agent_id: int,
+    update: AdminAgentUpdate,
+    request: Request,
+    actor: str = Depends(require_admin_actor),
+    db=Depends(get_db),
+):
+    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    updates = update.dict(exclude_unset=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    before = {
+        "name": agent.name,
+        "description": agent.description,
+        "model_type": agent.model_type,
+        "config": agent.config,
+    }
+    for field, value in updates.items():
+        setattr(agent, field, value)
+    after = {
+        "name": agent.name,
+        "description": agent.description,
+        "model_type": agent.model_type,
+        "config": agent.config,
+    }
+
+    _write_audit_log(
+        db=db,
+        action="agent.update",
+        actor=actor,
+        target=f"agent:{agent.id}",
+        before_values=before,
+        after_values=after,
+        ip=request.client.host if request.client else None,
+    )
+    db.commit()
+    db.refresh(agent)
+    return {"id": agent.id, "name": agent.name, "model_type": agent.model_type}
+
+
+@router.get("/audit-log")
+async def get_audit_log(
+    actor: Optional[str] = None,
+    action: Optional[str] = None,
+    start_date: Optional[datetime] = Query(None),
+    end_date: Optional[datetime] = Query(None),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    db=Depends(get_db),
+):
+    query = db.query(AuditLog)
+
+    if actor:
+        query = query.filter(AuditLog.actor == actor)
+    if action:
+        query = query.filter(AuditLog.action == action)
+    if start_date:
+        query = query.filter(AuditLog.timestamp >= start_date)
+    if end_date:
+        query = query.filter(AuditLog.timestamp <= end_date)
+
+    logs = query.order_by(AuditLog.timestamp.desc()).offset(skip).limit(limit).all()
+    return [
+        {
+            "id": log.id,
+            "action": log.action,
+            "actor": log.actor,
+            "target": log.target,
+            "before_values": log.before_values,
+            "after_values": log.after_values,
+            "timestamp": log.timestamp.isoformat(),
+            "ip": log.ip,
+        }
+        for log in logs
+    ]

--- a/api/tests/test_admin_audit_log.py
+++ b/api/tests/test_admin_audit_log.py
@@ -1,0 +1,137 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+API_ROOT = Path(__file__).resolve().parents[1]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+from models.database import Agent, AuditLog, Base, User, get_db
+from routes.admin import router as admin_router
+
+
+@pytest.fixture()
+def test_context():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    app = FastAPI()
+    app.include_router(admin_router)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    seed = TestingSessionLocal()
+    seed.add(User(id=1, address="0x1111111111111111111111111111111111111111", username="alice"))
+    seed.add(
+        Agent(
+            id=1,
+            name="agent-1",
+            description="baseline",
+            model_type="gpt-4",
+            config={"temperature": 0.2},
+            owner_id=1,
+        )
+    )
+    seed.commit()
+    seed.close()
+
+    return client, TestingSessionLocal
+
+
+def test_admin_action_creates_audit_log_with_before_after(test_context):
+    client, SessionLocal = test_context
+
+    response = client.patch(
+        "/admin/users/1",
+        json={"username": "alice-updated"},
+        headers={"X-Admin-Actor": "alice-admin", "X-Admin-Role": "admin"},
+    )
+
+    assert response.status_code == 200
+
+    db = SessionLocal()
+    logs = db.query(AuditLog).all()
+    db.close()
+
+    assert len(logs) == 1
+    assert logs[0].action == "user.update"
+    assert logs[0].actor == "alice-admin"
+    assert logs[0].before_values == {"username": "alice"}
+    assert logs[0].after_values == {"username": "alice-updated"}
+
+
+def test_audit_log_query_supports_actor_action_and_date_filters(test_context):
+    client, _ = test_context
+
+    client.patch(
+        "/admin/users/1",
+        json={"username": "alice-v2"},
+        headers={"X-Admin-Actor": "alice-admin", "X-Admin-Role": "admin"},
+    )
+    client.patch(
+        "/admin/agents/1",
+        json={"model_type": "gpt-4.1"},
+        headers={"X-Admin-Actor": "bob-admin", "X-Admin-Role": "admin"},
+    )
+
+    by_actor = client.get("/admin/audit-log", params={"actor": "alice-admin"})
+    assert by_actor.status_code == 200
+    assert len(by_actor.json()) == 1
+    assert by_actor.json()[0]["action"] == "user.update"
+
+    by_action = client.get("/admin/audit-log", params={"action": "agent.update"})
+    assert by_action.status_code == 200
+    assert len(by_action.json()) == 1
+    assert by_action.json()[0]["actor"] == "bob-admin"
+
+    future = (datetime.utcnow() + timedelta(days=1)).isoformat()
+    by_future = client.get("/admin/audit-log", params={"start_date": future})
+    assert by_future.status_code == 200
+    assert by_future.json() == []
+
+
+def test_audit_log_records_are_immutable(test_context):
+    _, SessionLocal = test_context
+    db = SessionLocal()
+    db.add(
+        AuditLog(
+            action="user.update",
+            actor="seed-admin",
+            target="user:1",
+            before_values={"username": "alice"},
+            after_values={"username": "alice-v3"},
+            ip="127.0.0.1",
+        )
+    )
+    db.commit()
+
+    log = db.query(AuditLog).first()
+    log.action = "changed"
+    with pytest.raises(ValueError):
+        db.commit()
+    db.rollback()
+
+    with pytest.raises(ValueError):
+        db.delete(log)
+        db.commit()
+    db.close()


### PR DESCRIPTION
## Summary
- add AuditLog database model with immutable update/delete guards
- add admin write endpoints that emit audit rows with actor, target, before/after values, timestamp, and ip
- add GET /admin/audit-log with pagination plus actor/action/date-range filters
- add focused tests for create log, filter query, and immutability

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest OpenAgents-192-minpr/api/tests/test_admin_audit_log.py

Closes #192
/claim #192