### PR TITLE
[Codex] Add OpenAPI auth schemes and docs for API schema

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,129 @@
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Annotated, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Security
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict
 
 app = FastAPI(
     title="OpenAgents API",
-    description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
+    description=(
+        "Off-chain indexer and agent discovery API for the OpenAgents protocol.\n\n"
+        "Authentication: all non-health endpoints accept either:\n"
+        "1) JWT Bearer token in `Authorization: Bearer <token>`\n"
+        "2) API key in `X-API-Key: <key>`"
+    ),
     version="0.1.0",
 )
+
+
+AGENT_EXAMPLE = {
+    "agent_id": "agent_01",
+    "name": "ResearchBot",
+    "owner": "0x8ba1f109551bd432803012645ac136ddd64dba72",
+    "endpoint": "https://agent.example.com/infer",
+    "reputation": 87,
+    "tasks_completed": 42,
+    "registered_at": "2026-05-30T10:15:00Z",
+    "active": True,
+}
+
+TASK_EXAMPLE = {
+    "task_id": 101,
+    "creator": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b",
+    "description": "Summarize protocol changes for sprint planning",
+    "reward_wei": "500000000000000000",
+    "deadline": "2026-06-01T12:00:00Z",
+    "status": "open",
+    "assigned_agent": "agent_01",
+}
+
+LEADERBOARD_EXAMPLE = {
+    "agent_id": "agent_01",
+    "name": "ResearchBot",
+    "reputation": 87,
+    "tasks_completed": 42,
+    "success_rate": 0.95,
+}
+
+HEALTH_EXAMPLE = {
+    "status": "ok",
+    "agents_indexed": 152,
+    "tasks_indexed": 984,
+    "timestamp": "2026-05-30T11:00:00.000000Z",
+}
+
+
+bearer_auth = HTTPBearer(
+    bearerFormat="JWT",
+    scheme_name="JWTBearer",
+    description="JWT access token in the Authorization header.",
+    auto_error=False,
+)
+api_key_auth = APIKeyHeader(
+    name="X-API-Key",
+    scheme_name="ApiKeyAuth",
+    description="Service API key passed via X-API-Key header.",
+    auto_error=False,
+)
+
+
+async def require_auth(
+    bearer: Annotated[Optional[HTTPAuthorizationCredentials], Security(bearer_auth)] = None,
+    api_key: Annotated[Optional[str], Security(api_key_auth)] = None,
+) -> dict:
+    if bearer is None and api_key is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing authentication. Provide JWT bearer token or X-API-Key.",
+        )
+    return {
+        "auth_method": "bearer" if bearer is not None else "api_key",
+        "principal": bearer.credentials if bearer is not None else api_key,
+    }
+
+
+class ErrorResponse(BaseModel):
+    detail: str
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"detail": "Missing authentication credentials"}}
+    )
+
+
+COMMON_ERROR_RESPONSES = {
+    400: {
+        "description": "Bad request",
+        "model": ErrorResponse,
+        "content": {"application/json": {"example": {"detail": "Invalid query parameter"}}},
+    },
+    401: {
+        "description": "Unauthorized",
+        "model": ErrorResponse,
+        "content": {
+            "application/json": {
+                "example": {
+                    "detail": "Missing authentication. Provide JWT bearer token or X-API-Key."
+                }
+            }
+        },
+    },
+    403: {
+        "description": "Forbidden",
+        "model": ErrorResponse,
+        "content": {"application/json": {"example": {"detail": "Insufficient permissions"}}},
+    },
+    404: {
+        "description": "Not found",
+        "model": ErrorResponse,
+        "content": {"application/json": {"example": {"detail": "Resource not found"}}},
+    },
+    429: {
+        "description": "Too many requests",
+        "model": ErrorResponse,
+        "content": {"application/json": {"example": {"detail": "Rate limit exceeded"}}},
+    },
+}
 
 
 class AgentResponse(BaseModel):
@@ -20,6 +136,8 @@ class AgentResponse(BaseModel):
     registered_at: datetime
     active: bool
 
+    model_config = ConfigDict(json_schema_extra={"example": AGENT_EXAMPLE})
+
 
 class TaskResponse(BaseModel):
     task_id: int
@@ -30,6 +148,8 @@ class TaskResponse(BaseModel):
     status: str
     assigned_agent: Optional[str] = None
 
+    model_config = ConfigDict(json_schema_extra={"example": TASK_EXAMPLE})
+
 
 class LeaderboardEntry(BaseModel):
     agent_id: str
@@ -38,13 +158,35 @@ class LeaderboardEntry(BaseModel):
     tasks_completed: int
     success_rate: float
 
+    model_config = ConfigDict(json_schema_extra={"example": LEADERBOARD_EXAMPLE})
+
+
+class HealthResponse(BaseModel):
+    status: str
+    agents_indexed: int
+    tasks_indexed: int
+    timestamp: str
+
+    model_config = ConfigDict(json_schema_extra={"example": HEALTH_EXAMPLE})
+
 
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
 
 
-@app.get("/agents", response_model=list[AgentResponse])
+@app.get(
+    "/agents",
+    response_model=list[AgentResponse],
+    dependencies=[Depends(require_auth)],
+    responses={
+        **COMMON_ERROR_RESPONSES,
+        200: {
+            "description": "Agents list",
+            "content": {"application/json": {"example": [AGENT_EXAMPLE]}},
+        },
+    },
+)
 async def list_agents(
     active_only: bool = Query(True),
     min_reputation: int = Query(0),
@@ -58,14 +200,36 @@ async def list_agents(
     return results[offset : offset + limit]
 
 
-@app.get("/agents/{agent_id}", response_model=AgentResponse)
+@app.get(
+    "/agents/{agent_id}",
+    response_model=AgentResponse,
+    dependencies=[Depends(require_auth)],
+    responses={
+        **COMMON_ERROR_RESPONSES,
+        200: {
+            "description": "Agent details",
+            "content": {"application/json": {"example": AGENT_EXAMPLE}},
+        },
+    },
+)
 async def get_agent(agent_id: str):
     if agent_id not in agents_cache:
         raise HTTPException(status_code=404, detail="Agent not found")
     return agents_cache[agent_id]
 
 
-@app.get("/tasks", response_model=list[TaskResponse])
+@app.get(
+    "/tasks",
+    response_model=list[TaskResponse],
+    dependencies=[Depends(require_auth)],
+    responses={
+        **COMMON_ERROR_RESPONSES,
+        200: {
+            "description": "Tasks list",
+            "content": {"application/json": {"example": [TASK_EXAMPLE]}},
+        },
+    },
+)
 async def list_tasks(
     status: Optional[str] = Query(None),
     limit: int = Query(50, le=100),
@@ -77,14 +241,36 @@ async def list_tasks(
     return results[offset : offset + limit]
 
 
-@app.get("/tasks/{task_id}", response_model=TaskResponse)
+@app.get(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    dependencies=[Depends(require_auth)],
+    responses={
+        **COMMON_ERROR_RESPONSES,
+        200: {
+            "description": "Task details",
+            "content": {"application/json": {"example": TASK_EXAMPLE}},
+        },
+    },
+)
 async def get_task(task_id: int):
     if task_id not in tasks_cache:
         raise HTTPException(status_code=404, detail="Task not found")
     return tasks_cache[task_id]
 
 
-@app.get("/leaderboard", response_model=list[LeaderboardEntry])
+@app.get(
+    "/leaderboard",
+    response_model=list[LeaderboardEntry],
+    dependencies=[Depends(require_auth)],
+    responses={
+        **COMMON_ERROR_RESPONSES,
+        200: {
+            "description": "Leaderboard entries",
+            "content": {"application/json": {"example": [LEADERBOARD_EXAMPLE]}},
+        },
+    },
+)
 async def leaderboard(limit: int = Query(20, le=50)):
     entries = []
     for agent in agents_cache.values():
@@ -102,7 +288,16 @@ async def leaderboard(limit: int = Query(20, le=50)):
     return entries[:limit]
 
 
-@app.get("/health")
+@app.get(
+    "/health",
+    response_model=HealthResponse,
+    responses={
+        200: {
+            "description": "Service health status",
+            "content": {"application/json": {"example": HEALTH_EXAMPLE}},
+        }
+    },
+)
 async def health():
     return {
         "status": "ok",

--- a/api/tests/test_openapi_schema.py
+++ b/api/tests/test_openapi_schema.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_openapi_contains_both_security_schemes() -> None:
+    schema = client.get("/openapi.json").json()
+    security_schemes = schema["components"]["securitySchemes"]
+
+    assert "JWTBearer" in security_schemes
+    assert security_schemes["JWTBearer"]["type"] == "http"
+    assert security_schemes["JWTBearer"]["scheme"] == "bearer"
+
+    assert "ApiKeyAuth" in security_schemes
+    assert security_schemes["ApiKeyAuth"]["type"] == "apiKey"
+    assert security_schemes["ApiKeyAuth"]["in"] == "header"
+    assert security_schemes["ApiKeyAuth"]["name"] == "X-API-Key"
+
+
+def test_protected_endpoints_have_security_requirements() -> None:
+    schema = client.get("/openapi.json").json()
+    protected_operations = [
+        ("/agents", "get"),
+        ("/agents/{agent_id}", "get"),
+        ("/tasks", "get"),
+        ("/tasks/{task_id}", "get"),
+        ("/leaderboard", "get"),
+    ]
+
+    for path, method in protected_operations:
+        operation = schema["paths"][path][method]
+        security = operation.get("security", [])
+        security_keys = {next(iter(requirement.keys())) for requirement in security}
+        assert "JWTBearer" in security_keys
+        assert "ApiKeyAuth" in security_keys
+
+    assert "security" not in schema["paths"]["/health"]["get"]
+
+
+def test_openapi_error_responses_and_model_examples() -> None:
+    schema = client.get("/openapi.json").json()
+    responses = schema["paths"]["/agents"]["get"]["responses"]
+
+    for status_code in ("400", "401", "403", "404", "429"):
+        assert status_code in responses
+        response_schema = responses[status_code]["content"]["application/json"]["schema"]
+        assert response_schema["$ref"] == "#/components/schemas/ErrorResponse"
+
+    component_schemas = schema["components"]["schemas"]
+    for model_name in (
+        "AgentResponse",
+        "TaskResponse",
+        "LeaderboardEntry",
+        "HealthResponse",
+        "ErrorResponse",
+    ):
+        assert "example" in component_schemas[model_name]


### PR DESCRIPTION
## Summary
- add JWT Bearer + API key auth security dependencies in pi/main.py
- document protected endpoints with OpenAPI security requirements (Swagger lock icon)
- add shared error response schemas for 400/401/403/404/429
- add example values for all API models and endpoint response examples
- add targeted tests validating OpenAPI schema auth + error docs

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_openapi_schema.py -q

Closes #185
/claim #185