### PR TITLE
Add minimal gas sponsorship relay for TaskRouter

### DIFF
--- a/contracts/TaskRouter.sol
+++ b/contracts/TaskRouter.sol
@@ -5,6 +5,7 @@ import "./AgentRegistry.sol";
 
 contract TaskRouter {
     AgentRegistry public registry;
+    uint256 private constant RELAY_OVERHEAD = 50000;
 
     enum TaskStatus { Open, Assigned, Completed, Disputed, Cancelled }
 
@@ -21,11 +22,17 @@ contract TaskRouter {
     mapping(uint256 => Task) public tasks;
     uint256 public taskCount;
     uint256 public platformFee; // basis points
+    mapping(address => uint256) public stakeBalances;
+    mapping(address => uint256) public nonces;
+    address private _activeRelayedAgent;
 
     event TaskCreated(uint256 indexed taskId, address indexed creator, uint256 reward);
     event TaskAssigned(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskCompleted(uint256 indexed taskId, bytes32 indexed agentId);
     event TaskDisputed(uint256 indexed taskId);
+    event StakeDeposited(address indexed agent, uint256 amount);
+    event StakeWithdrawn(address indexed agent, uint256 amount);
+    event RelayExecuted(address indexed agent, address indexed relayer, uint256 indexed nonce, uint256 reimbursement);
 
     constructor(address _registry, uint256 _platformFee) {
         registry = AgentRegistry(_registry);
@@ -58,7 +65,7 @@ contract TaskRouter {
 
         AgentRegistry.Agent memory agent = registry.getAgent(agentId);
         require(agent.active, "Agent not active");
-        require(agent.owner == msg.sender, "Not agent owner");
+        require(agent.owner == _msgSender(), "Not agent owner");
 
         task.assignedAgent = agentId;
         task.status = TaskStatus.Assigned;
@@ -67,11 +74,12 @@ contract TaskRouter {
     }
 
     function completeTask(uint256 taskId, bytes calldata result) external {
+        address sender = _msgSender();
         Task storage task = tasks[taskId];
         require(task.status == TaskStatus.Assigned, "Not assigned");
 
         AgentRegistry.Agent memory agent = registry.getAgent(task.assignedAgent);
-        require(agent.owner == msg.sender, "Not assigned agent owner");
+        require(agent.owner == sender, "Not assigned agent owner");
 
         task.result = result;
         task.status = TaskStatus.Completed;
@@ -79,29 +87,112 @@ contract TaskRouter {
         uint256 fee = task.reward * platformFee / 10000;
         uint256 payout = task.reward - fee;
 
-        (bool success, ) = msg.sender.call{value: payout}("");
+        (bool success, ) = sender.call{value: payout}("");
         require(success, "Payout failed");
 
         emit TaskCompleted(taskId, task.assignedAgent);
     }
 
     function cancelTask(uint256 taskId) external {
+        address sender = _msgSender();
         Task storage task = tasks[taskId];
-        require(task.creator == msg.sender, "Not creator");
+        require(task.creator == sender, "Not creator");
         require(task.status == TaskStatus.Open, "Cannot cancel");
 
         task.status = TaskStatus.Cancelled;
-        (bool success, ) = msg.sender.call{value: task.reward}("");
+        (bool success, ) = sender.call{value: task.reward}("");
         require(success, "Refund failed");
     }
 
     function disputeTask(uint256 taskId) external {
+        address sender = _msgSender();
         Task storage task = tasks[taskId];
-        require(task.creator == msg.sender, "Not creator");
+        require(task.creator == sender, "Not creator");
         require(task.status == TaskStatus.Assigned, "Not assigned");
         require(block.timestamp > task.deadline, "Deadline not passed");
 
         task.status = TaskStatus.Disputed;
         emit TaskDisputed(taskId);
+    }
+
+    function depositStake() external payable {
+        require(msg.value > 0, "Stake required");
+        stakeBalances[msg.sender] += msg.value;
+        emit StakeDeposited(msg.sender, msg.value);
+    }
+
+    function withdrawStake(uint256 amount) external {
+        address sender = _msgSender();
+        require(stakeBalances[sender] >= amount, "Insufficient stake");
+        stakeBalances[sender] -= amount;
+
+        (bool success, ) = sender.call{value: amount}("");
+        require(success, "Withdraw failed");
+        emit StakeWithdrawn(sender, amount);
+    }
+
+    function executeOnBehalf(address agent, bytes calldata data, bytes calldata signature) external returns (bytes memory) {
+        require(agent != address(0), "Invalid agent");
+        require(_activeRelayedAgent == address(0), "Relay active");
+
+        uint256 nonce = nonces[agent];
+        _verifySignature(agent, data, nonce, signature);
+        nonces[agent] = nonce + 1;
+
+        uint256 gasStart = gasleft();
+        _activeRelayedAgent = agent;
+        (bool success, bytes memory result) = address(this).call(data);
+        _activeRelayedAgent = address(0);
+
+        if (!success) {
+            _revertWithData(result);
+        }
+
+        uint256 gasUsed = gasStart - gasleft() + RELAY_OVERHEAD;
+        uint256 reimbursement = gasUsed * tx.gasprice;
+        require(stakeBalances[agent] >= reimbursement, "Insufficient stake");
+
+        stakeBalances[agent] -= reimbursement;
+        (bool reimbursed, ) = msg.sender.call{value: reimbursement}("");
+        require(reimbursed, "Reimbursement failed");
+
+        emit RelayExecuted(agent, msg.sender, nonce, reimbursement);
+        return result;
+    }
+
+    function _msgSender() internal view returns (address) {
+        if (msg.sender == address(this) && _activeRelayedAgent != address(0)) {
+            return _activeRelayedAgent;
+        }
+        return msg.sender;
+    }
+
+    function _verifySignature(address agent, bytes calldata data, uint256 nonce, bytes calldata signature) internal view {
+        require(signature.length == 65, "Invalid signature");
+        bytes32 messageHash = keccak256(abi.encode(address(this), block.chainid, agent, nonce, keccak256(data)));
+        bytes32 ethSignedMessageHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        (bytes32 r, bytes32 s, uint8 v) = _splitSignature(signature);
+        address recovered = ecrecover(ethSignedMessageHash, v, r, s);
+        require(recovered == agent, "Invalid signature");
+    }
+
+    function _splitSignature(bytes calldata signature) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+        if (v < 27) {
+            v += 27;
+        }
+    }
+
+    function _revertWithData(bytes memory revertData) internal pure {
+        if (revertData.length == 0) {
+            revert("Relayed call failed");
+        }
+        assembly {
+            revert(add(revertData, 32), mload(revertData))
+        }
     }
 }

--- a/test/TaskRouterRelay.test.js
+++ b/test/TaskRouterRelay.test.js
@@ -1,0 +1,145 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function signRelayCall(agentSigner, router, agentAddress, nonce, data) {
+  const { chainId } = await ethers.provider.getNetwork();
+  const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+    ["address", "uint256", "address", "uint256", "bytes32"],
+    [router.target, chainId, agentAddress, nonce, ethers.keccak256(data)]
+  );
+  const messageHash = ethers.keccak256(encoded);
+  return agentSigner.signMessage(ethers.getBytes(messageHash));
+}
+
+describe("TaskRouter relay sponsorship", function () {
+  let registry;
+  let router;
+  let creator;
+  let agentOwner;
+  let relayer;
+  let agentId;
+  const taskId = 0n;
+
+  beforeEach(async function () {
+    [creator, agentOwner, relayer] = await ethers.getSigners();
+
+    const Registry = await ethers.getContractFactory("AgentRegistry");
+    registry = await Registry.deploy(0);
+
+    const Router = await ethers.getContractFactory("TaskRouter");
+    router = await Router.deploy(registry.target, 500);
+
+    const latestBlock = await ethers.provider.getBlock("latest");
+    const deadline = BigInt(latestBlock.timestamp + 3600);
+
+    await router.connect(creator).createTask("relay completion", deadline, {
+      value: ethers.parseEther("1"),
+    });
+
+    const registerTx = await registry
+      .connect(agentOwner)
+      .registerAgent("relay-agent", "https://agent.local", { value: 0 });
+    const receipt = await registerTx.wait();
+    for (const log of receipt.logs) {
+      try {
+        const parsed = registry.interface.parseLog(log);
+        if (parsed && parsed.name === "AgentRegistered") {
+          agentId = parsed.args.agentId;
+          break;
+        }
+      } catch (_) {}
+    }
+
+    await router.connect(agentOwner).assignTask(taskId, agentId);
+  });
+
+  it("executes sponsored completion and reimburses relayer from agent stake", async function () {
+    await router.connect(agentOwner).depositStake({ value: ethers.parseEther("1") });
+
+    const data = router.interface.encodeFunctionData("completeTask", [
+      taskId,
+      ethers.toUtf8Bytes("done"),
+    ]);
+    const nonce = await router.nonces(agentOwner.address);
+    const signature = await signRelayCall(
+      agentOwner,
+      router,
+      agentOwner.address,
+      nonce,
+      data
+    );
+
+    const stakeBefore = await router.stakeBalances(agentOwner.address);
+    const relayerBalanceBefore = await ethers.provider.getBalance(relayer.address);
+
+    const tx = await router
+      .connect(relayer)
+      .executeOnBehalf(agentOwner.address, data, signature);
+    const receipt = await tx.wait();
+
+    const stakeAfter = await router.stakeBalances(agentOwner.address);
+    const relayerBalanceAfter = await ethers.provider.getBalance(relayer.address);
+
+    let reimbursement = 0n;
+    for (const log of receipt.logs) {
+      try {
+        const parsed = router.interface.parseLog(log);
+        if (parsed && parsed.name === "RelayExecuted") {
+          reimbursement = parsed.args.reimbursement;
+          break;
+        }
+      } catch (_) {}
+    }
+
+    const task = await router.tasks(taskId);
+
+    expect(task.status).to.equal(2n); // Completed
+    expect(reimbursement).to.be.gt(0n);
+    expect(stakeBefore - stakeAfter).to.equal(reimbursement);
+    expect(relayerBalanceAfter).to.equal(relayerBalanceBefore - receipt.fee + reimbursement);
+  });
+
+  it("prevents replay with nonce-based signature checks", async function () {
+    await router.connect(agentOwner).depositStake({ value: ethers.parseEther("1") });
+
+    const data = router.interface.encodeFunctionData("completeTask", [
+      taskId,
+      ethers.toUtf8Bytes("done"),
+    ]);
+    const nonce = await router.nonces(agentOwner.address);
+    const signature = await signRelayCall(
+      agentOwner,
+      router,
+      agentOwner.address,
+      nonce,
+      data
+    );
+
+    await router
+      .connect(relayer)
+      .executeOnBehalf(agentOwner.address, data, signature);
+
+    await expect(
+      router.connect(relayer).executeOnBehalf(agentOwner.address, data, signature)
+    ).to.be.revertedWith("Invalid signature");
+  });
+
+  it("reverts when stake cannot cover gas reimbursement", async function () {
+    const data = router.interface.encodeFunctionData("completeTask", [
+      taskId,
+      ethers.toUtf8Bytes("done"),
+    ]);
+    const nonce = await router.nonces(agentOwner.address);
+    const signature = await signRelayCall(
+      agentOwner,
+      router,
+      agentOwner.address,
+      nonce,
+      data
+    );
+
+    await expect(
+      router.connect(relayer).executeOnBehalf(agentOwner.address, data, signature)
+    ).to.be.revertedWith("Insufficient stake");
+  });
+});


### PR DESCRIPTION
## Summary
- add stake balance + nonce tracking for relay sponsorship in TaskRouter
- add xecuteOnBehalf(agent, data, signature) with signature verification and nonce replay protection
- reimburse relayer gas from agent stake while preserving direct-call compatibility
- add focused tests for sponsored execution, replay prevention, and insufficient stake

## Validation
- 
px hardhat test test/TaskRouterRelay.test.js --config .tmp.hardhat.190.config.js
- result: 3 passing

Closes #190
/claim #190