### PR TITLE
[API] Fix #200: differentiate auth/anonymous/premium rate limits with backward compatibility

### DIFF
--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -2,22 +2,34 @@
 
 import time
 from collections import defaultdict
-from fastapi import Request, HTTPException
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 
 class RateLimitConfig:
     def __init__(
         self,
-        requests_per_window: int = 100,
+        requests_per_window: Optional[int] = 100,
         window_seconds: int = 60,
         burst_limit: int = 20,
+        anonymous_requests_per_window: int = 60,
+        authenticated_requests_per_window: int = 300,
+        premium_requests_per_window: int = 1000,
     ):
+        if requests_per_window is not None:
+            # Backward compatibility: legacy single-limit behavior applies to all tiers.
+            anonymous_requests_per_window = requests_per_window
+            authenticated_requests_per_window = requests_per_window
+            premium_requests_per_window = requests_per_window
+
         self.requests_per_window = requests_per_window
         self.window_seconds = window_seconds
         self.burst_limit = burst_limit
+        self.anonymous_requests_per_window = anonymous_requests_per_window
+        self.authenticated_requests_per_window = authenticated_requests_per_window
+        self.premium_requests_per_window = premium_requests_per_window
 
 
 # BUG: In-memory store — all counters reset when the server restarts,
@@ -38,55 +50,102 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return forwarded.split(",")[0].strip()
         return request.client.host if request.client else "unknown"
 
-    def _is_rate_limited(self, client_ip: str) -> Tuple[bool, int]:
+    def _get_tier(self, request: Request) -> str:
+        api_key = request.headers.get("X-API-Key")
+        api_tier = request.headers.get("X-API-Tier", "")
+
+        if api_key and (api_key.lower().startswith("premium_") or api_tier.lower() == "premium"):
+            return "premium"
+        if request.headers.get("Authorization") or api_key:
+            return "authenticated"
+        return "anonymous"
+
+    def _limit_for_tier(self, tier: str) -> int:
+        if tier == "premium":
+            return self.config.premium_requests_per_window
+        if tier == "authenticated":
+            return self.config.authenticated_requests_per_window
+        return self.config.anonymous_requests_per_window
+
+    def _is_rate_limited(self, client_key: str, limit: int) -> Tuple[bool, int, int]:
         global _request_counts
-        count, window_start = _request_counts[client_ip]
+        count, window_start = _request_counts[client_key]
         now = time.time()
 
         # BUG: Fixed window instead of sliding window — a burst of requests at
         # the boundary of two windows allows 2x the intended rate
         if now - window_start >= self.config.window_seconds:
-            _request_counts[client_ip] = (1, now)
-            return False, self.config.requests_per_window - 1
+            _request_counts[client_key] = (1, now)
+            return False, limit - 1, int(now + self.config.window_seconds)
 
-        if count >= self.config.requests_per_window:
-            retry_after = int(self.config.window_seconds - (now - window_start))
-            return True, retry_after
+        reset_at = int(window_start + self.config.window_seconds)
 
-        _request_counts[client_ip] = (count + 1, window_start)
-        remaining = self.config.requests_per_window - count - 1
-        return False, remaining
+        if count >= limit:
+            retry_after = max(1, int(self.config.window_seconds - (now - window_start)))
+            return True, retry_after, reset_at
+
+        _request_counts[client_key] = (count + 1, window_start)
+        remaining = limit - count - 1
+        return False, remaining, reset_at
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path.startswith("/health"):
             return await call_next(request)
 
         client_ip = self._get_client_ip(request)
-        is_limited, value = self._is_rate_limited(client_ip)
+        tier = self._get_tier(request)
+        limit = self._limit_for_tier(tier)
+        client_key = f"{tier}:{client_ip}"
+        is_limited, value, reset_at = self._is_rate_limited(client_key, limit)
+        rate_limit_headers = {
+            "X-RateLimit-Limit": str(limit),
+            "X-RateLimit-Reset": str(reset_at),
+        }
 
         if is_limited:
+            headers = {
+                "Retry-After": str(value),
+                "X-RateLimit-Remaining": "0",
+                **rate_limit_headers,
+            }
             return JSONResponse(
                 status_code=429,
                 content={
                     "error": "Rate limit exceeded",
                     "retry_after": value,
                 },
-                headers={"Retry-After": str(value)},
+                headers=headers,
             )
 
         response = await call_next(request)
         response.headers["X-RateLimit-Remaining"] = str(value)
-        response.headers["X-RateLimit-Limit"] = str(self.config.requests_per_window)
+        response.headers["X-RateLimit-Limit"] = str(limit)
+        response.headers["X-RateLimit-Reset"] = str(reset_at)
         return response
 
 
 def create_rate_limiter(
     requests_per_minute: int = 100,
     burst: int = 20,
+    anonymous_requests_per_minute: Optional[int] = None,
+    authenticated_requests_per_minute: Optional[int] = None,
+    premium_requests_per_minute: Optional[int] = None,
 ) -> RateLimitMiddleware:
+    use_tiered_limits = any(
+        value is not None
+        for value in (
+            anonymous_requests_per_minute,
+            authenticated_requests_per_minute,
+            premium_requests_per_minute,
+        )
+    )
+
     config = RateLimitConfig(
-        requests_per_window=requests_per_minute,
+        requests_per_window=None if use_tiered_limits else requests_per_minute,
         window_seconds=60,
         burst_limit=burst,
+        anonymous_requests_per_window=anonymous_requests_per_minute or 60,
+        authenticated_requests_per_window=authenticated_requests_per_minute or 300,
+        premium_requests_per_window=premium_requests_per_minute or 1000,
     )
     return RateLimitMiddleware(app=None, config=config)

--- a/api/tests/test_ratelimit.py
+++ b/api/tests/test_ratelimit.py
@@ -1,0 +1,109 @@
+import unittest
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from api.middleware import ratelimit
+from api.middleware.ratelimit import RateLimitConfig, RateLimitMiddleware
+
+
+async def _noop_app(scope, receive, send):
+    return None
+
+
+class RateLimitMiddlewareTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        ratelimit._request_counts.clear()
+
+    def _build_request(self, path="/agents", headers=None, client_ip="127.0.0.1"):
+        header_items = []
+        for key, value in (headers or {}).items():
+            header_items.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode("latin-1"),
+            "query_string": b"",
+            "headers": header_items,
+            "client": (client_ip, 12345),
+            "server": ("testserver", 80),
+        }
+        return Request(scope)
+
+    async def _ok_response(self, _request):
+        return Response("ok", status_code=200)
+
+    async def test_limits_differ_by_request_auth_state(self):
+        middleware = RateLimitMiddleware(
+            _noop_app,
+            RateLimitConfig(
+                requests_per_window=None,
+                anonymous_requests_per_window=60,
+                authenticated_requests_per_window=300,
+                premium_requests_per_window=1000,
+            ),
+        )
+
+        anonymous = await middleware.dispatch(self._build_request(), self._ok_response)
+        authenticated = await middleware.dispatch(
+            self._build_request(headers={"Authorization": "Bearer test-token"}, client_ip="127.0.0.2"),
+            self._ok_response,
+        )
+        premium = await middleware.dispatch(
+            self._build_request(headers={"X-API-Key": "premium_demo"}, client_ip="127.0.0.3"),
+            self._ok_response,
+        )
+
+        self.assertEqual("60", anonymous.headers["X-RateLimit-Limit"])
+        self.assertEqual("300", authenticated.headers["X-RateLimit-Limit"])
+        self.assertEqual("1000", premium.headers["X-RateLimit-Limit"])
+
+    async def test_headers_present_and_429_contains_retry_after(self):
+        middleware = RateLimitMiddleware(
+            _noop_app,
+            RateLimitConfig(
+                requests_per_window=None,
+                anonymous_requests_per_window=1,
+                authenticated_requests_per_window=1,
+                premium_requests_per_window=1,
+            ),
+        )
+
+        first = await middleware.dispatch(self._build_request(), self._ok_response)
+        second = await middleware.dispatch(self._build_request(), self._ok_response)
+
+        self.assertEqual(200, first.status_code)
+        self.assertIn("X-RateLimit-Limit", first.headers)
+        self.assertIn("X-RateLimit-Remaining", first.headers)
+        self.assertIn("X-RateLimit-Reset", first.headers)
+
+        self.assertEqual(429, second.status_code)
+        self.assertIn("Retry-After", second.headers)
+        self.assertIn("X-RateLimit-Limit", second.headers)
+        self.assertIn("X-RateLimit-Remaining", second.headers)
+        self.assertIn("X-RateLimit-Reset", second.headers)
+
+    async def test_legacy_single_limit_remains_compatible(self):
+        middleware = RateLimitMiddleware(_noop_app, RateLimitConfig(requests_per_window=2))
+
+        first = await middleware.dispatch(self._build_request(), self._ok_response)
+        second = await middleware.dispatch(
+            self._build_request(headers={"Authorization": "Bearer token"}, client_ip="127.0.0.8"),
+            self._ok_response,
+        )
+        third = await middleware.dispatch(
+            self._build_request(headers={"X-API-Key": "premium_key"}, client_ip="127.0.0.9"),
+            self._ok_response,
+        )
+
+        self.assertEqual("2", first.headers["X-RateLimit-Limit"])
+        self.assertEqual("2", second.headers["X-RateLimit-Limit"])
+        self.assertEqual("2", third.headers["X-RateLimit-Limit"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- differentiate rate-limit tiers by request auth state (anonymous/authenticated/premium)
- preserve backward compatibility for legacy single-limit config (`requests_per_minute` / `requests_per_window`)
- add `X-RateLimit-Reset` and ensure rate-limit headers are returned on normal and 429 responses
- add focused middleware tests for tier limits, headers, and 429 behavior

## Validation
- `python -m unittest discover -s api/tests -p "test_ratelimit.py" -v`

Closes #200
/claim #200
