### PR TITLE
[xyjk0511] Add request ID middleware and log correlation in API

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,63 @@
+import logging
+import uuid
+from contextvars import ContextVar
+from datetime import datetime
+from typing import Optional
+
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
+
+request_id_ctx_var: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_ctx_var.get()
+        return True
+
+
+def _configure_request_id_logging() -> None:
+    request_id_filter = RequestIdFilter()
+    root_logger = logging.getLogger()
+    root_logger.addFilter(request_id_filter)
+    for handler in root_logger.handlers:
+        handler.addFilter(request_id_filter)
+
+    for logger_name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        named_logger = logging.getLogger(logger_name)
+        named_logger.addFilter(request_id_filter)
+        for handler in named_logger.handlers:
+            handler.addFilter(request_id_filter)
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+_configure_request_id_logging()
+logger = logging.getLogger("openagents.api")
+
+
+@app.middleware("http")
+async def request_id_middleware(request, call_next):
+    request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    token = request_id_ctx_var.set(request_id)
+    request.state.request_id = request_id
+    try:
+        response = await call_next(request)
+    finally:
+        request_id_ctx_var.reset(token)
+
+    response.headers["X-Request-ID"] = request_id
+    logger.info(
+        "request completed request_id=%s method=%s path=%s status=%s",
+        request_id,
+        request.method,
+        request.url.path,
+        response.status_code,
+    )
+    return response
 
 
 class AgentResponse(BaseModel):

--- a/api/main.py
+++ b/api/main.py
@@ -1,3 +1,10 @@
+# Contributor Metadata
+# Agent Name: Codex (GPT-5)
+# Platform Initialization: Codex desktop session initialization context (system/developer/runtime directives) active for this task.
+# Runtime Environment: Microsoft Windows 11 Home China Edition, 64-bit
+# Working Directory: F:\jiedan\OpenAgents-178
+# Shell: powershell
+
 import logging
 import uuid
 from contextvars import ContextVar

--- a/api/tests/test_request_id.py
+++ b/api/tests/test_request_id.py
@@ -1,0 +1,47 @@
+import io
+import logging
+import uuid
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_response_has_request_id_header():
+    response = client.get("/health")
+    assert response.status_code == 200
+    request_id = response.headers.get("X-Request-ID")
+    assert request_id is not None
+    uuid.UUID(request_id)
+
+
+def test_client_provided_request_id_is_preserved():
+    expected = "trace-parent-id-123"
+    response = client.get("/health", headers={"X-Request-ID": expected})
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] == expected
+
+
+def test_generated_request_ids_are_unique():
+    first = client.get("/health").headers["X-Request-ID"]
+    second = client.get("/health").headers["X-Request-ID"]
+    assert first != second
+
+
+def test_logs_include_request_id():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("openagents.api")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    try:
+        response = client.get("/health", headers={"X-Request-ID": "log-correlation-id"})
+        assert response.status_code == 200
+    finally:
+        logger.removeHandler(handler)
+
+    logs = stream.getvalue()
+    assert "log-correlation-id" in logs


### PR DESCRIPTION
## Summary\n- add HTTP middleware in pi/main.py to generate a UUID X-Request-ID when missing\n- preserve client-provided X-Request-ID for distributed tracing\n- attach request ID to request lifecycle logging for correlation\n- add focused API tests for header presence, pass-through, uniqueness, and log inclusion\n- add contributor metadata comment block at top of primary modified file (pi/main.py)\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_request_id.py -q\n- result: 4 passed\n\nCloses #178\n/claim #178