### PR TITLE
[API] Add /tasks/ws websocket updates with subscription + heartbeat

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-gpt5-55093",
+      "timestamp": "2026-05-31T05:47:09Z",
+      "platform_instructions": "Codex session with system/developer/user instructions for OpenAgents issue #188 minimal websocket endpoint fix and targeted tests.",
+      "runtime": {
+        "os": "windows",
+        "arch": "x64",
+        "home_dir": "C:\\Users\\55093",
+        "working_dir": "F:\\jiedan\\OpenAgents-188",
+        "shell": "powershell"
+      },
+      "contribution": "Added task websocket endpoint with subscription filtering, heartbeat, disconnect cleanup, and minimal API websocket tests for issue #188"
     }
   ]
 }

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,9 +1,11 @@
 """Task management endpoints for bounty assignments."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
+import asyncio
 from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
 from ..models.database import get_db, Task
 from ..middleware.auth import get_current_user
@@ -11,6 +13,55 @@ from ..middleware.auth import get_current_user
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 VALID_STATUSES = {"open", "assigned", "in_progress", "review", "completed", "cancelled"}
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+class TaskWebSocketManager:
+    def __init__(self):
+        self._connections: dict[WebSocket, set[int]] = {}
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self._connections[websocket] = set()
+
+    def disconnect(self, websocket: WebSocket):
+        self._connections.pop(websocket, None)
+
+    def subscribe(self, websocket: WebSocket, task_id: int):
+        if websocket in self._connections:
+            self._connections[websocket].add(task_id)
+
+    def unsubscribe(self, websocket: WebSocket, task_id: int):
+        if websocket in self._connections:
+            self._connections[websocket].discard(task_id)
+
+    async def broadcast(self, task_id: int, payload: dict):
+        stale_connections: list[WebSocket] = []
+        for websocket, subscriptions in list(self._connections.items()):
+            if task_id not in subscriptions:
+                continue
+            try:
+                await websocket.send_json(payload)
+            except Exception:
+                stale_connections.append(websocket)
+
+        for websocket in stale_connections:
+            self.disconnect(websocket)
+
+    def connection_count(self) -> int:
+        return len(self._connections)
+
+    def subscription_count(self, task_id: int) -> int:
+        return sum(1 for subscriptions in self._connections.values() if task_id in subscriptions)
+
+
+task_ws_manager = TaskWebSocketManager()
+
+
+async def _heartbeat(websocket: WebSocket):
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        await websocket.send_json({"type": "heartbeat", "timestamp": datetime.utcnow().isoformat()})
 
 
 class TaskCreate(BaseModel):
@@ -23,6 +74,37 @@ class TaskCreate(BaseModel):
 
 class TaskStatusUpdate(BaseModel):
     status: str  # BUG: Not validated against VALID_STATUSES enum — any string accepted
+
+
+@router.websocket("/ws")
+async def tasks_websocket(websocket: WebSocket):
+    await task_ws_manager.connect(websocket)
+    heartbeat_task = asyncio.create_task(_heartbeat(websocket))
+    try:
+        while True:
+            message = await websocket.receive_json()
+            action = message.get("action")
+            task_id = message.get("task_id")
+
+            if action not in {"subscribe", "unsubscribe"}:
+                await websocket.send_json({"type": "error", "detail": "Unsupported action"})
+                continue
+
+            if not isinstance(task_id, int):
+                await websocket.send_json({"type": "error", "detail": "task_id must be an integer"})
+                continue
+
+            if action == "subscribe":
+                task_ws_manager.subscribe(websocket, task_id)
+                await websocket.send_json({"type": "subscribed", "task_id": task_id})
+            else:
+                task_ws_manager.unsubscribe(websocket, task_id)
+                await websocket.send_json({"type": "unsubscribed", "task_id": task_id})
+    except WebSocketDisconnect:
+        pass
+    finally:
+        heartbeat_task.cancel()
+        task_ws_manager.disconnect(websocket)
 
 
 @router.post("/")
@@ -88,6 +170,16 @@ async def update_task_status(
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
+
+    await task_ws_manager.broadcast(
+        task.id,
+        {
+            "type": "task_update",
+            "task_id": task.id,
+            "status": task.status,
+            "updated_at": task.updated_at.isoformat(),
+        },
+    )
     return {"id": task.id, "status": task.status}
 
 
@@ -101,5 +193,16 @@ async def cancel_task(task_id: int, user=Depends(get_current_user), db=Depends(g
     if task.status not in ("open", "assigned"):
         raise HTTPException(status_code=400, detail="Cannot cancel an active task")
     task.status = "cancelled"
+    task.updated_at = datetime.utcnow()
     db.commit()
+
+    await task_ws_manager.broadcast(
+        task.id,
+        {
+            "type": "task_update",
+            "task_id": task.id,
+            "status": task.status,
+            "updated_at": task.updated_at.isoformat(),
+        },
+    )
     return {"id": task.id, "status": "cancelled"}

--- a/api/tests/test_tasks_websocket.py
+++ b/api/tests/test_tasks_websocket.py
@@ -1,0 +1,128 @@
+import os
+import pathlib
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.routes import tasks as tasks_routes
+
+
+class FakeTask:
+    def __init__(self, task_id: int, status: str = "open", creator_id: int = 1):
+        self.id = task_id
+        self.status = status
+        self.creator_id = creator_id
+        self.updated_at = None
+
+
+class FakeQuery:
+    def __init__(self, task: FakeTask):
+        self.task = task
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self.task
+
+
+class FakeDB:
+    def __init__(self, task: FakeTask):
+        self.task = task
+
+    def query(self, _model):
+        return FakeQuery(self.task)
+
+    def commit(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_task_ws_manager():
+    tasks_routes.task_ws_manager._connections.clear()
+    yield
+    tasks_routes.task_ws_manager._connections.clear()
+
+
+def build_client(task: FakeTask) -> TestClient:
+    app = FastAPI()
+    app.include_router(tasks_routes.router)
+
+    fake_db = FakeDB(task)
+
+    def override_get_current_user():
+        return {"id": 1, "address": "0xabc"}
+
+    def override_get_db():
+        return fake_db
+
+    app.dependency_overrides[tasks_routes.get_current_user] = override_get_current_user
+    app.dependency_overrides[tasks_routes.get_db] = override_get_db
+
+    return TestClient(app)
+
+
+def test_websocket_subscribe_and_receive_task_update():
+    task = FakeTask(task_id=1)
+    client = build_client(task)
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.send_json({"action": "subscribe", "task_id": 1})
+        assert websocket.receive_json() == {"type": "subscribed", "task_id": 1}
+
+        response = client.patch("/tasks/1/status", json={"status": "in_progress"})
+        assert response.status_code == 200
+
+        message = websocket.receive_json()
+        assert message["type"] == "task_update"
+        assert message["task_id"] == 1
+        assert message["status"] == "in_progress"
+
+
+def test_unsubscribe_removes_task_subscription():
+    task = FakeTask(task_id=1)
+    client = build_client(task)
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.send_json({"action": "subscribe", "task_id": 1})
+        assert websocket.receive_json() == {"type": "subscribed", "task_id": 1}
+        assert tasks_routes.task_ws_manager.subscription_count(1) == 1
+
+        websocket.send_json({"action": "unsubscribe", "task_id": 1})
+        assert websocket.receive_json() == {"type": "unsubscribed", "task_id": 1}
+        assert tasks_routes.task_ws_manager.subscription_count(1) == 0
+
+
+def test_heartbeat_message_sent_to_connected_client():
+    task = FakeTask(task_id=1)
+    client = build_client(task)
+
+    original_interval = tasks_routes.HEARTBEAT_INTERVAL_SECONDS
+    tasks_routes.HEARTBEAT_INTERVAL_SECONDS = 0.01
+    try:
+        with client.websocket_connect("/tasks/ws") as websocket:
+            message = websocket.receive_json()
+            assert message["type"] == "heartbeat"
+            assert "timestamp" in message
+    finally:
+        tasks_routes.HEARTBEAT_INTERVAL_SECONDS = original_interval
+
+
+def test_disconnected_clients_are_cleaned_up():
+    task = FakeTask(task_id=1)
+    client = build_client(task)
+
+    with client.websocket_connect("/tasks/ws") as websocket:
+        websocket.send_json({"action": "subscribe", "task_id": 1})
+        websocket.receive_json()
+        assert tasks_routes.task_ws_manager.connection_count() == 1
+
+    assert tasks_routes.task_ws_manager.connection_count() == 0


### PR DESCRIPTION
## Summary
- add `ws /tasks/ws` endpoint in `api/routes/tasks.py`
- support `subscribe` / `unsubscribe` by `task_id`
- broadcast task status updates on task status/cancel mutations
- send heartbeat ping every 30s and clean disconnected clients
- add minimal websocket tests for connect/subscribe/update/heartbeat/disconnect cleanup

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest api/tests/test_tasks_websocket.py -q`
- result: `4 passed`

Closes #188
/claim #188
