### PR TITLE
fix(api): complete #203 structured error response AC with minimal changes

### DIFF
--- a/api/ERROR_CODES.md
+++ b/api/ERROR_CODES.md
@@ -1,0 +1,38 @@
+# OpenAgents API Error Codes
+
+All API errors use this schema:
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Agent not found",
+  "details": {},
+  "request_id": "f77d5c41-8acd-4e48-84dd-64c07da42e2c"
+}
+```
+
+## Codes
+
+- `VALIDATION_ERROR`: Request payload, path, query, or type validation failed.
+- `NOT_FOUND`: Requested resource does not exist.
+- `AUTH_FAILED`: Authentication or authorization failed.
+- `RATE_LIMITED`: Request throttled by rate limiting.
+- `INTERNAL_ERROR`: Unexpected server-side failure.
+- `BAD_REQUEST`: Client sent an invalid request.
+
+## Validation Error Details
+
+Validation failures include field-level details:
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Request validation failed",
+  "details": {
+    "fields": {
+      "task_id": "Input should be a valid integer"
+    }
+  },
+  "request_id": "abc-123"
+}
+```

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,96 @@
+"""Structured error schema and handlers for the OpenAgents API."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+
+STATUS_CODE_TO_ERROR_CODE = {
+    400: "BAD_REQUEST",
+    401: "AUTH_FAILED",
+    403: "AUTH_FAILED",
+    404: "NOT_FOUND",
+    429: "RATE_LIMITED",
+}
+
+
+def ensure_request_id(request: Request) -> str:
+    request_id = getattr(request.state, "request_id", None) or request.headers.get("X-Request-ID")
+    if not request_id:
+        request_id = str(uuid4())
+    request.state.request_id = request_id
+    return request_id
+
+
+def make_error_payload(
+    *,
+    code: str,
+    message: str,
+    request_id: str,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "message": message,
+        "details": details or {},
+        "request_id": request_id,
+    }
+
+
+def code_for_status(status_code: int) -> str:
+    return STATUS_CODE_TO_ERROR_CODE.get(status_code, "INTERNAL_ERROR")
+
+
+def details_from_validation(exc: RequestValidationError) -> dict[str, Any]:
+    fields: dict[str, str] = {}
+    for error in exc.errors():
+        loc = [str(part) for part in error.get("loc", []) if part not in {"body", "query", "path"}]
+        key = ".".join(loc) if loc else "request"
+        fields[key] = error.get("msg", "Invalid value")
+    return {"fields": fields}
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    request_id = ensure_request_id(request)
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else "Request failed"
+    details = detail if isinstance(detail, dict) else {}
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=make_error_payload(
+            code=code_for_status(exc.status_code),
+            message=message,
+            details=details,
+            request_id=request_id,
+        ),
+    )
+
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    request_id = ensure_request_id(request)
+    return JSONResponse(
+        status_code=422,
+        content=make_error_payload(
+            code="VALIDATION_ERROR",
+            message="Request validation failed",
+            details=details_from_validation(exc),
+            request_id=request_id,
+        ),
+    )
+
+
+async def internal_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    request_id = ensure_request_id(request)
+    return JSONResponse(
+        status_code=500,
+        content=make_error_payload(
+            code="INTERNAL_ERROR",
+            message="Internal server error",
+            request_id=request_id,
+        ),
+    )

--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,34 @@
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+
+from .errors import (
+    ensure_request_id,
+    http_exception_handler,
+    internal_exception_handler,
+    validation_exception_handler,
+)
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
 )
+
+
+@app.middleware("http")
+async def request_id_middleware(request: Request, call_next):
+    request_id = ensure_request_id(request)
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    return response
+
+
+app.add_exception_handler(HTTPException, http_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(Exception, internal_exception_handler)
 
 
 class AgentResponse(BaseModel):

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -2,10 +2,12 @@
 
 import time
 from collections import defaultdict
-from fastapi import Request, HTTPException
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from typing import Dict, Tuple
+
+from ..errors import ensure_request_id, make_error_payload
 
 
 class RateLimitConfig:
@@ -65,13 +67,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         is_limited, value = self._is_rate_limited(client_ip)
 
         if is_limited:
+            request_id = ensure_request_id(request)
             return JSONResponse(
                 status_code=429,
-                content={
-                    "error": "Rate limit exceeded",
-                    "retry_after": value,
-                },
-                headers={"Retry-After": str(value)},
+                content=make_error_payload(
+                    code="RATE_LIMITED",
+                    message="Rate limit exceeded",
+                    details={"retry_after": value},
+                    request_id=request_id,
+                ),
+                headers={"Retry-After": str(value), "X-Request-ID": request_id},
             )
 
         response = await call_next(request)

--- a/api/tests/test_errors.py
+++ b/api/tests/test_errors.py
@@ -1,0 +1,97 @@
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.errors import code_for_status
+from api.main import app
+
+
+def _install_error_routes() -> None:
+    known_paths = {route.path for route in app.routes}
+    if "/_test/error400" not in known_paths:
+        @app.get("/_test/error400")
+        async def _error400():
+            raise HTTPException(status_code=400, detail="Bad request test")
+
+    if "/_test/error401" not in known_paths:
+        @app.get("/_test/error401")
+        async def _error401():
+            raise HTTPException(status_code=401, detail="Auth failed test")
+
+    if "/_test/error429" not in known_paths:
+        @app.get("/_test/error429")
+        async def _error429():
+            raise HTTPException(status_code=429, detail="Rate limit test")
+
+    if "/_test/error500" not in known_paths:
+        @app.get("/_test/error500")
+        async def _error500():
+            raise RuntimeError("boom")
+
+
+_install_error_routes()
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_not_found_error_schema_and_request_id():
+    response = client.get("/agents/missing-agent")
+    body = response.json()
+
+    assert response.status_code == 404
+    assert body["code"] == "NOT_FOUND"
+    assert body["message"] == "Agent not found"
+    assert isinstance(body["details"], dict)
+    assert body["request_id"]
+
+
+def test_request_id_pass_through():
+    response = client.get("/agents/missing-agent", headers={"X-Request-ID": "req-123"})
+    body = response.json()
+
+    assert body["request_id"] == "req-123"
+    assert response.headers["X-Request-ID"] == "req-123"
+
+
+def test_validation_error_has_field_details():
+    response = client.get("/tasks/not-an-int")
+    body = response.json()
+
+    assert response.status_code == 422
+    assert body["code"] == "VALIDATION_ERROR"
+    assert body["message"] == "Request validation failed"
+    assert "fields" in body["details"]
+    assert "task_id" in body["details"]["fields"]
+    assert body["request_id"]
+
+
+def test_status_code_mapping_covers_required_codes():
+    assert code_for_status(400) == "BAD_REQUEST"
+    assert code_for_status(401) == "AUTH_FAILED"
+    assert code_for_status(403) == "AUTH_FAILED"
+    assert code_for_status(404) == "NOT_FOUND"
+    assert code_for_status(429) == "RATE_LIMITED"
+    assert code_for_status(500) == "INTERNAL_ERROR"
+
+
+def test_bad_request_and_auth_and_rate_limited_errors_use_structured_schema():
+    for path, expected_code, status in (
+        ("/_test/error400", "BAD_REQUEST", 400),
+        ("/_test/error401", "AUTH_FAILED", 401),
+        ("/_test/error429", "RATE_LIMITED", 429),
+    ):
+        response = client.get(path)
+        body = response.json()
+        assert response.status_code == status
+        assert body["code"] == expected_code
+        assert body["request_id"]
+        assert "message" in body
+        assert isinstance(body["details"], dict)
+
+
+def test_internal_error_uses_structured_schema():
+    response = client.get("/_test/error500")
+    body = response.json()
+
+    assert response.status_code == 500
+    assert body["code"] == "INTERNAL_ERROR"
+    assert body["message"] == "Internal server error"
+    assert body["request_id"]


### PR DESCRIPTION
Closes #203
/claim #203

## Summary
- add centralized structured error handlers and status->error-code mapping
- add request-id middleware and include equest_id in error responses
- align rate-limit middleware 429 response to the same schema
- document error codes in pi/ERROR_CODES.md
- add focused API tests for schema, request_id, validation field details, and required error-code mapping

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest api/tests/test_errors.py -q
- Result: 6 passed
