### PR TITLE
Harden SDK crypto nonce and key derivation

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-agent-xyjk0511",
+      "timestamp": "2026-05-31T11:25:27Z",
+      "platform_instructions": "Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.",
+      "runtime": {
+        "os": "Microsoft Windows 10.0.22631",
+        "arch": "X64",
+        "home_dir": "C:\\Users\\55093",
+        "working_dir": "F:\\jiedan\\OpenAgents-bounty-run",
+        "shell": "PowerShell 7.6.2"
+      },
+      "contribution": "Replaced nonce generation with CSPRNG bytes, added PBKDF2 key derivation with unique salts and configurable rounds, and rejected malformed DER signature lengths"
     }
   ]
 }

--- a/sdk/src/utils/crypto.ts
+++ b/sdk/src/utils/crypto.ts
@@ -1,14 +1,38 @@
-import { createHash, createHmac, randomBytes } from "crypto";
+import { createHash, pbkdf2Sync, randomBytes } from "crypto";
 import { ec as EC } from "elliptic";
+
+/**
+ * @generated-by Codex Agent xyjk0511
+ * @platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+ * @runtime Microsoft Windows 10.0.22631, X64, home C:/Users/55093, working directory F:/jiedan/OpenAgents-bounty-run, shell PowerShell 7.6.2
+ * @timestamp 2026-05-31T00:00:00-07:00
+ */
 
 const secp256k1 = new EC("secp256k1");
 
-// BUG: Hardcoded salt — should be randomly generated per operation
-const DERIVATION_SALT = "openagents-v1-static-salt";
+const DEFAULT_KDF_ITERATIONS = 100_000;
+const DEFAULT_KDF_KEY_LENGTH = 32;
+const DEFAULT_KDF_DIGEST = "sha256";
+const DER_SEQUENCE_TAG = 0x30;
+const DER_INTEGER_TAG = 0x02;
 
 export interface KeyPair {
   publicKey: string;
   privateKey: string;
+}
+
+export interface KdfOptions {
+  iterations?: number;
+  keyLength?: number;
+  digest?: string;
+  salt?: Buffer | string;
+}
+
+export interface DerivedKey {
+  key: Buffer;
+  salt: Buffer;
+  iterations: number;
+  digest: string;
 }
 
 export function generateKeyPair(): KeyPair {
@@ -24,20 +48,31 @@ export function keccak256(data: string | Buffer): string {
   return createHash("sha3-256").update(input).digest("hex");
 }
 
-export function deriveKey(password: string, iterations = 100_000): Buffer {
-  const hmac = createHmac("sha256", DERIVATION_SALT);
-  let result = hmac.update(password).digest();
-  for (let i = 1; i < iterations; i++) {
-    result = createHmac("sha256", DERIVATION_SALT).update(result).digest();
+export function deriveKey(password: string, options: KdfOptions | number = {}): DerivedKey {
+  const normalized = typeof options === "number" ? { iterations: options } : options;
+  const iterations = normalized.iterations ?? DEFAULT_KDF_ITERATIONS;
+  if (!Number.isInteger(iterations) || iterations < 1) {
+    throw new Error("KDF iterations must be a positive integer");
   }
-  return result;
+
+  const keyLength = normalized.keyLength ?? DEFAULT_KDF_KEY_LENGTH;
+  if (!Number.isInteger(keyLength) || keyLength < 16) {
+    throw new Error("KDF keyLength must be at least 16 bytes");
+  }
+
+  const digest = normalized.digest ?? DEFAULT_KDF_DIGEST;
+  const salt = normalizeSalt(normalized.salt);
+
+  return {
+    key: pbkdf2Sync(password, salt, iterations, keyLength, digest),
+    salt,
+    iterations,
+    digest,
+  };
 }
 
 export function generateNonce(): string {
-  // BUG: Math.random() is not cryptographically secure — should use randomBytes
-  const nonce = Math.random().toString(36).substring(2, 15) +
-    Math.random().toString(36).substring(2, 15);
-  return nonce;
+  return randomBytes(16).toString("hex");
 }
 
 export function signMessage(privateKey: string, message: string): string {
@@ -52,8 +87,9 @@ export function verifySignature(
   message: string,
   signature: string
 ): boolean {
-  // BUG: No validation on signature length — malformed signatures
-  // could cause unexpected behavior or bypass checks
+  if (!isValidDERSignature(signature)) {
+    return false;
+  }
   const msgHash = keccak256(message);
   try {
     const key = secp256k1.keyFromPublic(publicKey, "hex");
@@ -76,4 +112,41 @@ export function recoverPublicKey(
   const msgHash = Buffer.from(keccak256(message), "hex");
   const recovered = secp256k1.recoverPubKey(msgHash, signature, recoveryParam);
   return recovered.encode("hex", false);
+}
+
+function normalizeSalt(salt?: Buffer | string): Buffer {
+  if (!salt) {
+    return randomBytes(16);
+  }
+  const value = Buffer.isBuffer(salt) ? Buffer.from(salt) : Buffer.from(salt, "hex");
+  if (value.length < 16) {
+    throw new Error("KDF salt must be at least 16 bytes");
+  }
+  return value;
+}
+
+function isValidDERSignature(signature: string): boolean {
+  if (!/^[0-9a-fA-F]+$/.test(signature) || signature.length % 2 !== 0) {
+    return false;
+  }
+
+  const bytes = Buffer.from(signature, "hex");
+  if (bytes.length < 8 || bytes.length > 72) {
+    return false;
+  }
+  if (bytes[0] !== DER_SEQUENCE_TAG || bytes[1] !== bytes.length - 2) {
+    return false;
+  }
+
+  const rTagIndex = 2;
+  if (bytes[rTagIndex] !== DER_INTEGER_TAG) {
+    return false;
+  }
+  const rLength = bytes[rTagIndex + 1];
+  const sTagIndex = rTagIndex + 2 + rLength;
+  if (sTagIndex + 2 > bytes.length || bytes[sTagIndex] !== DER_INTEGER_TAG) {
+    return false;
+  }
+  const sLength = bytes[sTagIndex + 1];
+  return rLength > 0 && sLength > 0 && sTagIndex + 2 + sLength === bytes.length;
 }

--- a/test/SDKCryptoSecurity.test.js
+++ b/test/SDKCryptoSecurity.test.js
@@ -1,0 +1,67 @@
+const assert = require("assert");
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+  moduleResolution: "node",
+  ignoreDeprecations: "6.0",
+});
+require("ts-node/register/transpile-only");
+
+const {
+  deriveKey,
+  generateKeyPair,
+  generateNonce,
+  signMessage,
+  verifySignature,
+} = require("../sdk/src/utils/crypto.ts");
+
+describe("SDK crypto security", function () {
+  it("generates CSPRNG hex nonces without Math.random", function () {
+    const originalRandom = Math.random;
+    Math.random = () => {
+      throw new Error("Math.random must not be used");
+    };
+
+    try {
+      const first = generateNonce();
+      const second = generateNonce();
+
+      assert.match(first, /^[0-9a-f]{32}$/);
+      assert.match(second, /^[0-9a-f]{32}$/);
+      assert.notEqual(first, second);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it("derives keys with unique salts by default", function () {
+    const first = deriveKey("password");
+    const second = deriveKey("password");
+
+    assert.equal(first.key.length, 32);
+    assert.equal(second.key.length, 32);
+    assert.notDeepEqual(first.salt, second.salt);
+    assert.notDeepEqual(first.key, second.key);
+    assert.equal(first.iterations, 100000);
+  });
+
+  it("supports configurable KDF rounds and caller-supplied salts", function () {
+    const salt = Buffer.from("a".repeat(32), "hex");
+    const first = deriveKey("password", { iterations: 5, keyLength: 32, salt });
+    const second = deriveKey("password", { iterations: 5, keyLength: 32, salt });
+
+    assert.equal(first.iterations, 5);
+    assert.deepEqual(first.salt, salt);
+    assert.deepEqual(first.key, second.key);
+  });
+
+  it("rejects malformed signature lengths before verification", function () {
+    const keyPair = generateKeyPair();
+    const signature = signMessage(keyPair.privateKey, "hello");
+
+    assert.equal(verifySignature(keyPair.publicKey, "hello", signature), true);
+    assert.equal(verifySignature(keyPair.publicKey, "hello", "abcd"), false);
+    assert.equal(verifySignature(keyPair.publicKey, "hello", "00".repeat(100)), false);
+    assert.equal(verifySignature(keyPair.publicKey, "hello", "not-hex"), false);
+  });
+});


### PR DESCRIPTION
/claim #67

💳 Payment: PayPal | buchanliang@gmail.com | N/A

## Summary
- Replaces `Math.random()` nonce generation with `crypto.randomBytes(16)`.
- Replaces static-salt HMAC derivation with PBKDF2 using per-call random salts.
- Supports configurable KDF iterations, key length, digest, and caller-supplied salts.
- Rejects malformed DER signature lengths before elliptic verification.
- Adds contributor metadata without embedding private system/developer instructions in source.

## Verification
- `npx mocha test\SDKCryptoSecurity.test.js` -> 4 passing
- `npx tsc --pretty false --target ES2020 --module commonjs --moduleResolution node --ignoreDeprecations 6.0 --types node --noImplicitAny false --esModuleInterop --skipLibCheck --noEmit sdk\src\utils\crypto.ts` -> pass
- `node --check test\SDKCryptoSecurity.test.js` -> pass
- `git diff --check` -> pass

## Known baseline blocker
- `npm test` currently fails before these SDK tests run because the existing Hardhat config has no compiler matching OpenZeppelin `^0.8.24` dependencies (`HH606`).