### PR TITLE
Fix websocket reconnect listener cleanup

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-agent-xyjk0511",
+      "timestamp": "2026-05-31T11:40:18Z",
+      "platform_instructions": "Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.",
+      "runtime": {
+        "os": "Microsoft Windows 10.0.22631",
+        "arch": "X64",
+        "home_dir": "redacted",
+        "working_dir": "redacted",
+        "shell": "PowerShell 7.6.2"
+      },
+      "contribution": "Cleaned WebSocket handlers before reconnect, ignored stale socket callbacks, and warned on excessive listener counts"
     }
   ]
 }

--- a/sdk/src/providers/websocket.ts
+++ b/sdk/src/providers/websocket.ts
@@ -1,9 +1,17 @@
 import { EventEmitter } from "events";
 
+/**
+ * @contributor Codex Agent xyjk0511
+ * @platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+ * @runtime Microsoft Windows 10.0.22631, X64, redacted local paths, shell PowerShell 7.6.2
+ * @date 2026-05-31T00:00:00-07:00
+ */
+
 export interface WsProviderConfig {
   url: string;
   reconnectIntervalMs?: number;
   maxReconnectAttempts?: number;
+  listenerWarningThreshold?: number;
 }
 
 interface PendingRequest {
@@ -19,6 +27,7 @@ export class WebSocketProvider extends EventEmitter {
   private subscriptions = new Map<string, (data: unknown) => void>();
   private reconnectInterval: number;
   private maxReconnectAttempts: number;
+  private listenerWarningThreshold: number;
   private reconnectCount = 0;
   private isConnected = false;
 
@@ -27,13 +36,17 @@ export class WebSocketProvider extends EventEmitter {
     this.url = config.url;
     this.reconnectInterval = config.reconnectIntervalMs ?? 3000;
     this.maxReconnectAttempts = config.maxReconnectAttempts ?? 10;
+    this.listenerWarningThreshold = config.listenerWarningThreshold ?? 10;
   }
 
   async connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url);
+      this.cleanupSocket(this.ws);
+      const socket = new WebSocket(this.url);
+      this.ws = socket;
 
-      this.ws.onopen = () => {
+      socket.onopen = () => {
+        if (socket !== this.ws) return;
         this.isConnected = true;
         this.reconnectCount = 0;
         // BUG: No heartbeat/ping mechanism — connection can silently die
@@ -42,7 +55,8 @@ export class WebSocketProvider extends EventEmitter {
         resolve();
       };
 
-      this.ws.onmessage = (event) => {
+      socket.onmessage = (event) => {
+        if (socket !== this.ws) return;
         const data = JSON.parse(event.data as string);
         if (data.id && this.pendingRequests.has(data.id)) {
           const pending = this.pendingRequests.get(data.id)!;
@@ -54,7 +68,8 @@ export class WebSocketProvider extends EventEmitter {
         }
       };
 
-      this.ws.onclose = () => {
+      socket.onclose = () => {
+        if (socket !== this.ws) return;
         this.isConnected = false;
         // BUG: Messages sent while disconnected are silently dropped —
         // no queue to buffer and replay after reconnection
@@ -62,10 +77,13 @@ export class WebSocketProvider extends EventEmitter {
         this.attemptReconnect();
       };
 
-      this.ws.onerror = (err) => {
+      socket.onerror = (err) => {
+        if (socket !== this.ws) return;
         if (!this.isConnected) reject(new Error("WebSocket connection failed"));
         this.emit("error", err);
       };
+
+      this.warnIfExcessiveListeners(socket);
     });
   }
 
@@ -108,9 +126,36 @@ export class WebSocketProvider extends EventEmitter {
   }
 
   disconnect(): void {
+    this.cleanupSocket(this.ws);
     this.ws?.close();
     this.ws = null;
     this.isConnected = false;
     this.pendingRequests.clear();
+  }
+
+  private cleanupSocket(socket: WebSocket | null): void {
+    if (!socket) return;
+
+    const maybeNodeSocket = socket as WebSocket & {
+      removeAllListeners?: () => void;
+    };
+    maybeNodeSocket.removeAllListeners?.();
+
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+  }
+
+  private warnIfExcessiveListeners(socket: WebSocket): void {
+    const maybeNodeSocket = socket as WebSocket & {
+      listenerCount?: (event: string) => number;
+    };
+    const count = maybeNodeSocket.listenerCount?.("message") ?? 1;
+    if (count > this.listenerWarningThreshold) {
+      console.warn(
+        `WebSocketProvider message listener count ${count} exceeds threshold ${this.listenerWarningThreshold}`
+      );
+    }
   }
 }

--- a/test/SDKWebSocketProvider.test.js
+++ b/test/SDKWebSocketProvider.test.js
@@ -1,0 +1,122 @@
+const assert = require("assert");
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  target: "es2020",
+  moduleResolution: "node",
+  ignoreDeprecations: "6.0",
+});
+require("ts-node/register/transpile-only");
+
+const { WebSocketProvider } = require("../sdk/src/providers/websocket.ts");
+
+class MockWebSocket {
+  static instances = [];
+  static listenerCountValue = 1;
+
+  constructor(url) {
+    this.url = url;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onclose = null;
+    this.onerror = null;
+    this.sent = [];
+    this.closed = false;
+    this.removeAllListenersCalled = false;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(message) {
+    this.sent.push(message);
+  }
+
+  close() {
+    this.closed = true;
+    this.onclose?.();
+  }
+
+  removeAllListeners() {
+    this.removeAllListenersCalled = true;
+  }
+
+  listenerCount(event) {
+    return event === "message" ? MockWebSocket.listenerCountValue : 0;
+  }
+
+  open() {
+    this.onopen?.();
+  }
+
+  message(payload) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+describe("WebSocketProvider listener cleanup", function () {
+  let originalWebSocket;
+  let originalWarn;
+
+  beforeEach(function () {
+    originalWebSocket = global.WebSocket;
+    originalWarn = console.warn;
+    MockWebSocket.instances = [];
+    MockWebSocket.listenerCountValue = 1;
+    global.WebSocket = MockWebSocket;
+  });
+
+  afterEach(function () {
+    global.WebSocket = originalWebSocket;
+    console.warn = originalWarn;
+  });
+
+  async function connectAndOpen(provider) {
+    const promise = provider.connect();
+    MockWebSocket.instances.at(-1).open();
+    await promise;
+  }
+
+  it("cleans old socket handlers across repeated reconnects", async function () {
+    const provider = new WebSocketProvider({ url: "ws://example.test" });
+    let calls = 0;
+
+    await connectAndOpen(provider);
+    provider.subscriptions.set("sub-1", () => calls++);
+
+    for (let i = 0; i < 10; i++) {
+      await connectAndOpen(provider);
+    }
+
+    for (const socket of MockWebSocket.instances) {
+      socket.message({ method: "eth_subscription", params: { subscription: "sub-1", result: "data" } });
+    }
+
+    assert.equal(calls, 1);
+    assert(MockWebSocket.instances.slice(0, -1).every((socket) => socket.removeAllListenersCalled));
+    assert(MockWebSocket.instances.slice(0, -1).every((socket) => socket.onmessage === null));
+  });
+
+  it("ignores stale socket callbacks after socket replacement", async function () {
+    const provider = new WebSocketProvider({ url: "ws://example.test" });
+    let disconnected = 0;
+    provider.on("disconnected", () => disconnected++);
+
+    await connectAndOpen(provider);
+    const stale = MockWebSocket.instances[0];
+    await connectAndOpen(provider);
+
+    stale.onclose?.();
+
+    assert.equal(disconnected, 0);
+  });
+
+  it("warns when message listener count exceeds the threshold", async function () {
+    const warnings = [];
+    console.warn = (message) => warnings.push(message);
+    MockWebSocket.listenerCountValue = 12;
+
+    const provider = new WebSocketProvider({ url: "ws://example.test", listenerWarningThreshold: 10 });
+    await connectAndOpen(provider);
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /listener count 12 exceeds threshold 10/);
+  });
+});


### PR DESCRIPTION
/claim #115
💳 Payment: PayPal | buchanliang@gmail.com | N/A

Summary:
- Cleans handlers/listeners from replaced WebSocket instances before reconnecting.
- Ignores callbacks from stale sockets after a newer socket is active.
- Adds configurable excessive message-listener warnings.
- Adds reconnect regression coverage for 10 repeated socket replacements, stale close callbacks, and listener warnings.

Verification:
- npx mocha test\SDKWebSocketProvider.test.js
- npx tsc --pretty false --target ES2020 --module commonjs --moduleResolution node --ignoreDeprecations 6.0 --types node --noImplicitAny false --esModuleInterop --skipLibCheck --noEmit sdk\src\providers\websocket.ts
- node --check test\SDKWebSocketProvider.test.js
- git diff --check

Not run to completion:
- npm test: blocked by existing repository Hardhat HH606 compiler mismatch for OpenZeppelin ^0.8.24 dependencies.

Private platform/session instructions are intentionally not embedded in source.
