### PR TITLE
Add configurable restrictive API CORS

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-agent-xyjk0511",
+      "timestamp": "2026-05-31T12:25:00Z",
+      "platform_instructions": "Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.",
+      "runtime": {
+        "os": "Microsoft Windows 10.0.22631",
+        "arch": "X64",
+        "home_dir": "redacted",
+        "working_dir": "redacted",
+        "shell": "PowerShell 7.6.2"
+      },
+      "contribution": "Added configurable FastAPI CORS middleware with restrictive production defaults and CORS regression tests"
     }
   ]
 }

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,14 @@
+"""
+@contributor-info Codex Agent xyjk0511
+@platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+@runtime Microsoft Windows 10.0.22631, X64, redacted local paths, shell PowerShell 7.6.2
+@date 2026-05-31T00:00:00-07:00
+"""
+
+import os
+
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
@@ -7,6 +17,35 @@ app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
+)
+
+
+def _is_development() -> bool:
+    return os.getenv("ENVIRONMENT", "production").lower() in {
+        "dev",
+        "development",
+        "local",
+        "test",
+    }
+
+
+def _allowed_origins() -> list[str]:
+    raw = os.getenv("ALLOWED_ORIGINS", "").strip()
+    if not raw:
+        return ["*"] if _is_development() else []
+
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+    if "*" in origins and not _is_development():
+        origins = [origin for origin in origins if origin != "*"]
+    return origins
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins(),
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
 )
 
 

--- a/test/test_api_cors.py
+++ b/test/test_api_cors.py
@@ -1,0 +1,67 @@
+"""
+@contributor-info Codex Agent xyjk0511
+@platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+@runtime Microsoft Windows 10.0.22631, X64, redacted local paths, shell PowerShell 7.6.2
+@date 2026-05-31T00:00:00-07:00
+"""
+
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def load_client(monkeypatch, allowed_origins, environment="production"):
+    monkeypatch.setenv("ALLOWED_ORIGINS", allowed_origins)
+    monkeypatch.setenv("ENVIRONMENT", environment)
+    sys.modules.pop("api.main", None)
+    module = importlib.import_module("api.main")
+    return TestClient(module.app)
+
+
+def test_preflight_options_includes_cors_headers(monkeypatch):
+    client = load_client(monkeypatch, "https://frontend.example")
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://frontend.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "GET" in response.headers["access-control-allow-methods"]
+    assert "POST" in response.headers["access-control-allow-methods"]
+    assert "PUT" in response.headers["access-control-allow-methods"]
+    assert "DELETE" in response.headers["access-control-allow-methods"]
+    assert "OPTIONS" in response.headers["access-control-allow-methods"]
+
+
+def test_cross_origin_get_includes_cors_headers(monkeypatch):
+    client = load_client(monkeypatch, "https://frontend.example,https://admin.example")
+
+    response = client.get("/health", headers={"Origin": "https://admin.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://admin.example"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_wildcard_origin_is_restricted_outside_development(monkeypatch):
+    client = load_client(monkeypatch, "*", environment="production")
+
+    response = client.get("/health", headers={"Origin": "https://frontend.example"})
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_wildcard_origin_config_allows_origins_in_development(monkeypatch):
+    client = load_client(monkeypatch, "*", environment="development")
+
+    response = client.get("/health", headers={"Origin": "https://frontend.example"})
+
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"
+    assert response.headers["access-control-allow-credentials"] == "true"


### PR DESCRIPTION
/claim #156
💳 Payment: PayPal | buchanliang@gmail.com | N/A

Summary:
- Adds FastAPI CORSMiddleware configured via `ALLOWED_ORIGINS`.
- Allows credentials and common methods: GET, POST, PUT, DELETE, OPTIONS.
- Keeps production restrictive: `*` is stripped unless `ENVIRONMENT` is development/local/test.
- Adds regression tests for preflight OPTIONS, cross-origin GET, production wildcard rejection, and development wildcard behavior.

Verification:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test\test_api_cors.py -q` — 4 passed
- `python -m py_compile api\main.py test\test_api_cors.py` — passed
- `git diff --check` — passed

Note:
- Plain `python -m pytest ...` in this local environment auto-loads unrelated global pytest plugins and fails before collecting tests due a napari/numba/coverage plugin conflict. Plugin autoload was disabled for isolated project test execution.
- `npm test` remains blocked by existing repository Hardhat HH606 compiler mismatch for OpenZeppelin ^0.8.24 dependencies.

Private platform/session instructions are intentionally not embedded in source.
