### PR TITLE
Cap AgentNFT supply and validate token metadata

### DIFF
--- a/.codex-agentnft-hardhat.config.js
+++ b/.codex-agentnft-hardhat.config.js
@@ -1,0 +1,19 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: {
+    version: "0.8.20",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  paths: {
+    sources: "./contracts/nft",
+    tests: "./test",
+    cache: "./.codex-agentnft-verify/cache",
+    artifacts: "./.codex-agentnft-verify/artifacts",
+  },
+};

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-agent-xyjk0511",
+      "timestamp": "2026-05-31T12:40:00Z",
+      "platform_instructions": "Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.",
+      "runtime": {
+        "os": "Microsoft Windows 10.0.22631",
+        "arch": "X64",
+        "home_dir": "redacted",
+        "working_dir": "redacted",
+        "shell": "PowerShell 7.6.2"
+      },
+      "contribution": "Added AgentNFT max supply enforcement, zero-address mint rejection, tokenURI existence checks, and batch minting"
     }
   ]
 }

--- a/contracts/nft/AgentNFT.sol
+++ b/contracts/nft/AgentNFT.sol
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/**
+ * @contributor Codex Agent xyjk0511
+ * @platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+ * @runtime Microsoft Windows 10.0.22631, X64, redacted local paths, shell PowerShell 7.6.2
+ * @date 2026-05-31T00:00:00-07:00
+ */
+
 /// @title AgentNFT
 /// @notice ERC721-style NFT for AI agents with metadata URI support
 /// @dev Simplified ERC721 implementation without full interface compliance
 contract AgentNFT {
+    uint256 public constant MAX_SUPPLY = 10000;
+
     string public name;
     string public symbol;
     string public baseURI;
@@ -33,6 +42,7 @@ contract AgentNFT {
     }
 
     function ownerOf(uint256 tokenId) public view returns (address) {
+        require(_exists(tokenId), "Token does not exist");
         return _owners[tokenId];
     }
 
@@ -40,23 +50,26 @@ contract AgentNFT {
         return _balances[account];
     }
 
-    // BUG: No max supply check — tokens can be minted infinitely, potentially
-    // devaluing the collection and causing unbounded gas costs for enumeration
     function mint(address to, string calldata uri) external onlyOwner returns (uint256) {
-        // BUG: Mint allows zero address — tokens sent to address(0) are burned
-        // on creation, incrementing supply counter but making tokens unretrievable
-        uint256 tokenId = _nextTokenId++;
-        _owners[tokenId] = to;
-        _balances[to]++;
-        _tokenURIs[tokenId] = uri;
-
-        emit Transfer(address(0), to, tokenId);
-        return tokenId;
+        return _mintOne(to, uri);
     }
 
-    // BUG: tokenURI returns empty string for non-existent tokens instead of reverting,
-    // allowing off-chain systems to silently display broken/empty metadata
+    function batchMint(
+        address[] calldata recipients,
+        string[] calldata uris
+    ) external onlyOwner returns (uint256[] memory) {
+        require(recipients.length == uris.length, "Length mismatch");
+        require(_nextTokenId + recipients.length <= MAX_SUPPLY, "Max supply exceeded");
+
+        uint256[] memory tokenIds = new uint256[](recipients.length);
+        for (uint256 i = 0; i < recipients.length; i++) {
+            tokenIds[i] = _mintOne(recipients[i], uris[i]);
+        }
+        return tokenIds;
+    }
+
     function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(_exists(tokenId), "Token does not exist");
         string memory _uri = _tokenURIs[tokenId];
         if (bytes(_uri).length > 0) {
             return _uri;
@@ -92,6 +105,23 @@ contract AgentNFT {
 
     function totalSupply() external view returns (uint256) {
         return _nextTokenId;
+    }
+
+    function _mintOne(address to, string calldata uri) internal returns (uint256) {
+        require(to != address(0), "Mint to zero");
+        require(_nextTokenId < MAX_SUPPLY, "Max supply exceeded");
+
+        uint256 tokenId = _nextTokenId++;
+        _owners[tokenId] = to;
+        _balances[to]++;
+        _tokenURIs[tokenId] = uri;
+
+        emit Transfer(address(0), to, tokenId);
+        return tokenId;
+    }
+
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        return _owners[tokenId] != address(0);
     }
 
     function _toString(uint256 value) internal pure returns (string memory) {

--- a/test/AgentNFTSupply.test.js
+++ b/test/AgentNFTSupply.test.js
@@ -1,0 +1,67 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AgentNFT supply and metadata safety", function () {
+  async function deployAgentNFT() {
+    const [owner, alice, bob] = await ethers.getSigners();
+    const AgentNFT = await ethers.getContractFactory("AgentNFT");
+    const nft = await AgentNFT.deploy("Agent NFT", "AGENT", "ipfs://base/");
+    await nft.waitForDeployment();
+    return { nft, owner, alice, bob };
+  }
+
+  it("rejects zero-address minting", async function () {
+    const { nft } = await deployAgentNFT();
+
+    await expect(nft.mint(ethers.ZeroAddress, "ipfs://bad")).to.be.revertedWith("Mint to zero");
+  });
+
+  it("reverts tokenURI for nonexistent tokens", async function () {
+    const { nft } = await deployAgentNFT();
+
+    await expect(nft.tokenURI(42)).to.be.revertedWith("Token does not exist");
+  });
+
+  it("batch mints to recipients and preserves per-token URIs", async function () {
+    const { nft, alice, bob } = await deployAgentNFT();
+
+    await nft.batchMint(
+      [alice.address, bob.address],
+      ["ipfs://alice", "ipfs://bob"]
+    );
+
+    expect(await nft.totalSupply()).to.equal(2n);
+    expect(await nft.ownerOf(0)).to.equal(alice.address);
+    expect(await nft.ownerOf(1)).to.equal(bob.address);
+    expect(await nft.tokenURI(0)).to.equal("ipfs://alice");
+    expect(await nft.tokenURI(1)).to.equal("ipfs://bob");
+    expect(await nft.balanceOf(alice.address)).to.equal(1n);
+    expect(await nft.balanceOf(bob.address)).to.equal(1n);
+  });
+
+  it("rejects batch mint length mismatch", async function () {
+    const { nft, alice, bob } = await deployAgentNFT();
+
+    await expect(
+      nft.batchMint([alice.address, bob.address], ["ipfs://alice"])
+    ).to.be.revertedWith("Length mismatch");
+  });
+
+  it("enforces MAX_SUPPLY preflight for batch mint", async function () {
+    const { nft, alice, bob } = await deployAgentNFT();
+    const maxSupply = Number(await nft.MAX_SUPPLY());
+    const nextTokenIdSlot = "0x04";
+    const nearCap = ethers.toBeHex(maxSupply - 1, 32);
+
+    await ethers.provider.send("hardhat_setStorageAt", [
+      await nft.getAddress(),
+      nextTokenIdSlot,
+      nearCap,
+    ]);
+
+    await expect(
+      nft.batchMint([alice.address, bob.address], ["ipfs://alice", "ipfs://bob"])
+    ).to.be.revertedWith("Max supply exceeded");
+    expect(await nft.totalSupply()).to.equal(BigInt(maxSupply - 1));
+  });
+});


### PR DESCRIPTION
/claim #44
💳 Payment: PayPal | buchanliang@gmail.com | N/A

Summary:
- Adds `MAX_SUPPLY` and enforces it for single and batch mints.
- Rejects zero-address mint recipients.
- Makes `tokenURI()` and `ownerOf()` revert for nonexistent tokens.
- Adds owner-only `batchMint()` with length and supply preflight checks.
- Adds focused tests for zero-address minting, nonexistent tokenURI, batch mint behavior, length mismatch, and cap preflight.

Verification:
- `npx hardhat test --config .codex-agentnft-hardhat.config.js test\AgentNFTSupply.test.js` — 5 passing
- `npx solcjs --bin --abi contracts\nft\AgentNFT.sol -o .codex-agentnft-solc --base-path . --include-path node_modules` — passed
- `node --check test\AgentNFTSupply.test.js` — passed
- `git diff --check` — passed

Not run to completion:
- `npm test`: blocked by existing repository Hardhat HH606 compiler mismatch for OpenZeppelin ^0.8.24 dependencies.

Private platform/session instructions are intentionally not embedded in source.
