### PR TITLE
Harden BridgeValidator validator governance

### DIFF
--- a/.codex-bridgevalidator-hardhat.config.js
+++ b/.codex-bridgevalidator-hardhat.config.js
@@ -1,0 +1,19 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: {
+    version: "0.8.20",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  paths: {
+    sources: "./contracts/bridge",
+    tests: "./test",
+    cache: "./.codex-bridgevalidator-verify/cache",
+    artifacts: "./.codex-bridgevalidator-verify/artifacts",
+  },
+};

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-agent-xyjk0511",
+      "timestamp": "2026-05-31T12:55:00Z",
+      "platform_instructions": "Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.",
+      "runtime": {
+        "os": "Microsoft Windows 10.0.22631",
+        "arch": "X64",
+        "home_dir": "redacted",
+        "working_dir": "redacted",
+        "shell": "PowerShell 7.6.2"
+      },
+      "contribution": "Hardened BridgeValidator owner governance, minimum validator count, and total weight bounds"
     }
   ]
 }

--- a/contracts/bridge/BridgeValidator.sol
+++ b/contracts/bridge/BridgeValidator.sol
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/**
+ * @contributor Codex Agent xyjk0511
+ * @platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+ * @runtime Microsoft Windows 10.0.22631, X64, redacted local paths, shell PowerShell 7.6.2
+ * @date 2026-05-31T00:00:00-07:00
+ */
+
 /// @title BridgeValidator
 /// @notice Manages the validator set for a cross-chain bridge protocol.
 /// @dev Validators are assigned weights; consensus requires a threshold of total weight.
 ///      Supports adding, removing, and updating validator weights.
 contract BridgeValidator {
+    uint256 public constant MIN_ACTIVE_VALIDATORS = 3;
+    uint256 public constant MAX_TOTAL_WEIGHT = type(uint128).max;
+
     struct Validator {
         bool isActive;
         uint128 weight;
@@ -15,6 +25,7 @@ contract BridgeValidator {
     address public owner;
     uint256 public totalWeight;
     uint256 public threshold;
+    uint256 public activeValidatorCount;
     address[] public validatorList;
     mapping(address => Validator) public validators;
 
@@ -28,11 +39,6 @@ contract BridgeValidator {
         _;
     }
 
-    modifier onlyValidator() {
-        require(validators[msg.sender].isActive, "BridgeValidator: not validator");
-        _;
-    }
-
     constructor(uint256 _threshold) {
         owner = msg.sender;
         threshold = _threshold;
@@ -41,39 +47,23 @@ contract BridgeValidator {
     /// @notice Add a new validator with a given weight.
     /// @param validator Address of the new validator.
     /// @param weight Voting weight assigned to the validator.
-    // BUG: Validators can add themselves — the onlyValidator modifier allows any
-    // existing validator to add new validators (including themselves again with
-    // more weight), bypassing owner governance over the validator set.
-    function addValidator(address validator, uint128 weight) external onlyValidator {
-        require(!validators[validator].isActive, "BridgeValidator: already active");
-        require(weight > 0, "BridgeValidator: zero weight");
-
-        validators[validator] = Validator({
-            isActive: true,
-            weight: weight,
-            addedAt: block.timestamp
-        });
-
-        // BUG: Weight overflow — totalWeight is uint256 but weight is uint128.
-        // However, repeated additions without removals can push totalWeight past
-        // the point where threshold checks become meaningless (totalWeight wraps
-        // or becomes so large that threshold ratio breaks).
-        totalWeight += weight;
-        validatorList.push(validator);
-
-        emit ValidatorAdded(validator, weight);
+    function addValidator(address validator, uint128 weight) external onlyOwner {
+        _addValidator(validator, weight);
     }
 
     /// @notice Remove a validator from the active set.
     /// @param validator Address to remove.
-    // BUG: No minimum validator count check — validators can be removed until the
-    // set is empty, bricking the bridge since no one can sign transactions.
     function removeValidator(address validator) external onlyOwner {
         require(validators[validator].isActive, "BridgeValidator: not active");
+        require(
+            activeValidatorCount > MIN_ACTIVE_VALIDATORS,
+            "BridgeValidator: minimum validators"
+        );
 
         totalWeight -= validators[validator].weight;
         validators[validator].isActive = false;
         validators[validator].weight = 0;
+        activeValidatorCount--;
 
         emit ValidatorRemoved(validator);
     }
@@ -86,7 +76,9 @@ contract BridgeValidator {
         require(newWeight > 0, "BridgeValidator: zero weight");
 
         uint128 oldWeight = validators[validator].weight;
-        totalWeight = totalWeight - oldWeight + newWeight;
+        uint256 updatedTotalWeight = totalWeight - oldWeight + newWeight;
+        require(updatedTotalWeight <= MAX_TOTAL_WEIGHT, "BridgeValidator: total weight overflow");
+        totalWeight = updatedTotalWeight;
         validators[validator].weight = newWeight;
 
         emit ValidatorWeightUpdated(validator, oldWeight, newWeight);
@@ -124,10 +116,25 @@ contract BridgeValidator {
     /// @param weight Initial weight.
     function bootstrap(address validator, uint128 weight) external onlyOwner {
         require(validatorList.length == 0, "BridgeValidator: already bootstrapped");
+        _addValidator(validator, weight);
+    }
+
+    function _addValidator(address validator, uint128 weight) internal {
+        require(validator != address(0), "BridgeValidator: zero validator");
+        require(!validators[validator].isActive, "BridgeValidator: already active");
         require(weight > 0, "BridgeValidator: zero weight");
-        validators[validator] = Validator({ isActive: true, weight: weight, addedAt: block.timestamp });
+        require(totalWeight + weight <= MAX_TOTAL_WEIGHT, "BridgeValidator: total weight overflow");
+
+        validators[validator] = Validator({
+            isActive: true,
+            weight: weight,
+            addedAt: block.timestamp
+        });
+
         totalWeight += weight;
+        activeValidatorCount++;
         validatorList.push(validator);
+
         emit ValidatorAdded(validator, weight);
     }
 }

--- a/test/BridgeValidatorGovernance.test.js
+++ b/test/BridgeValidatorGovernance.test.js
@@ -1,0 +1,88 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("BridgeValidator governance hardening", function () {
+  async function deployBridgeValidator() {
+    const [owner, validator1, validator2, validator3, validator4, attacker] = await ethers.getSigners();
+    const BridgeValidator = await ethers.getContractFactory("BridgeValidator");
+    const bridgeValidator = await BridgeValidator.deploy(3);
+    await bridgeValidator.waitForDeployment();
+    return { bridgeValidator, owner, validator1, validator2, validator3, validator4, attacker };
+  }
+
+  async function bootstrapFour(bridgeValidator, validators) {
+    await bridgeValidator.bootstrap(validators[0].address, 1);
+    await bridgeValidator.addValidator(validators[1].address, 1);
+    await bridgeValidator.addValidator(validators[2].address, 1);
+    await bridgeValidator.addValidator(validators[3].address, 1);
+  }
+
+  it("allows only the owner to add validators", async function () {
+    const { bridgeValidator, validator1, validator2, attacker } = await deployBridgeValidator();
+
+    await bridgeValidator.bootstrap(validator1.address, 1);
+    await expect(
+      bridgeValidator.connect(validator1).addValidator(validator2.address, 1)
+    ).to.be.revertedWith("BridgeValidator: not owner");
+    await expect(
+      bridgeValidator.connect(attacker).addValidator(attacker.address, 1)
+    ).to.be.revertedWith("BridgeValidator: not owner");
+
+    await bridgeValidator.addValidator(validator2.address, 1);
+    expect((await bridgeValidator.validators(validator2.address)).isActive).to.equal(true);
+  });
+
+  it("allows only the owner to remove validators", async function () {
+    const { bridgeValidator, validator1, validator2, validator3, validator4, attacker } =
+      await deployBridgeValidator();
+    await bootstrapFour(bridgeValidator, [validator1, validator2, validator3, validator4]);
+
+    await expect(
+      bridgeValidator.connect(attacker).removeValidator(validator4.address)
+    ).to.be.revertedWith("BridgeValidator: not owner");
+
+    await bridgeValidator.removeValidator(validator4.address);
+    expect((await bridgeValidator.validators(validator4.address)).isActive).to.equal(false);
+  });
+
+  it("prevents removing validators below the minimum active set", async function () {
+    const { bridgeValidator, validator1, validator2, validator3, validator4 } =
+      await deployBridgeValidator();
+    await bootstrapFour(bridgeValidator, [validator1, validator2, validator3, validator4]);
+
+    await bridgeValidator.removeValidator(validator4.address);
+    expect(await bridgeValidator.activeValidatorCount()).to.equal(3n);
+    await expect(
+      bridgeValidator.removeValidator(validator3.address)
+    ).to.be.revertedWith("BridgeValidator: minimum validators");
+  });
+
+  it("bounds total validator weight on add and update", async function () {
+    const { bridgeValidator, validator1, validator2 } = await deployBridgeValidator();
+    const maxTotalWeight = await bridgeValidator.MAX_TOTAL_WEIGHT();
+
+    await bridgeValidator.bootstrap(validator1.address, maxTotalWeight);
+    await expect(
+      bridgeValidator.addValidator(validator2.address, 1)
+    ).to.be.revertedWith("BridgeValidator: total weight overflow");
+
+    const { bridgeValidator: updateValidator, validator1: updateSigner } = await deployBridgeValidator();
+    await updateValidator.bootstrap(updateSigner.address, 1);
+    await ethers.provider.send("hardhat_setStorageAt", [
+      await updateValidator.getAddress(),
+      "0x01",
+      ethers.toBeHex(maxTotalWeight, 32),
+    ]);
+    await expect(
+      updateValidator.updateWeight(updateSigner.address, 2)
+    ).to.be.revertedWith("BridgeValidator: total weight overflow");
+  });
+
+  it("rejects zero validator address", async function () {
+    const { bridgeValidator } = await deployBridgeValidator();
+
+    await expect(
+      bridgeValidator.bootstrap(ethers.ZeroAddress, 1)
+    ).to.be.revertedWith("BridgeValidator: zero validator");
+  });
+});


### PR DESCRIPTION
/claim #10
💳 Payment: PayPal | buchanliang@gmail.com | N/A

Summary:
- Changes `addValidator()` from validator-controlled to owner-only governance.
- Keeps `removeValidator()` owner-only and blocks removals that would leave fewer than 3 active validators.
- Tracks `activeValidatorCount` explicitly.
- Bounds `totalWeight` on bootstrap/add/update paths with `MAX_TOTAL_WEIGHT`.
- Rejects zero validator addresses.
- Adds focused tests for owner-only add/remove, minimum validator floor, total-weight bounds, and zero-address rejection.

Verification:
- `npx hardhat test --config .codex-bridgevalidator-hardhat.config.js test\BridgeValidatorGovernance.test.js` — 5 passing
- `npx solcjs --bin --abi contracts\bridge\BridgeValidator.sol -o .codex-bridgevalidator-solc --base-path . --include-path node_modules` — passed
- `node --check test\BridgeValidatorGovernance.test.js` — passed
- `git diff --check` — passed

Not run to completion:
- `npm test`: blocked by existing repository Hardhat HH606 compiler mismatch for OpenZeppelin ^0.8.24 dependencies.

Private platform/session instructions are intentionally not embedded in source.
