### PR TITLE
Harden VestingWallet vesting math and revoke accounting

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-agent-xyjk0511",
+      "timestamp": "2026-05-31T13:10:00Z",
+      "platform_instructions": "Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.",
+      "runtime": {
+        "os": "Microsoft Windows 10.0.22631",
+        "arch": "X64",
+        "home_dir": "redacted",
+        "working_dir": "redacted",
+        "shell": "PowerShell 7.6.2"
+      },
+      "contribution": "Hardened VestingWallet vesting math, cliff revoke accounting, and zero-address validation"
     }
   ]
 }

--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/**
+ * @contributor Codex Agent xyjk0511
+ * @platform Safety-preserving Codex execution context; private system and developer instructions are not embedded in source.
+ * @runtime Microsoft Windows 10.0.22631, X64, redacted local paths, shell PowerShell 7.6.2
+ * @date 2026-05-31T00:00:00-07:00
+ */
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -26,8 +33,6 @@ contract VestingWallet {
     event TokensReleased(address indexed beneficiary, uint256 amount);
     event VestingRevoked(address indexed token, uint256 refund);
 
-    // BUG: No zero-address validation on beneficiary — if beneficiary is set to
-    // address(0), all vested tokens are sent to the zero address (burned) on release.
     constructor(
         address _beneficiary,
         address _token,
@@ -37,6 +42,8 @@ contract VestingWallet {
         uint256 _totalAllocation,
         bool _revocable
     ) {
+        require(_beneficiary != address(0), "Vesting: zero beneficiary");
+        require(_token != address(0), "Vesting: zero token");
         require(_vestingDuration > _cliffDuration, "Vesting: cliff exceeds duration");
         require(_totalAllocation > 0, "Vesting: zero allocation");
 
@@ -53,6 +60,7 @@ contract VestingWallet {
     /// @notice Release vested tokens to the beneficiary.
     function release() external {
         require(msg.sender == beneficiary, "Vesting: not beneficiary");
+        require(!revoked, "Vesting: revoked");
         uint256 vested = vestedAmount();
         uint256 unreleased = vested - released;
         require(unreleased > 0, "Vesting: nothing to release");
@@ -65,17 +73,21 @@ contract VestingWallet {
     /// @notice Calculate the total vested amount at the current timestamp.
     /// @return The total amount of tokens that have vested.
     function vestedAmount() public view returns (uint256) {
-        if (block.timestamp < start + cliffDuration) {
+        if (block.timestamp < start) {
             return 0;
         }
-        if (block.timestamp >= start + vestingDuration) {
+
+        uint256 elapsed = block.timestamp - start;
+        if (elapsed < cliffDuration) {
+            return 0;
+        }
+        if (elapsed >= vestingDuration) {
             return totalAllocation;
         }
-        // BUG: Overflow risk — (totalAllocation * elapsed) can overflow for large
-        // allocations. E.g., if totalAllocation is 1e30 and elapsed is 1e8, the
-        // product exceeds uint256 max. Should use mulDiv or restructure the math.
-        uint256 elapsed = block.timestamp - start;
-        return (totalAllocation * elapsed) / vestingDuration;
+
+        uint256 quotient = totalAllocation / vestingDuration;
+        uint256 remainder = totalAllocation % vestingDuration;
+        return quotient * elapsed + (remainder * elapsed) / vestingDuration;
     }
 
     /// @notice Revoke unvested tokens and return them to the owner.
@@ -85,13 +97,11 @@ contract VestingWallet {
         require(!revoked, "Vesting: already revoked");
 
         revoked = true;
-        uint256 vested = vestedAmount();
-        // BUG: During the cliff period, vestedAmount() returns 0, so refund is
-        // calculated as totalAllocation - 0 = totalAllocation. But tokens may have
-        // already been partially transferred to the contract. The refund should use
-        // the actual token balance, not totalAllocation - vested, as the contract
-        // might not hold the full allocation yet, causing a revert or incorrect refund.
-        uint256 refund = totalAllocation - vested;
+        uint256 refund = totalAllocation - released;
+        uint256 balance = token.balanceOf(address(this));
+        if (refund > balance) {
+            refund = balance;
+        }
 
         token.safeTransfer(owner, refund);
         emit VestingRevoked(address(token), refund);
@@ -99,11 +109,18 @@ contract VestingWallet {
 
     /// @notice Get the releasable (vested but not yet released) token amount.
     function releasable() external view returns (uint256) {
-        return vestedAmount() - released;
+        if (revoked) {
+            return 0;
+        }
+        uint256 vested = vestedAmount();
+        return vested > released ? vested - released : 0;
     }
 
     /// @notice Check if the cliff period has passed.
     function cliffReached() external view returns (bool) {
-        return block.timestamp >= start + cliffDuration;
+        if (block.timestamp < start) {
+            return false;
+        }
+        return block.timestamp - start >= cliffDuration;
     }
 }

--- a/test/VestingWalletSafety.test.js
+++ b/test/VestingWalletSafety.test.js
@@ -1,0 +1,147 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+function loadArtifact(name) {
+  const base = path.join(__dirname, "..", ".codex-vesting-solc");
+  const abiPath = path.join(base, `${name}.abi`);
+  const binPath = path.join(base, `${name}.bin`);
+  if (!fs.existsSync(abiPath) || !fs.existsSync(binPath)) {
+    throw new Error("Missing solcjs artifacts. Run the solcjs verification command before this test.");
+  }
+  return {
+    abi: JSON.parse(fs.readFileSync(abiPath, "utf8")),
+    bytecode: `0x${fs.readFileSync(binPath, "utf8").trim()}`,
+  };
+}
+
+describe("VestingWallet safety", function () {
+  const VESTING_ARTIFACT = "contracts_token_VestingWallet_sol_VestingWallet";
+  const TOKEN_ARTIFACT = "test_mocks_MockERC20_sol_MockERC20";
+  const ONE_BILLION_TOKENS = ethers.parseUnits("1000000000", 18);
+  const DAY = 24 * 60 * 60;
+
+  async function deployToken(owner) {
+    const artifact = loadArtifact(TOKEN_ARTIFACT);
+    const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, owner);
+    const token = await factory.deploy();
+    await token.waitForDeployment();
+    return token;
+  }
+
+  async function deployVesting({ beneficiary, token, start, cliff, duration, allocation, revocable = true, owner }) {
+    const artifact = loadArtifact(VESTING_ARTIFACT);
+    const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, owner);
+    const vesting = await factory.deploy(
+      beneficiary,
+      await token.getAddress(),
+      start,
+      cliff,
+      duration,
+      allocation,
+      revocable
+    );
+    await vesting.waitForDeployment();
+    return vesting;
+  }
+
+  async function now() {
+    const block = await ethers.provider.getBlock("latest");
+    return block.timestamp;
+  }
+
+  it("rejects zero-address beneficiaries", async function () {
+    const [owner] = await ethers.getSigners();
+    const token = await deployToken(owner);
+    const timestamp = await now();
+
+    await expect(
+      deployVesting({
+        beneficiary: ethers.ZeroAddress,
+        token,
+        start: timestamp,
+        cliff: DAY,
+        duration: 365 * DAY,
+        allocation: ONE_BILLION_TOKENS,
+        owner,
+      })
+    ).to.be.revertedWith("Vesting: zero beneficiary");
+  });
+
+  it("vests a 1B token allocation without multiplication overflow", async function () {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const token = await deployToken(owner);
+    const start = (await now()) + 10;
+    const duration = 365 * DAY;
+    const vesting = await deployVesting({
+      beneficiary: beneficiary.address,
+      token,
+      start,
+      cliff: 0,
+      duration,
+      allocation: ONE_BILLION_TOKENS,
+      owner,
+    });
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [start + Math.floor(duration / 2)]);
+    await ethers.provider.send("evm_mine", []);
+
+    const vested = await vesting.vestedAmount();
+    expect(vested).to.equal(ONE_BILLION_TOKENS / 2n);
+  });
+
+  it("refunds unreleased allocation during cliff revoke", async function () {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const token = await deployToken(owner);
+    const start = (await now()) + 10;
+    const allocation = ethers.parseUnits("1000", 18);
+    const vesting = await deployVesting({
+      beneficiary: beneficiary.address,
+      token,
+      start,
+      cliff: 30 * DAY,
+      duration: 365 * DAY,
+      allocation,
+      owner,
+    });
+    await token.mint(await vesting.getAddress(), allocation);
+
+    const ownerBefore = await token.balanceOf(owner.address);
+    await vesting.revoke();
+
+    expect(await token.balanceOf(owner.address)).to.equal(ownerBefore + allocation);
+    expect(await token.balanceOf(await vesting.getAddress())).to.equal(0n);
+    expect(await vesting.revoked()).to.equal(true);
+    expect(await vesting.releasable()).to.equal(0n);
+  });
+
+  it("refunds total allocation minus released tokens on revoke", async function () {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const token = await deployToken(owner);
+    const start = (await now()) + 10;
+    const duration = 1000;
+    const allocation = ethers.parseUnits("1000", 18);
+    const vesting = await deployVesting({
+      beneficiary: beneficiary.address,
+      token,
+      start,
+      cliff: 0,
+      duration,
+      allocation,
+      owner,
+    });
+    await token.mint(await vesting.getAddress(), allocation);
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [start + Math.floor(duration / 4)]);
+    await ethers.provider.send("evm_mine", []);
+    await vesting.connect(beneficiary).release();
+    const released = await vesting.released();
+
+    const ownerBefore = await token.balanceOf(owner.address);
+    await vesting.revoke();
+
+    expect(await token.balanceOf(owner.address)).to.equal(ownerBefore + allocation - released);
+    expect(await token.balanceOf(await vesting.getAddress())).to.equal(0n);
+  });
+});

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name = "Mock Token";
+    string public symbol = "MOCK";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "MockERC20: insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "MockERC20: insufficient balance");
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "MockERC20: insufficient allowance");
+        allowance[from][msg.sender] = allowed - amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}


### PR DESCRIPTION
/claim #12
💳 Payment: PayPal | buchanliang@gmail.com | N/A

Summary:
- Adds zero-address beneficiary and token validation.
- Reworks `vestedAmount()` into quotient + remainder math to avoid `totalAllocation * elapsed` overflow.
- Fixes revoke accounting to refund `totalAllocation - released`, capped by actual contract token balance.
- Blocks release after revoke and returns zero releasable amount once revoked.
- Adds focused tests for 1B token allocation vesting, cliff revoke refund, post-release revoke accounting, and zero beneficiary rejection.

Verification:
- `npx solcjs --bin --abi contracts\token\VestingWallet.sol test\mocks\MockERC20.sol -o .codex-vesting-solc --base-path . --include-path node_modules` — passed
- `npx hardhat test --no-compile test\VestingWalletSafety.test.js` — 4 passing
- `node --check test\VestingWalletSafety.test.js` — passed
- `git diff --check` — passed

Not run to completion:
- `npm test`: blocked by existing repository Hardhat HH606 compiler mismatch for OpenZeppelin ^0.8.24 dependencies.

Private platform/session instructions are intentionally not embedded in source.
