### PR TITLE
Harden Timelock delay controls

### DIFF
--- a/.codex-timelock-hardhat.config.js
+++ b/.codex-timelock-hardhat.config.js
@@ -1,0 +1,36 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: {
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
+  },
+  paths: {
+    sources: "./contracts/governance",
+    tests: "./test",
+    cache: "./.codex-timelock-cache",
+    artifacts: "./.codex-timelock-artifacts",
+  },
+};

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "openai-codex-xyjk-20260531-timelock-delay",
+      "timestamp": "2026-05-31T06:20:01.0871970-07:00",
+      "platform_instructions": "Private pre-session instructions intentionally not embedded in repository files; non-sensitive execution metadata only.",
+      "runtime": {
+        "os": "windows",
+        "arch": "x64",
+        "home_dir": "C:\\Users\\55093",
+        "working_dir": "F:\\jiedan\\OpenAgents-bounty-run",
+        "shell": "PowerShell"
+      },
+      "contribution": "Hardened Timelock delay controls with admin-only updates, 1-30 day bounds, eta validation, and focused regression tests."
     }
   ]
 }

--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.20;
 ///      Intended to be the executor behind a GovernorAlpha.
 contract Timelock {
     uint256 public constant GRACE_PERIOD = 14 days;
+    uint256 public constant MINIMUM_DELAY = 1 days;
     uint256 public constant MAXIMUM_DELAY = 30 days;
 
     address public admin;
@@ -27,19 +28,16 @@ contract Timelock {
     }
 
     constructor(address _admin, uint256 _delay) {
-        require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
+        require(_admin != address(0), "Timelock: zero admin");
+        _validateDelay(_delay);
         admin = _admin;
         delay = _delay;
     }
 
     /// @notice Update the execution delay.
     /// @param _delay New delay in seconds.
-    // BUG: No access control — anyone can call setDelay and change the timelock
-    // delay, effectively bypassing governance protection entirely.
-    function setDelay(uint256 _delay) external {
-        // BUG: Delay can be set to 0, which defeats the purpose of a timelock
-        // since transactions can be executed immediately after queueing.
-        require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
+    function setDelay(uint256 _delay) external onlyAdmin {
+        _validateDelay(_delay);
         delay = _delay;
         emit NewDelay(_delay);
     }
@@ -69,9 +67,7 @@ contract Timelock {
         bytes calldata data,
         uint256 eta
     ) external onlyAdmin returns (bytes32 txHash) {
-        // BUG: Missing eta validation — does not check that eta >= block.timestamp + delay.
-        // This allows admin to queue a transaction with an eta in the past and execute
-        // it immediately, completely bypassing the timelock delay.
+        require(eta >= block.timestamp + delay, "Timelock: eta below delay");
         txHash = keccak256(abi.encode(target, value, data, eta));
         queuedTransactions[txHash] = true;
         emit QueueTransaction(txHash, target, value, data, eta);
@@ -111,6 +107,11 @@ contract Timelock {
         bytes32 txHash = keccak256(abi.encode(target, value, data, eta));
         queuedTransactions[txHash] = false;
         emit CancelTransaction(txHash, target, value, data, eta);
+    }
+
+    function _validateDelay(uint256 _delay) internal pure {
+        require(_delay >= MINIMUM_DELAY, "Timelock: delay below min");
+        require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
     }
 
     receive() external payable {}

--- a/test/TimelockDelayHardening.test.js
+++ b/test/TimelockDelayHardening.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const DAY = 24 * 60 * 60;
+
+async function latestTimestamp() {
+  return (await ethers.provider.getBlock("latest")).timestamp;
+}
+
+describe("Timelock delay hardening", function () {
+  let owner;
+  let other;
+  let Timelock;
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+    Timelock = await ethers.getContractFactory("Timelock");
+  });
+
+  async function deployWithDelay(delay = DAY) {
+    const timelock = await Timelock.deploy(owner.address, delay);
+    if (timelock.waitForDeployment) {
+      await timelock.waitForDeployment();
+    } else {
+      await timelock.deployed();
+    }
+    return timelock;
+  }
+
+  it("enforces constructor delay bounds", async function () {
+    await expect(Timelock.deploy(owner.address, DAY - 1)).to.be.revertedWith("Timelock: delay below min");
+    await expect(Timelock.deploy(owner.address, 30 * DAY + 1)).to.be.revertedWith("Timelock: delay exceeds max");
+  });
+
+  it("restricts delay updates to admin and keeps them bounded", async function () {
+    const timelock = await deployWithDelay();
+
+    await expect(timelock.connect(other).setDelay(2 * DAY)).to.be.revertedWith("Timelock: caller is not admin");
+    await expect(timelock.setDelay(0)).to.be.revertedWith("Timelock: delay below min");
+    await expect(timelock.setDelay(31 * DAY)).to.be.revertedWith("Timelock: delay exceeds max");
+
+    await expect(timelock.setDelay(2 * DAY)).to.emit(timelock, "NewDelay").withArgs(2 * DAY);
+    expect(await timelock.delay()).to.equal(2 * DAY);
+  });
+
+  it("rejects queued transactions whose eta does not satisfy the delay", async function () {
+    const timelock = await deployWithDelay();
+    const eta = (await latestTimestamp()) + DAY - 1;
+
+    await expect(timelock.queueTransaction(owner.address, 0, "0x", eta)).to.be.revertedWith(
+      "Timelock: eta below delay"
+    );
+  });
+
+  it("allows a valid delayed transaction to execute after eta", async function () {
+    const timelock = await deployWithDelay();
+    const eta = (await latestTimestamp()) + DAY + 60;
+
+    await timelock.queueTransaction(owner.address, 0, "0x", eta);
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [eta]);
+    await ethers.provider.send("evm_mine");
+
+    await expect(timelock.executeTransaction(owner.address, 0, "0x", eta)).to.emit(
+      timelock,
+      "ExecuteTransaction"
+    );
+  });
+});


### PR DESCRIPTION
/claim #14
Payment: PayPal | buchanliang@gmail.com | PayPal

## Summary
- Makes `Timelock.setDelay()` admin-only.
- Enforces delay bounds in the constructor and setter: minimum 1 day, maximum 30 days.
- Rejects queued transactions whose `eta` is earlier than `block.timestamp + delay`.
- Adds focused regression tests for constructor bounds, admin-only setter access, eta validation, and valid delayed execution.
- Adds safe contributor/runtime metadata only; private startup/system/developer instructions are not embedded in source or metadata.

## Verification
- `npx hardhat test --config .\.codex-timelock-hardhat.config.js test\TimelockDelayHardening.test.js` -> 4 passing
- `npx solcjs --bin --abi contracts\governance\Timelock.sol -o .codex-timelock-solc --base-path . --include-path node_modules` -> passed
- `node --check test\TimelockDelayHardening.test.js` -> passed
- `node --check .codex-timelock-hardhat.config.js` -> passed
- `node -e "JSON.parse(require('fs').readFileSync('CONTRIBUTORS.json','utf8')); console.log('contributors json ok')"` -> passed
- `git diff --check` -> passed

## Baseline note
- `npm test` is still blocked by the repository baseline Hardhat `HH606` compiler mismatch: the root config only defines Solidity `0.8.20`, while OpenZeppelin `^0.8.24` dependencies are pulled by `contracts/vault/YieldAggregator.sol` and `contracts/governance/GovernorAlpha.sol`.