### PR TITLE
[KHHH2312] Fix agent endpoint URL validation

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,5 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+SQLAlchemy>=2.0.0
+PyJWT>=2.10.0

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,43 +1,319 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
+import asyncio
+from datetime import datetime
+import ipaddress
+import socket
+import ssl
+from typing import Any, Dict, List, NamedTuple, Optional, Union
+from urllib.parse import SplitResult, urljoin, urlsplit
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
+ENDPOINT_REACHABILITY_TIMEOUT_SECONDS = 5.0
+MAX_ENDPOINT_REDIRECTS = 3
+_ALLOWED_ENDPOINT_SCHEMES = {"http", "https"}
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+class EndpointTarget(NamedTuple):
+    url: str
+    parsed: SplitResult
+    port: int
+    addresses: List[IPAddress]
+
+
+class EndpointProbeResponse(NamedTuple):
+    status_code: int
+    headers: Dict[str, str]
+
+
+def _validation_error(detail: str) -> HTTPException:
+    return HTTPException(status_code=422, detail=detail)
+
+
+def _parse_endpoint(endpoint: str):
+    if not isinstance(endpoint, str) or not endpoint.strip():
+        raise _validation_error("Agent endpoint is required")
+    if any(ord(char) < 32 or ord(char) == 127 for char in endpoint):
+        raise _validation_error("Agent endpoint contains invalid control characters")
+
+    normalized = endpoint.strip()
+    try:
+        parsed = urlsplit(normalized)
+        port = parsed.port or (80 if parsed.scheme.lower() == "http" else 443)
+    except ValueError as exc:
+        raise _validation_error("Agent endpoint must be a valid http/https URL") from exc
+
+    if parsed.scheme.lower() not in _ALLOWED_ENDPOINT_SCHEMES or not parsed.hostname:
+        raise _validation_error("Agent endpoint must be a valid http/https URL")
+    if parsed.username or parsed.password:
+        raise _validation_error("Agent endpoint must not include URL credentials")
+
+    return normalized, parsed, port
+
+
+def _is_internal_address(address: IPAddress) -> bool:
+    return not address.is_global
+
+
+def _resolve_hostname_addresses(hostname: str, port: int) -> List[IPAddress]:
+    try:
+        return [ipaddress.ip_address(hostname)]
+    except ValueError:
+        pass
+
+    try:
+        addrinfo = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise _validation_error("Agent endpoint hostname could not be resolved") from exc
+
+    addresses: List[IPAddress] = []
+    for family, _, _, _, sockaddr in addrinfo:
+        if family not in {socket.AF_INET, socket.AF_INET6}:
+            continue
+        addresses.append(ipaddress.ip_address(sockaddr[0]))
+
+    if not addresses:
+        raise _validation_error("Agent endpoint hostname could not be resolved")
+
+    return addresses
+
+
+def _validate_endpoint_target(endpoint: str) -> EndpointTarget:
+    normalized, parsed, port = _parse_endpoint(endpoint)
+    addresses = _resolve_hostname_addresses(parsed.hostname, port)
+
+    if any(_is_internal_address(address) for address in addresses):
+        raise _validation_error("Agent endpoint must not resolve to a private/internal IP")
+
+    return EndpointTarget(
+        url=normalized,
+        parsed=parsed,
+        port=port,
+        addresses=addresses,
+    )
+
+
+def _endpoint_host_header(target: EndpointTarget) -> str:
+    hostname = target.parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    if target.parsed.port is not None:
+        return f"{hostname}:{target.parsed.port}"
+    return hostname
+
+
+def _endpoint_request_target(target: EndpointTarget) -> str:
+    path = target.parsed.path or "/"
+    if target.parsed.query:
+        return f"{path}?{target.parsed.query}"
+    return path
+
+
+def _parse_head_response(raw_headers: bytes) -> EndpointProbeResponse:
+    if not raw_headers:
+        raise _validation_error("Agent endpoint is unreachable")
+
+    header_text = raw_headers.decode("iso-8859-1", errors="replace")
+    lines = header_text.split("\r\n")
+    status_parts = lines[0].split(" ", 2)
+    if len(status_parts) < 2 or not status_parts[1].isdigit():
+        raise _validation_error("Agent endpoint returned an invalid HTTP response")
+
+    headers: Dict[str, str] = {}
+    for line in lines[1:]:
+        if not line or ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers[name.lower()] = value.strip()
+
+    return EndpointProbeResponse(status_code=int(status_parts[1]), headers=headers)
+
+
+async def _read_head_response(reader: asyncio.StreamReader) -> EndpointProbeResponse:
+    try:
+        raw_headers = await asyncio.wait_for(
+            reader.readuntil(b"\r\n\r\n"),
+            timeout=ENDPOINT_REACHABILITY_TIMEOUT_SECONDS,
+        )
+    except asyncio.IncompleteReadError as exc:
+        raw_headers = exc.partial
+    except asyncio.LimitOverrunError as exc:
+        raise _validation_error("Agent endpoint response headers are too large") from exc
+    except asyncio.TimeoutError as exc:
+        raise _validation_error("Agent endpoint reachability check timed out") from exc
+
+    return _parse_head_response(raw_headers)
+
+
+async def _close_writer(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=1.0)
+    except (asyncio.TimeoutError, OSError, ssl.SSLError):
+        pass
+
+
+async def _request_endpoint_head(target: EndpointTarget) -> EndpointProbeResponse:
+    last_timeout = False
+    use_tls = target.parsed.scheme.lower() == "https"
+    tls_context = ssl.create_default_context() if use_tls else None
+
+    for address in target.addresses:
+        writer: Optional[asyncio.StreamWriter] = None
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(
+                    host=address.compressed,
+                    port=target.port,
+                    ssl=tls_context,
+                    server_hostname=target.parsed.hostname if use_tls else None,
+                ),
+                timeout=ENDPOINT_REACHABILITY_TIMEOUT_SECONDS,
+            )
+            request = (
+                f"HEAD {_endpoint_request_target(target)} HTTP/1.1\r\n"
+                f"Host: {_endpoint_host_header(target)}\r\n"
+                "User-Agent: OpenAgents endpoint validator\r\n"
+                "Accept: */*\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+            ).encode("ascii")
+            writer.write(request)
+            await asyncio.wait_for(
+                writer.drain(),
+                timeout=ENDPOINT_REACHABILITY_TIMEOUT_SECONDS,
+            )
+            return await _read_head_response(reader)
+        except asyncio.TimeoutError:
+            last_timeout = True
+        except (OSError, ssl.SSLError, ValueError):
+            last_timeout = False
+        finally:
+            if writer is not None:
+                await _close_writer(writer)
+
+    if last_timeout:
+        raise _validation_error("Agent endpoint reachability check timed out")
+    raise _validation_error("Agent endpoint is unreachable")
+
+
+async def validate_agent_endpoint(endpoint: str) -> str:
+    """Validate endpoint format, SSRF safety, and reachability."""
+
+    original_target = _validate_endpoint_target(endpoint)
+    current_target = original_target
+
+    for _ in range(MAX_ENDPOINT_REDIRECTS + 1):
+        response = await _request_endpoint_head(current_target)
+
+        if 300 <= response.status_code < 400:
+            redirect_location = response.headers.get("location")
+            if not redirect_location:
+                raise _validation_error("Agent endpoint redirect is missing a Location header")
+            current_target = _validate_endpoint_target(
+                urljoin(current_target.url, redirect_location)
+            )
+            continue
+
+        if response.status_code == 405:
+            return original_target.url
+
+        if response.status_code >= 400:
+            raise _validation_error("Agent endpoint is unreachable")
+
+        return original_target.url
+
+    raise _validation_error("Agent endpoint has too many redirects")
+
+
+def _endpoint_from_config(config: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not config or "endpoint" not in config:
+        return None
+
+    endpoint = config["endpoint"]
+    if not isinstance(endpoint, str):
+        raise _validation_error("Agent endpoint must be a string")
+    return endpoint
+
+
+def _extract_agent_endpoint(
+    endpoint: Optional[str],
+    config: Optional[Dict[str, Any]],
+    *,
+    required: bool,
+) -> Optional[str]:
+    config_endpoint = _endpoint_from_config(config)
+    if endpoint is not None and config_endpoint is not None and endpoint != config_endpoint:
+        raise _validation_error("Agent endpoint field must match config.endpoint")
+
+    selected_endpoint = endpoint if endpoint is not None else config_endpoint
+    if required and selected_endpoint is None:
+        raise _validation_error("Agent endpoint is required")
+
+    return selected_endpoint
+
+
+def _merge_agent_config(
+    existing_config: Optional[Dict[str, Any]],
+    provided_config: Optional[Dict[str, Any]],
+    validated_endpoint: Optional[str],
+) -> Dict[str, Any]:
+    merged_config = dict(existing_config or {})
+    if provided_config is not None:
+        merged_config.update(provided_config)
+    if validated_endpoint is not None:
+        merged_config["endpoint"] = validated_endpoint
+    return merged_config
+
 
 class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    endpoint: Optional[str] = None
     description: Optional[str] = None
     model_type: str = "gpt-4"
-    config: Optional[dict] = None
+    config: Optional[Dict[str, Any]] = None
 
 
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
-    config: Optional[dict] = None
+    endpoint: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
 
 
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    endpoint = _extract_agent_endpoint(agent.endpoint, agent.config, required=True)
+    if endpoint is None:
+        raise _validation_error("Agent endpoint is required")
+    validated_endpoint = await validate_agent_endpoint(endpoint)
+    config = _merge_agent_config(None, agent.config, validated_endpoint)
+
     new_agent = Agent(
         name=agent.name,
         description=agent.description,
         model_type=agent.model_type,
-        config=agent.config or {},
+        config=config,
         owner_id=user["id"],
         created_at=datetime.utcnow(),
     )
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {
+        "id": new_agent.id,
+        "name": new_agent.name,
+        "owner": user["address"],
+        "endpoint": validated_endpoint,
+    }
 
 
 @router.get("/")
@@ -71,7 +347,20 @@ async def update_agent(
         raise HTTPException(status_code=404, detail="Agent not found")
     if agent.owner_id != user["id"]:
         raise HTTPException(status_code=403, detail="Not the owner")
-    for field, value in update.dict(exclude_unset=True).items():
+
+    updates = update.model_dump(exclude_unset=True)
+    config = updates.pop("config", None)
+    endpoint = _extract_agent_endpoint(updates.pop("endpoint", None), config, required=False)
+
+    validated_endpoint = None
+
+    if endpoint is not None:
+        validated_endpoint = await validate_agent_endpoint(endpoint)
+
+    if endpoint is not None or config is not None:
+        updates["config"] = _merge_agent_config(agent.config, config, validated_endpoint)
+
+    for field, value in updates.items():
         setattr(agent, field, value)
     db.commit()
     return agent

--- a/api/tests/test_agent_endpoint_validation.py
+++ b/api/tests/test_agent_endpoint_validation.py
@@ -1,0 +1,244 @@
+import asyncio
+import ipaddress
+import os
+from typing import Dict, List
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+from api.routes import agents
+
+
+def _public_resolver(hostname: str, port: int):
+    return [ipaddress.ip_address("93.184.216.34")]
+
+
+def _public_then_literal_resolver(hostname: str, port: int):
+    try:
+        return [ipaddress.ip_address(hostname)]
+    except ValueError:
+        return _public_resolver(hostname, port)
+
+
+def _set_probe(monkeypatch, responses):
+    calls = []
+    response_iter = iter(responses)
+
+    async def probe(target):
+        calls.append(target)
+        response = next(response_iter)
+        if isinstance(response, Exception):
+            raise response
+        return agents.EndpointProbeResponse(
+            status_code=response[0],
+            headers=response[1] if len(response) > 1 else {},
+        )
+
+    monkeypatch.setattr(agents, "_request_endpoint_head", probe)
+    return calls
+
+
+def test_validate_agent_endpoint_accepts_reachable_public_url(monkeypatch):
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", _public_resolver)
+    calls = _set_probe(monkeypatch, [(200, {})])
+
+    validated = asyncio.run(agents.validate_agent_endpoint(" https://example.com/agent "))
+
+    assert validated == "https://example.com/agent"
+    assert calls[0].url == "https://example.com/agent"
+    assert calls[0].addresses == [ipaddress.ip_address("93.184.216.34")]
+
+
+def test_validate_agent_endpoint_rejects_invalid_format():
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("not-a-url"))
+
+    assert exc_info.value.status_code == 422
+    assert "valid http/https URL" in exc_info.value.detail
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://10.1.2.3/agent",
+        "http://192.168.1.5/agent",
+        "http://127.0.0.1/agent",
+        "http://[::1]/agent",
+    ],
+)
+def test_validate_agent_endpoint_rejects_private_internal_ips(url):
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint(url))
+
+    assert exc_info.value.status_code == 422
+    assert "private/internal IP" in exc_info.value.detail
+
+
+def test_validate_agent_endpoint_rejects_timeout(monkeypatch):
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", _public_resolver)
+    calls = _set_probe(
+        monkeypatch,
+        [agents._validation_error("Agent endpoint reachability check timed out")],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert exc_info.value.status_code == 422
+    assert "timed out" in exc_info.value.detail
+    assert calls[0].url == "https://example.com/agent"
+
+
+def test_validate_agent_endpoint_accepts_head_method_not_allowed(monkeypatch):
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", _public_resolver)
+    calls = _set_probe(monkeypatch, [(405, {})])
+
+    validated = asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert validated == "https://example.com/agent"
+    assert calls[0].url == "https://example.com/agent"
+
+
+def test_validate_agent_endpoint_blocks_private_redirect_before_following(monkeypatch):
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", _public_then_literal_resolver)
+    calls = _set_probe(monkeypatch, [(302, {"location": "http://127.0.0.1/agent"})])
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert exc_info.value.status_code == 422
+    assert "private/internal IP" in exc_info.value.detail
+    assert len(calls) == 1
+
+
+def test_validate_agent_endpoint_rejects_redirect_without_location(monkeypatch):
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", _public_resolver)
+    _set_probe(monkeypatch, [(302, {})])
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert exc_info.value.status_code == 422
+    assert "Location" in exc_info.value.detail
+
+
+def test_validate_agent_endpoint_rejects_redirect_loop(monkeypatch):
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", _public_resolver)
+    calls = _set_probe(
+        monkeypatch,
+        [
+            (302, {"location": "https://example.com/agent"}),
+            (302, {"location": "https://example.com/agent"}),
+            (302, {"location": "https://example.com/agent"}),
+            (302, {"location": "https://example.com/agent"}),
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(agents.validate_agent_endpoint("https://example.com/agent"))
+
+    assert exc_info.value.status_code == 422
+    assert "too many redirects" in exc_info.value.detail
+    assert len(calls) == agents.MAX_ENDPOINT_REDIRECTS + 1
+
+
+def test_validate_agent_endpoint_uses_http_default_port(monkeypatch):
+    ports = []
+
+    def recording_resolver(hostname: str, port: int):
+        ports.append(port)
+        return _public_resolver(hostname, port)
+
+    monkeypatch.setattr(agents, "_resolve_hostname_addresses", recording_resolver)
+    _set_probe(monkeypatch, [(200, {})])
+
+    asyncio.run(agents.validate_agent_endpoint("http://example.com/agent"))
+
+    assert ports == [80]
+
+
+class _FakeReader:
+    async def readuntil(self, separator: bytes):
+        return b"HTTP/1.1 204 No Content\r\nX-Test: yes\r\n\r\n"
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.data = b""
+        self.closed = False
+        self.waited = False
+
+    def write(self, data: bytes):
+        self.data += data
+
+    async def drain(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        self.waited = True
+
+
+def test_request_endpoint_head_pins_request_to_validated_ip(monkeypatch):
+    open_args: Dict[str, object] = {}
+    writer = _FakeWriter()
+
+    async def fake_open_connection(**kwargs):
+        open_args.update(kwargs)
+        return _FakeReader(), writer
+
+    monkeypatch.setattr(agents.asyncio, "open_connection", fake_open_connection)
+    target = agents.EndpointTarget(
+        url="https://example.com/agent?case=1",
+        parsed=agents.urlsplit("https://example.com/agent?case=1"),
+        port=443,
+        addresses=[ipaddress.ip_address("93.184.216.34")],
+    )
+
+    response = asyncio.run(agents._request_endpoint_head(target))
+
+    assert response.status_code == 204
+    assert response.headers["x-test"] == "yes"
+    assert open_args["host"] == "93.184.216.34"
+    assert open_args["port"] == 443
+    assert open_args["server_hostname"] == "example.com"
+    assert b"HEAD /agent?case=1 HTTP/1.1\r\n" in writer.data
+    assert b"Host: example.com\r\n" in writer.data
+    assert writer.closed is True
+    assert writer.waited is True
+
+
+def test_extract_agent_endpoint_accepts_existing_config_shape():
+    endpoint = agents._extract_agent_endpoint(
+        None,
+        {"endpoint": "https://example.com/agent"},
+        required=True,
+    )
+
+    assert endpoint == "https://example.com/agent"
+
+
+def test_extract_agent_endpoint_rejects_conflicting_payload_shapes():
+    with pytest.raises(HTTPException) as exc_info:
+        agents._extract_agent_endpoint(
+            "https://example.com/one",
+            {"endpoint": "https://example.com/two"},
+            required=True,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "must match" in exc_info.value.detail
+
+
+def test_merge_agent_config_preserves_endpoint_when_update_omits_it():
+    merged = agents._merge_agent_config(
+        {"endpoint": "https://example.com/agent", "model": "old"},
+        {"model": "new"},
+        None,
+    )
+
+    assert merged == {"endpoint": "https://example.com/agent", "model": "new"}


### PR DESCRIPTION
## Summary
- Validate agent endpoint URLs during agent creation and endpoint updates.
- Support both the existing `config.endpoint` payload shape and an optional top-level `endpoint` field.
- Block non-public resolved addresses for SSRF protection, including private, loopback, link-local, multicast, reserved, unspecified, and IPv6 internal ranges.
- Pin the reachability probe to a prevalidated resolved IP address while preserving the original `Host` header and HTTPS SNI, avoiding a second DNS lookup during the request.
- Verify reachability with a bounded HEAD request, accept HEAD `405 Method Not Allowed` as reachable, and manually validate redirect targets before following them.
- Preserve existing validated endpoints during config-only updates unless a new endpoint is explicitly supplied.
- Add focused offline pytest coverage for valid URLs, invalid format, private/internal IPs, timeout handling, redirect SSRF protection, redirect edge cases, default port handling, pinned-IP probing, and payload-shape compatibility.
- Add missing API runtime dependencies already imported by the existing API code.

## Bounty / Issue
- Bounty: https://github.com/ClankerNation/OpenAgents/issues/173
- Issue: https://github.com/ClankerNation/OpenAgents/issues/173

/claim #173

## Root Cause
- Agent registration accepted endpoint data without validating URL format, DNS resolution safety, reachability, or SSRF-sensitive targets.
- The endpoint could be supplied through free-form config data, so invalid or internal URLs could be stored and later contacted by the system.

## Solution
- Extract endpoint values from either `endpoint` or `config.endpoint`, rejecting conflicting payloads.
- Validate only `http` and `https` URLs, reject URL credentials and malformed/control-character inputs, and require public DNS/IP resolution.
- Use a direct asyncio TCP/TLS HEAD probe against the validated IP, with the original hostname retained for `Host` and SNI.
- Validate every redirect target before probing it and reject redirect loops.
- Store the validated endpoint back into `Agent.config["endpoint"]` and return it from create responses.

💳 Payment Details:
Method: USDC
Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
Network: Base

💳 Payment: USDC | 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2 | Base

## Tests
- `JWT_SECRET=test-secret python -m pytest api/tests/test_agent_endpoint_validation.py -q` — passed, 16 tests.
- `JWT_SECRET=test-secret python -m pytest api -q` — passed, 16 tests.
- `JWT_SECRET=test-secret python -m py_compile api/routes/agents.py api/tests/test_agent_endpoint_validation.py` — passed.
- `git diff --check` — passed; Git emitted Windows autocrlf informational warnings only.

## Notes
- I did not include raw private session instructions or secrets in source comments.
- The implementation avoids real network calls in tests by mocking DNS resolution and stream connections.