### PR TITLE
[KHHH2312] Fix dynamic ABI parameter decoding

### DIFF
--- a/sdk/src/utils/encoding.test.mjs
+++ b/sdk/src/utils/encoding.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { AbiCoder } from "ethers";
+
+import {
+  decodeParameter,
+  decodeParameters,
+  decodeParams,
+  decodeUint256,
+} from "./encoding.ts";
+
+const coder = AbiCoder.defaultAbiCoder();
+
+test("decodeParameter preserves fixed-width backwards compatibility", () => {
+  const address = "0x000000000000000000000000000000000000dEaD";
+  const bytes32 = `0x${"ab".repeat(32)}`;
+
+  assert.equal(decodeParameter("uint256", coder.encode(["uint256"], [42n])), 42n);
+  assert.equal(decodeParameter("uint256", "0x2a"), 42n);
+  assert.equal(decodeUint256("0x2a"), 42n);
+  assert.equal(
+    decodeParameter("address", coder.encode(["address"], [address])),
+    address.toLowerCase(),
+  );
+  assert.equal(decodeParameter("bool", coder.encode(["bool"], [true])), true);
+  assert.equal(decodeParameter("bytes32", coder.encode(["bytes32"], [bytes32])), bytes32);
+});
+
+test("decodeParameter decodes dynamic string and bytes payloads", () => {
+  const bytesValue = "0x1234567890";
+
+  assert.equal(
+    decodeParameter("string", coder.encode(["string"], ["live demo flow"])),
+    "live demo flow",
+  );
+
+  const decodedBytes = decodeParameter("bytes", coder.encode(["bytes"], [bytesValue]));
+  assert.ok(Buffer.isBuffer(decodedBytes));
+  assert.equal(decodedBytes.toString("hex"), bytesValue.slice(2));
+});
+
+test("decodeParams decodes complex return data with string, array, and uint", () => {
+  const types = ["string", "uint256[]", "uint256"];
+  const encoded = coder.encode(types, ["agent-alpha", [3n, 5n, 8n], 13n]);
+  const expected = ["agent-alpha", [3n, 5n, 8n], 13n];
+
+  assert.deepEqual(decodeParams(types, encoded), expected);
+  assert.deepEqual(decodeParameters(types, encoded), expected);
+  assert.equal(decodeParameter("string", encoded, 0), "agent-alpha");
+  assert.deepEqual(decodeParameter("uint256[]", encoded, 32), [3n, 5n, 8n]);
+  assert.equal(decodeParameter("uint256", encoded, 64), 13n);
+});
+
+test("decodeParameter decodes nested tuple values recursively", () => {
+  const tupleType = "(string,uint256[],uint256,(bool,string))";
+  const value = ["validator", [7n, 11n], 19n, [true, "ready"]];
+  const encoded = coder.encode([tupleType], [value]);
+
+  assert.deepEqual(decodeParameter(tupleType, encoded), value);
+});
+
+test("decodeParameter supports tuple descriptors and dynamic tuple arrays", () => {
+  const descriptor = {
+    type: "tuple[]",
+    components: [
+      { type: "string", name: "name" },
+      { type: "uint256", name: "score" },
+      { type: "bytes", name: "payload" },
+    ],
+  };
+  const abiType = "(string,uint256,bytes)[]";
+  const encoded = coder.encode(
+    [abiType],
+    [
+      [
+        ["one", 1n, "0x0102"],
+        ["two", 2n, "0x030405"],
+      ],
+    ],
+  );
+
+  const decoded = decodeParameter(descriptor, encoded);
+  assert.deepEqual(decoded[0].slice(0, 2), ["one", 1n]);
+  assert.deepEqual(decoded[1].slice(0, 2), ["two", 2n]);
+  assert.ok(Buffer.isBuffer(decoded[0][2]));
+  assert.ok(Buffer.isBuffer(decoded[1][2]));
+  assert.equal(decoded[0][2].toString("hex"), "0102");
+  assert.equal(decoded[1][2].toString("hex"), "030405");
+});
+
+test("decodeParameter decodes dynamic arrays of dynamic elements", () => {
+  assert.deepEqual(
+    decodeParameter("string[]", coder.encode(["string[]"], [["red", "blue"]])),
+    ["red", "blue"],
+  );
+
+  const decodedBytesArray = decodeParameter(
+    "bytes[]",
+    coder.encode(["bytes[]"], [["0xaaaa", "0xbbccdd"]]),
+  );
+  assert.deepEqual(
+    decodedBytesArray.map((entry) => entry.toString("hex")),
+    ["aaaa", "bbccdd"],
+  );
+});
+
+test("decodeParameter rejects malformed dynamic data and unsafe dimensions", () => {
+  assert.throws(
+    () => decodeParameter("uint256", "0xnot-hex"),
+    /Invalid ABI hex data/,
+  );
+  assert.throws(
+    () => decodeParameter("string", "0x20"),
+    /out of bounds/,
+  );
+  assert.throws(
+    () => decodeParameter("uint256[100001]", coder.encode(["uint256"], [1n])),
+    /array length exceeds supported limit/,
+  );
+
+  const encoded = coder.encode(["string"], ["truncated"]);
+  assert.throws(
+    () => decodeParameter("string", `0x${encoded.slice(2, 96)}`),
+    /out of bounds/,
+  );
+});

--- a/sdk/src/utils/encoding.ts
+++ b/sdk/src/utils/encoding.ts
@@ -1,13 +1,53 @@
 /**
  * ABI encoding/decoding utilities for EVM-compatible contract interactions.
+ *
+ * @fix-author
+ * name: KHHH2312 Codex
+ * date: 2026-05-31
+ * @runtime documented in pull request metadata
  */
 
-export type AbiType = "uint256" | "address" | "bytes32" | "string" | "bool";
+export type AbiType = string;
+
+export interface AbiTypeDescriptor {
+  type: string;
+  components?: AbiTypeLike[];
+  name?: string;
+}
+
+export type AbiTypeLike = AbiType | AbiTypeDescriptor;
+export type DecodedAbiValue =
+  | bigint
+  | string
+  | boolean
+  | Buffer
+  | DecodedAbiValue[];
 
 export interface AbiParam {
-  type: AbiType;
-  value: string | number | bigint | boolean;
+  type: AbiTypeLike;
+  value: string | number | bigint | boolean | Buffer | Uint8Array | unknown[];
 }
+
+interface RuntimePrimitive {
+  kind: "primitive";
+  type: string;
+}
+
+interface RuntimeTuple {
+  kind: "tuple";
+  components: RuntimeAbiType[];
+}
+
+interface RuntimeArray {
+  kind: "array";
+  base: RuntimeAbiType;
+  length: number | null;
+}
+
+type RuntimeAbiType = RuntimePrimitive | RuntimeTuple | RuntimeArray;
+
+const MAX_ABI_ARRAY_LENGTH = 100_000;
+const MAX_SAFE_HEX_INDEX = Math.floor(Number.MAX_SAFE_INTEGER / 2);
 
 export function encodeUint256(value: bigint | number): string {
   const n = BigInt(value);
@@ -62,9 +102,8 @@ export function decodeHex(hex: string): bigint {
 }
 
 export function decodeUint256(slot: string): bigint {
-  // BUG: Doesn't handle short values — if slot is less than 64 chars,
-  // no left-padding is applied before parsing, giving wrong results
-  return BigInt("0x" + slot);
+  const cleaned = cleanHex(slot).padStart(64, "0");
+  return BigInt("0x" + cleaned);
 }
 
 export function decodeAddress(slot: string): string {
@@ -73,8 +112,41 @@ export function decodeAddress(slot: string): string {
 }
 
 export function decodeBool(slot: string): boolean {
-  return BigInt("0x" + slot) !== 0n;
+  return decodeUint256(slot) !== 0n;
 }
+
+export function decodeParameter(
+  type: AbiTypeLike,
+  data: string,
+  byteOffset = 0,
+): DecodedAbiValue {
+  const runtimeType = parseAbiType(type);
+  const hex = normalizeAbiData(data);
+  return decodeAt(runtimeType, hex, byteOffset, 0);
+}
+
+export function decodeParams(
+  types: AbiTypeLike[],
+  data: string,
+): DecodedAbiValue[] {
+  const hex = normalizeAbiData(data);
+  const runtimeTypes = types.map(parseAbiType);
+  const values: DecodedAbiValue[] = [];
+  let headOffset = 0;
+
+  for (const runtimeType of runtimeTypes) {
+    values.push(decodeAt(runtimeType, hex, headOffset, 0));
+    headOffset = checkedAdd(
+      headOffset,
+      isDynamic(runtimeType) ? 32 : staticSizeBytes(runtimeType),
+      "ABI parameter head offset",
+    );
+  }
+
+  return values;
+}
+
+export const decodeParameters = decodeParams;
 
 export function functionSelector(signature: string): string {
   const { createHash } = require("crypto");
@@ -85,4 +157,443 @@ export function functionSelector(signature: string): string {
 export function packCalldata(selector: string, params: AbiParam[]): string {
   const encodedParams = encodeParams(params).slice(2);
   return selector + encodedParams;
+}
+
+function cleanHex(hex: string): string {
+  const cleaned = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (cleaned.length > 0 && !/^[0-9a-fA-F]+$/.test(cleaned)) {
+    throw new Error("Invalid ABI hex data");
+  }
+  return cleaned.length % 2 === 0 ? cleaned.toLowerCase() : `0${cleaned.toLowerCase()}`;
+}
+
+function normalizeAbiData(data: string): string {
+  const hex = cleanHex(data);
+  if (hex.length === 0) {
+    throw new Error("ABI data is empty");
+  }
+  return hex.length < 64 ? hex.padStart(64, "0") : hex;
+}
+
+function readWord(hex: string, byteOffset: number): string {
+  if (!Number.isInteger(byteOffset) || byteOffset < 0) {
+    throw new Error("ABI byte offset must be a non-negative integer");
+  }
+  if (byteOffset > MAX_SAFE_HEX_INDEX) {
+    throw new Error("ABI byte offset exceeds safe integer range");
+  }
+
+  if (byteOffset === 0 && hex.length < 64) {
+    return hex.padStart(64, "0");
+  }
+
+  const start = byteOffset * 2;
+  const end = checkedAdd(start, 64, "ABI word end");
+  if (end > hex.length) {
+    throw new Error("ABI word offset is out of bounds");
+  }
+  return hex.slice(start, end);
+}
+
+function readUintWord(hex: string, byteOffset: number): bigint {
+  return BigInt(`0x${readWord(hex, byteOffset)}`);
+}
+
+function readUintOffset(hex: string, byteOffset: number): number {
+  const value = readUintWord(hex, byteOffset);
+  const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+  if (value > maxSafe) {
+    throw new Error("ABI offset exceeds safe integer range");
+  }
+  return Number(value);
+}
+
+function readLength(hex: string, byteOffset: number): number {
+  const value = readUintWord(hex, byteOffset);
+  const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+  if (value > maxSafe) {
+    throw new Error("ABI length exceeds safe integer range");
+  }
+  return Number(value);
+}
+
+function sliceBytes(hex: string, byteOffset: number, byteLength: number): string {
+  if (byteOffset > MAX_SAFE_HEX_INDEX || byteLength > MAX_SAFE_HEX_INDEX) {
+    throw new Error("ABI byte slice exceeds safe integer range");
+  }
+  const start = byteOffset * 2;
+  const end = checkedAdd(
+    start,
+    checkedMultiply(byteLength, 2, "ABI byte slice length"),
+    "ABI byte slice end",
+  );
+  if (end > hex.length) {
+    throw new Error("ABI byte slice is out of bounds");
+  }
+  return hex.slice(start, end);
+}
+
+function parseAbiType(input: AbiTypeLike): RuntimeAbiType {
+  if (typeof input === "string") {
+    return parseAbiTypeString(input.trim());
+  }
+
+  if (input.type.startsWith("tuple")) {
+    if (!input.components || input.components.length === 0) {
+      throw new Error("Tuple ABI descriptor requires components");
+    }
+
+    const components = input.components.map(parseAbiType);
+    let runtimeType: RuntimeAbiType = { kind: "tuple", components };
+    for (const dimension of parseArrayDimensions(input.type.slice("tuple".length))) {
+      runtimeType = { kind: "array", base: runtimeType, length: dimension };
+    }
+    return runtimeType;
+  }
+
+  return parseAbiTypeString(input.type.trim());
+}
+
+function parseAbiTypeString(type: string): RuntimeAbiType {
+  const { baseType, dimensions } = splitArraySuffixes(type);
+  let runtimeType: RuntimeAbiType;
+
+  if (baseType.startsWith("(") && baseType.endsWith(")")) {
+    const tupleBody = baseType.slice(1, -1);
+    runtimeType = {
+      kind: "tuple",
+      components: splitTopLevel(tupleBody).map(parseAbiTypeString),
+    };
+  } else {
+    runtimeType = { kind: "primitive", type: normalizePrimitive(baseType) };
+  }
+
+  for (const dimension of dimensions) {
+    runtimeType = { kind: "array", base: runtimeType, length: dimension };
+  }
+
+  return runtimeType;
+}
+
+function splitArraySuffixes(type: string): {
+  baseType: string;
+  dimensions: Array<number | null>;
+} {
+  let baseType = type.trim();
+  const dimensions: Array<number | null> = [];
+
+  while (baseType.endsWith("]")) {
+    const openBracket = baseType.lastIndexOf("[");
+    if (openBracket === -1) {
+      throw new Error(`Invalid ABI array type: ${type}`);
+    }
+    const rawLength = baseType.slice(openBracket + 1, -1);
+    const dimension = parseStaticArrayLength(rawLength);
+    dimensions.unshift(dimension);
+    baseType = baseType.slice(0, openBracket).trim();
+  }
+
+  return { baseType, dimensions };
+}
+
+function parseArrayDimensions(suffix: string): Array<number | null> {
+  if (suffix === "") {
+    return [];
+  }
+  if (!/^(\[\d*\])+$/.test(suffix)) {
+    throw new Error(`Invalid ABI tuple array suffix: ${suffix}`);
+  }
+
+  const dimensions: Array<number | null> = [];
+  const matches = suffix.matchAll(/\[(\d*)\]/g);
+  for (const match of matches) {
+    dimensions.push(parseStaticArrayLength(match[1]));
+  }
+  return dimensions;
+}
+
+function parseStaticArrayLength(rawLength: string): number | null {
+  if (rawLength === "") {
+    return null;
+  }
+  if (!/^\d+$/.test(rawLength)) {
+    throw new Error(`Invalid ABI array length: ${rawLength}`);
+  }
+
+  const length = BigInt(rawLength);
+  if (length > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("ABI array length exceeds safe integer range");
+  }
+
+  const numericLength = Number(length);
+  assertSafeArrayLength(numericLength);
+  return numericLength;
+}
+
+function normalizePrimitive(type: string): string {
+  if (type === "uint") {
+    return "uint256";
+  }
+  if (type === "int") {
+    return "int256";
+  }
+  return type;
+}
+
+function splitTopLevel(input: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index];
+    if (char === "(" || char === "[") {
+      depth++;
+    } else if (char === ")" || char === "]") {
+      depth--;
+      if (depth < 0) {
+        throw new Error("Invalid ABI tuple type");
+      }
+    } else if (char === "," && depth === 0) {
+      parts.push(input.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  if (depth !== 0) {
+    throw new Error("Invalid ABI tuple type");
+  }
+
+  const last = input.slice(start).trim();
+  if (last.length > 0) {
+    parts.push(last);
+  }
+  return parts;
+}
+
+function isDynamic(type: RuntimeAbiType): boolean {
+  switch (type.kind) {
+    case "primitive":
+      return type.type === "string" || type.type === "bytes";
+    case "array":
+      return type.length === null || isDynamic(type.base);
+    case "tuple":
+      return type.components.some(isDynamic);
+  }
+}
+
+function staticSizeBytes(type: RuntimeAbiType): number {
+  if (isDynamic(type)) {
+    return 32;
+  }
+
+  switch (type.kind) {
+    case "primitive":
+      return 32;
+    case "array":
+      if (type.length === null) {
+        throw new Error("Dynamic arrays do not have a static size");
+      }
+      return checkedMultiply(
+        type.length,
+        staticSizeBytes(type.base),
+        "ABI static array size",
+      );
+    case "tuple":
+      return type.components.reduce(
+        (sum, component) =>
+          checkedAdd(sum, staticSizeBytes(component), "ABI static tuple size"),
+        0,
+      );
+  }
+}
+
+function decodeAt(
+  type: RuntimeAbiType,
+  hex: string,
+  headOffset: number,
+  baseOffset: number,
+): DecodedAbiValue {
+  if (isDynamic(type)) {
+    const relativeOffset = readUintOffset(hex, headOffset);
+    return decodeDynamicPayload(type, hex, baseOffset + relativeOffset);
+  }
+
+  return decodeStatic(type, hex, headOffset, baseOffset);
+}
+
+function decodeStatic(
+  type: RuntimeAbiType,
+  hex: string,
+  headOffset: number,
+  baseOffset: number,
+): DecodedAbiValue {
+  switch (type.kind) {
+    case "primitive":
+      return decodePrimitive(type.type, hex, headOffset);
+    case "array":
+      if (type.length === null) {
+        throw new Error("Dynamic arrays must be decoded from their payload");
+      }
+      return decodeArrayElements(type.base, type.length, hex, headOffset, headOffset);
+    case "tuple":
+      return decodeTuple(type.components, hex, headOffset, baseOffset);
+  }
+}
+
+function decodeDynamicPayload(
+  type: RuntimeAbiType,
+  hex: string,
+  dataOffset: number,
+): DecodedAbiValue {
+  if (type.kind === "primitive") {
+    if (type.type === "string") {
+      const length = readLength(hex, dataOffset);
+      const raw = sliceBytes(
+        hex,
+        checkedAdd(dataOffset, 32, "ABI string payload offset"),
+        length,
+      );
+      return Buffer.from(raw, "hex").toString("utf8");
+    }
+
+    if (type.type === "bytes") {
+      const length = readLength(hex, dataOffset);
+      const raw = sliceBytes(
+        hex,
+        checkedAdd(dataOffset, 32, "ABI bytes payload offset"),
+        length,
+      );
+      return Buffer.from(raw, "hex");
+    }
+  }
+
+  if (type.kind === "array") {
+    if (type.length === null) {
+      const length = readLength(hex, dataOffset);
+      assertSafeArrayLength(length);
+      const headOffset = checkedAdd(dataOffset, 32, "ABI dynamic array head offset");
+      return decodeArrayElements(type.base, length, hex, headOffset, headOffset);
+    }
+
+    return decodeArrayElements(type.base, type.length, hex, dataOffset, dataOffset);
+  }
+
+  if (type.kind === "tuple") {
+    return decodeTuple(type.components, hex, dataOffset, dataOffset);
+  }
+
+  throw new Error("ABI type is not dynamic");
+}
+
+function decodeArrayElements(
+  elementType: RuntimeAbiType,
+  length: number,
+  hex: string,
+  headOffset: number,
+  baseOffset: number,
+): DecodedAbiValue[] {
+  assertSafeArrayLength(length);
+  const values: DecodedAbiValue[] = [];
+  const elementHeadSize = isDynamic(elementType) ? 32 : staticSizeBytes(elementType);
+
+  for (let index = 0; index < length; index++) {
+    const elementOffset = checkedAdd(
+      headOffset,
+      checkedMultiply(index, elementHeadSize, "ABI array element offset"),
+      "ABI array element offset",
+    );
+    values.push(decodeAt(elementType, hex, elementOffset, baseOffset));
+  }
+
+  return values;
+}
+
+function decodeTuple(
+  components: RuntimeAbiType[],
+  hex: string,
+  headOffset: number,
+  baseOffset: number,
+): DecodedAbiValue[] {
+  const values: DecodedAbiValue[] = [];
+  let componentOffset = headOffset;
+
+  for (const component of components) {
+    values.push(decodeAt(component, hex, componentOffset, baseOffset));
+    componentOffset = checkedAdd(
+      componentOffset,
+      isDynamic(component) ? 32 : staticSizeBytes(component),
+      "ABI tuple component offset",
+    );
+  }
+
+  return values;
+}
+
+function decodePrimitive(
+  type: string,
+  hex: string,
+  byteOffset: number,
+): DecodedAbiValue {
+  const word = readWord(hex, byteOffset);
+
+  if (/^uint(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)$/.test(type)) {
+    return BigInt(`0x${word}`);
+  }
+
+  if (/^int(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)$/.test(type)) {
+    const bits = Number(type.slice(3));
+    const value = BigInt(`0x${word}`);
+    const signBit = 1n << BigInt(bits - 1);
+    return (value & signBit) === 0n ? value : value - (1n << BigInt(bits));
+  }
+
+  if (type === "address") {
+    return `0x${word.slice(-40).toLowerCase()}`;
+  }
+
+  if (type === "bool") {
+    return BigInt(`0x${word}`) !== 0n;
+  }
+
+  const bytesMatch = type.match(/^bytes([1-9]|[12][0-9]|3[0-2])$/);
+  if (bytesMatch) {
+    const byteLength = Number(bytesMatch[1]);
+    return `0x${word.slice(0, byteLength * 2)}`;
+  }
+
+  throw new Error(`Unsupported ABI type: ${type}`);
+}
+
+function assertSafeArrayLength(length: number): void {
+  if (!Number.isInteger(length) || length < 0) {
+    throw new Error("ABI array length must be a non-negative integer");
+  }
+  if (length > MAX_ABI_ARRAY_LENGTH) {
+    throw new Error("ABI array length exceeds supported limit");
+  }
+}
+
+function checkedAdd(left: number, right: number, context: string): number {
+  if (!Number.isSafeInteger(left) || !Number.isSafeInteger(right)) {
+    throw new Error(`${context} exceeds safe integer range`);
+  }
+
+  const result = left + right;
+  if (!Number.isSafeInteger(result)) {
+    throw new Error(`${context} exceeds safe integer range`);
+  }
+  return result;
+}
+
+function checkedMultiply(left: number, right: number, context: string): number {
+  if (!Number.isSafeInteger(left) || !Number.isSafeInteger(right)) {
+    throw new Error(`${context} exceeds safe integer range`);
+  }
+
+  const result = left * right;
+  if (!Number.isSafeInteger(result)) {
+    throw new Error(`${context} exceeds safe integer range`);
+  }
+  return result;
 }


### PR DESCRIPTION
/claim #198

💳 Payment: USDC | 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2 | Base

## Summary
- Add backwards-compatible `decodeParameter(type, data, byteOffset?)` support for ABI dynamic values.
- Add `decodeParams` / `decodeParameters` for complex return blobs with mixed static and dynamic heads.
- Decode strings to JS strings, `bytes` to `Buffer`, dynamic/fixed arrays to JS arrays, and nested tuple/string descriptor shapes recursively.
- Preserve existing static slot callers, including short `uint256` slot decoding.
- Add bounds checks for unsafe ABI array dimensions and static offset math, and reject malformed dynamic data instead of silently falling back.
- Add focused Node tests covering string, bytes, dynamic arrays, nested tuples, tuple descriptors, malformed inputs, and the required string + array + uint complex return case.

## Verification
- `node --test sdk/src/utils/encoding.test.mjs` -> 7 passing
- `npx tsc --noEmit --target ES2020 --module commonjs --types node sdk/src/utils/encoding.ts` -> passing
- `git diff --check` -> passing
- `gh pr list --repo ClankerNation/OpenAgents --state open --search "198"` -> no open competing PRs before opening this PR

## Runtime Metadata
- Local verification runtime: Windows, x64, PowerShell
- Local absolute paths and private initialization text are intentionally not published in source or PR metadata.

## Note
The issue asks for initialization/runtime metadata. I kept the source metadata limited to author/date plus a pointer to this PR metadata, and did not publish private system/developer instructions, secrets, credentials, hidden policy text, or local absolute paths.