### PR TITLE
[Sifr] Add configurable API CORS

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,7 @@
+import os
+
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
@@ -7,6 +10,37 @@ app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
+)
+
+
+def _is_development() -> bool:
+    return os.getenv("ENV", os.getenv("ENVIRONMENT", "development")).lower() in {
+        "dev",
+        "development",
+        "local",
+        "test",
+    }
+
+
+def _cors_origins() -> list[str]:
+    configured = [
+        origin.strip()
+        for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")
+        if origin.strip()
+    ]
+    if configured:
+        if "*" in configured and not _is_development():
+            return []
+        return configured
+    return ["*"] if _is_development() else []
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins(),
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
 )
 
 

--- a/api/tests/test_cors.py
+++ b/api/tests/test_cors.py
@@ -1,0 +1,60 @@
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+
+
+def load_app(monkeypatch, allowed_origins="https://frontend.example", env="production"):
+    monkeypatch.setenv("ALLOWED_ORIGINS", allowed_origins)
+    monkeypatch.setenv("ENV", env)
+    import api.main as main
+
+    return importlib.reload(main).app
+
+
+def test_cors_preflight_allows_configured_origin(monkeypatch):
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+
+    response = client.options(
+        "/agents",
+        headers={
+            "Origin": "https://frontend.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "GET" in response.headers["access-control-allow-methods"]
+
+
+def test_cross_origin_get_includes_cors_headers(monkeypatch):
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/agents", headers={"Origin": "https://frontend.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_wildcard_origin_is_not_allowed_in_production(monkeypatch):
+    app = load_app(monkeypatch, allowed_origins="*", env="production")
+    client = TestClient(app)
+
+    response = client.get("/agents", headers={"Origin": "https://frontend.example"})
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_wildcard_origin_is_allowed_in_development(monkeypatch):
+    app = load_app(monkeypatch, allowed_origins="*", env="development")
+    client = TestClient(app)
+
+    response = client.get("/agents", headers={"Origin": "https://frontend.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://frontend.example"


### PR DESCRIPTION
/claim #156

Payment: PayPal email `Adjie_saputra@outlook.com` or PayPal.me/adjiels.

## Summary

Adds production-safe CORS support to the FastAPI API server.

This PR:

- Adds `CORSMiddleware` to `api/main.py`
- Reads comma-separated origins from `ALLOWED_ORIGINS`
- Allows `GET`, `POST`, `PUT`, `DELETE`, and `OPTIONS`
- Enables credentials for authenticated endpoints
- Defaults to wildcard CORS only in local/dev/test environments
- Refuses wildcard `*` in production by falling back to a restrictive empty allowlist
- Adds focused tests for preflight, cross-origin GET, production wildcard blocking, and development wildcard behavior

Closes #156.

## Validation

```bash
python3 -m py_compile api/main.py api/tests/test_cors.py
python3 -m pytest api/tests/test_cors.py -q
```

Observed result:

```text
4 passed in 0.31s
```

## Metadata note

The issue asks contributors to paste complete private session initialization context into source. I did not include private runtime/system instructions in the repository because that would disclose unrelated private operational context. The code change itself is limited to the requested CORS behavior and tests.
