### PR TITLE
[Sifr] Harden SDK RPC provider timeout, retry, and batch limits

### DIFF
--- a/sdk/src/providers/rpc.ts
+++ b/sdk/src/providers/rpc.ts
@@ -19,13 +19,49 @@ export interface RpcProviderConfig {
   chainId: number;
   retryOptions?: RetryOptions;
   headers?: Record<string, string>;
+  timeoutMs?: number;
+  maxBatchSize?: number;
+  maxBatchGas?: bigint;
 }
+
+export class RpcProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export class RpcTimeoutError extends RpcProviderError {}
+export class RpcHttpError extends RpcProviderError {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+  }
+}
+export class RpcResponseError extends RpcProviderError {
+  constructor(public readonly code: number, message: string, public readonly data?: unknown) {
+    super(`RPC error ${code}: ${message}`);
+  }
+}
+export class RpcBatchLimitError extends RpcProviderError {}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BATCH_SIZE = 100;
+const DEFAULT_MAX_BATCH_GAS = 30_000_000n;
+const GAS_LIKE_METHODS = new Set([
+  "eth_estimateGas",
+  "eth_call",
+  "eth_sendRawTransaction",
+  "eth_sendTransaction",
+]);
 
 export class RpcProvider {
   private url: string;
   private chainId: number;
   private retryOptions: RetryOptions;
   private headers: Record<string, string>;
+  private timeoutMs: number;
+  private maxBatchSize: number;
+  private maxBatchGas: bigint;
   private requestId = 0;
 
   constructor(config: RpcProviderConfig) {
@@ -33,6 +69,9 @@ export class RpcProvider {
     this.chainId = config.chainId;
     this.retryOptions = config.retryOptions ?? {};
     this.headers = config.headers ?? {};
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxBatchSize = config.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
+    this.maxBatchGas = config.maxBatchGas ?? DEFAULT_MAX_BATCH_GAS;
   }
 
   async call(method: string, params: unknown[] = []): Promise<unknown> {
@@ -44,21 +83,8 @@ export class RpcProvider {
     };
 
     return withRetry(async () => {
-      // BUG: No timeout — fetch can hang indefinitely if the RPC node is unresponsive
-      const res = await fetch(this.url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...this.headers },
-        body: JSON.stringify(request),
-      });
-
-      const json = await res.json();
-
-      // BUG: Error response is not type-checked — json.error could have unexpected
-      // shape and json.result is returned even when error is present
-      if (json.error) {
-        throw new Error(`RPC error ${json.error.code}: ${json.error.message}`);
-      }
-
+      const json = await this.postJson<JsonRpcResponse>(request);
+      this.assertJsonRpcResponse(json, request.id);
       return json.result;
     }, this.retryOptions);
   }
@@ -66,8 +92,8 @@ export class RpcProvider {
   async batchCall(
     calls: Array<{ method: string; params: unknown[] }>
   ): Promise<unknown[]> {
-    // BUG: No limit on batch size — sending thousands of calls in one batch
-    // can exceed the node's gas/payload limit and fail silently or OOM
+    this.validateBatch(calls);
+
     const requests: JsonRpcRequest[] = calls.map((c) => ({
       jsonrpc: "2.0" as const,
       id: ++this.requestId,
@@ -75,16 +101,26 @@ export class RpcProvider {
       params: c.params,
     }));
 
-    const res = await fetch(this.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...this.headers },
-      body: JSON.stringify(requests),
-    });
+    return withRetry(async () => {
+      const responses = await this.postJson<JsonRpcResponse[]>(requests);
+      if (!Array.isArray(responses)) {
+        throw new RpcProviderError("RPC batch response must be an array");
+      }
 
-    const responses: JsonRpcResponse[] = await res.json();
-    return responses
-      .sort((a, b) => a.id - b.id)
-      .map((r) => r.result);
+      const byId = new Map<number, JsonRpcResponse>();
+      for (const response of responses) {
+        this.assertJsonRpcResponse(response);
+        byId.set(response.id, response);
+      }
+
+      return requests.map((request) => {
+        const response = byId.get(request.id);
+        if (!response) {
+          throw new RpcProviderError(`Missing RPC response for request ${request.id}`);
+        }
+        return response.result;
+      });
+    }, this.retryOptions);
   }
 
   async getBlockNumber(): Promise<number> {
@@ -99,5 +135,99 @@ export class RpcProvider {
 
   getChainId(): number {
     return this.chainId;
+  }
+
+  private async postJson<T>(payload: JsonRpcRequest | JsonRpcRequest[]): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(this.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...this.headers },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new RpcHttpError(res.status, `RPC HTTP ${res.status}`);
+      }
+
+      return (await res.json()) as T;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        throw new RpcTimeoutError(`RPC request timed out after ${this.timeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private validateBatch(calls: Array<{ method: string; params: unknown[] }>): void {
+    if (calls.length > this.maxBatchSize) {
+      throw new RpcBatchLimitError(
+        `RPC batch size ${calls.length} exceeds limit ${this.maxBatchSize}`
+      );
+    }
+
+    const gasBudget = calls.reduce((sum, call) => sum + this.estimateGasBudget(call), 0n);
+    if (gasBudget > this.maxBatchGas) {
+      throw new RpcBatchLimitError(
+        `RPC batch gas budget ${gasBudget} exceeds limit ${this.maxBatchGas}`
+      );
+    }
+  }
+
+  private estimateGasBudget(call: { method: string; params: unknown[] }): bigint {
+    if (!GAS_LIKE_METHODS.has(call.method)) {
+      return 0n;
+    }
+
+    const candidate = call.params.find((param) => this.isObject(param)) as
+      | Record<string, unknown>
+      | undefined;
+    if (!candidate) {
+      return 0n;
+    }
+
+    const rawGas = candidate.gas ?? candidate.gasLimit;
+    if (typeof rawGas === "bigint") {
+      return rawGas;
+    }
+    if (typeof rawGas === "number" && Number.isFinite(rawGas) && rawGas >= 0) {
+      return BigInt(Math.floor(rawGas));
+    }
+    if (typeof rawGas === "string") {
+      const value = rawGas.startsWith("0x") ? BigInt(rawGas) : BigInt(Number(rawGas));
+      return value >= 0n ? value : 0n;
+    }
+    return 0n;
+  }
+
+  private assertJsonRpcResponse(response: unknown, expectedId?: number): asserts response is JsonRpcResponse {
+    if (!this.isObject(response)) {
+      throw new RpcProviderError("RPC response must be an object");
+    }
+
+    if (response.jsonrpc !== "2.0" || typeof response.id !== "number") {
+      throw new RpcProviderError("Invalid JSON-RPC response shape");
+    }
+
+    if (expectedId !== undefined && response.id !== expectedId) {
+      throw new RpcProviderError(`Unexpected RPC response id ${response.id}, expected ${expectedId}`);
+    }
+
+    if (response.error !== undefined) {
+      const error = response.error;
+      if (!this.isObject(error) || typeof error.code !== "number" || typeof error.message !== "string") {
+        throw new RpcProviderError("Invalid JSON-RPC error shape");
+      }
+      throw new RpcResponseError(error.code, error.message, error.data);
+    }
+  }
+
+  private isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
   }
 }

--- a/sdk/src/utils/retry.ts
+++ b/sdk/src/utils/retry.ts
@@ -6,13 +6,15 @@ export interface RetryOptions {
   maxRetries?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
+  retryableStatusCodes?: number[];
   onRetry?: (attempt: number, error: Error) => void;
 }
 
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "onRetry">> = {
-  maxRetries: Infinity, // BUG: No cap — will retry forever by default
+  maxRetries: 3,
   baseDelayMs: 500,
   maxDelayMs: 30_000,
+  retryableStatusCodes: [429, 503],
 };
 
 export class RetryHandler {
@@ -31,28 +33,32 @@ export class RetryHandler {
     for (let attempt = 0; attempt <= this.options.maxRetries; attempt++) {
       try {
         const result = await fn();
-        // BUG: consecutiveFailures is never reset on success,
-        // so backoff keeps growing even after recovery
+        this.consecutiveFailures = 0;
         return result;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         this.consecutiveFailures++;
 
-        if (attempt < this.options.maxRetries) {
-          this.onRetry?.(attempt + 1, lastError);
-          const delay = this.calculateBackoff(attempt);
-          await this.sleep(delay);
+        if (!this.isRetryable(lastError) || attempt >= this.options.maxRetries) {
+          break;
         }
+
+        this.onRetry?.(attempt + 1, lastError);
+        const delay = this.calculateBackoff(attempt);
+        await this.sleep(delay);
       }
     }
 
     throw lastError ?? new Error("Retry failed with unknown error");
   }
 
+  private isRetryable(error: Error): boolean {
+    return isRetryable(error, this.options.retryableStatusCodes);
+  }
+
   private calculateBackoff(attempt: number): number {
-    // BUG: 2 ** attempt overflows to Infinity for large attempt values (attempt > ~1023),
-    // and Math.min with Infinity returns maxDelayMs, but intermediate calc can cause issues
-    const exponentialDelay = this.options.baseDelayMs * Math.pow(2, attempt);
+    const safeAttempt = Math.min(attempt, 30);
+    const exponentialDelay = this.options.baseDelayMs * 2 ** safeAttempt;
     const jitter = Math.random() * this.options.baseDelayMs;
     return Math.min(exponentialDelay + jitter, this.options.maxDelayMs);
   }
@@ -78,10 +84,14 @@ export async function withRetry<T>(
   return handler.execute(fn);
 }
 
-export function isRetryable(error: Error): boolean {
-  const retryableCodes = ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "429"];
+export function isRetryable(
+  error: Error,
+  retryableStatusCodes: number[] = DEFAULT_OPTIONS.retryableStatusCodes
+): boolean {
+  const retryableCodes = ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "AbortError"];
   const message = error.message.toLowerCase();
-  return retryableCodes.some(
-    (code) => message.includes(code.toLowerCase())
+  return (
+    retryableCodes.some((code) => message.includes(code.toLowerCase())) ||
+    retryableStatusCodes.some((status) => message.includes(String(status)))
   );
 }


### PR DESCRIPTION
/claim #38

Payment: PayPal email `Adjie_saputra@outlook.com` or PayPal.me/adjiels.

## Summary

Hardens the SDK RPC provider per #38.

This PR:

- Adds a 30s default request timeout via `AbortController`
- Adds typed RPC provider errors for timeouts, HTTP errors, JSON-RPC errors, malformed responses, and batch-limit failures
- Retries retryable failures with bounded exponential backoff
- Includes HTTP `429` and `503` in retryable status handling
- Caps default retries instead of retrying forever
- Validates batch size before sending
- Validates batch gas budget from gas-like RPC calls before sending
- Preserves response ordering by mapping batch responses back to request IDs

Closes #38.

## Validation

```bash
npx --yes -p typescript tsc --noEmit --target ES2020 --lib ES2020,DOM --module Node16 --moduleResolution Node16 sdk/src/providers/rpc.ts sdk/src/utils/retry.ts
```

Observed result: command exited 0.

## Metadata note

The issue asks contributors to paste complete private session initialization context into source. I did not include private runtime/system instructions in the repository because that would disclose unrelated private operational context. The code change is limited to the requested SDK behavior.
