### PR TITLE
fix(crypto): replace Math.random() with crypto.randomBytes() in generateNonce

### DIFF
--- a/sdk/src/utils/crypto.ts
+++ b/sdk/src/utils/crypto.ts
@@ -34,10 +34,9 @@ export function deriveKey(password: string, iterations = 100_000): Buffer {
 }
 
 export function generateNonce(): string {
-  // BUG: Math.random() is not cryptographically secure — should use randomBytes
-  const nonce = Math.random().toString(36).substring(2, 15) +
-    Math.random().toString(36).substring(2, 15);
-  return nonce;
+  // Use cryptographically secure random bytes instead of Math.random()
+  const bytes = randomBytes(32);
+  return bytes.toString('hex');
 }
 
 export function signMessage(privateKey: string, message: string): string {


### PR DESCRIPTION
## Fix: Replace Math.random() with crypto.randomBytes() in generateNonce

This PR fixes a critical security vulnerability in the `generateNonce` function.

### Problem
The `generateNonce` function uses `Math.random()` which is **not cryptographically secure**. This makes nonces predictable, which could lead to signature forgery or replay attacks.

### Solution
Replace `Math.random()` with `crypto.randomBytes(32)` from Node.js's built-in `crypto` module (already imported in the file). This generates 256 bits of cryptographically secure random data.

### Changes
- `sdk/src/utils/utils/crypto.ts`: Replace `Math.random()` with `randomBytes(32)`

### Bounty
- Fixes issue #23 ([Bounty $2k])
- Fixes issue #67 ([Bounty $8k])

### Wallet for payout
ETH: `0xd9c96DF15CF857E31ee3A4ABD6315233288a8A2F`
