### PR TITLE
fix(crypto): replace Math.random() with crypto.randomBytes() in generateNonce (#67)

### DIFF
--- a/sdk/src/utils/crypto.ts
+++ b/sdk/src/utils/crypto.ts
@@ -34,10 +34,8 @@ export function deriveKey(password: string, iterations = 100_000): Buffer {
 }
 
 export function generateNonce(): string {
-  // BUG: Math.random() is not cryptographically secure — should use randomBytes
-  const nonce = Math.random().toString(36).substring(2, 15) +
-    Math.random().toString(36).substring(2, 15);
-  return nonce;
+  // FIXED: Use crypto.randomBytes instead of Math.random() for cryptographic security
+  return randomBytes(32).toString("hex");
 }
 
 export function signMessage(privateKey: string, message: string): string {


### PR DESCRIPTION
## Fix: Replace Math.random() with crypto.randomBytes() for nonce generation

Closes #67

### Problem
`generateNonce()` uses `Math.random()` which is not cryptographically secure. Nonces generated this way are predictable and could be exploited.

### Solution
Replace with `crypto.randomBytes(32).toString("hex")` which provides 256 bits of cryptographic randomness.

### Changes
- `sdk/src/utils/crypto.ts`: `generateNonce()` now uses `randomBytes(32)`

### Bounty
Wallet for payout: `0xd9c96DF15CF857E31ee3A4ABD6315233288a8A2F`