### PR TITLE
[KHHH2312 Codex] Fix dynamic ABI decoding

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "KHHH2312 Codex",
+      "timestamp": "2026-06-05T13:10:00Z",
+      "platform_instructions": "Non-public pre-conversation initialization payload withheld. Hidden system/developer instructions, private session configuration, secrets, credentials, and non-public policy text are not published.",
+      "runtime": {
+        "os": "Windows",
+        "arch": "x64",
+        "home_dir": "C:\\Users\\Khalid",
+        "working_dir": "C:\\Users\\Khalid\\Desktop\\bounty\\OpenAgents-198-v2",
+        "shell": "PowerShell"
+      },
+      "contribution": "Added backwards-compatible ABI dynamic decoding for strings, bytes, arrays, and nested tuples in the SDK encoding utilities"
     }
   ]
 }

--- a/sdk/src/utils/encoding.test.mjs
+++ b/sdk/src/utils/encoding.test.mjs
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { AbiCoder } from "ethers";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "../../..");
+const outDir = mkdtempSync(path.join(repoRoot, ".encoding-test-"));
+const tscBin = path.join(repoRoot, "node_modules/typescript/bin/tsc");
+
+execFileSync(
+  process.execPath,
+  [
+    tscBin,
+    "--pretty",
+    "false",
+    "--ignoreDeprecations",
+    "6.0",
+    "--target",
+    "ES2020",
+    "--module",
+    "commonjs",
+    "--moduleResolution",
+    "node",
+    "--esModuleInterop",
+    "--skipLibCheck",
+    "--types",
+    "node",
+    "--outDir",
+    outDir,
+    path.join(repoRoot, "sdk/src/utils/encoding.ts"),
+  ],
+  { cwd: repoRoot, stdio: "inherit" }
+);
+
+process.on("exit", () => {
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+function findCompiledEncoding(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = findCompiledEncoding(fullPath);
+      if (nested) return nested;
+    }
+    if (entry.name === "encoding.js") {
+      return fullPath;
+    }
+  }
+  return null;
+}
+
+const compiledEncoding = findCompiledEncoding(outDir);
+assert.ok(compiledEncoding && existsSync(compiledEncoding), "compiled encoding.js was emitted");
+
+const encoding = await import(pathToFileURL(compiledEncoding).href);
+const coder = AbiCoder.defaultAbiCoder();
+
+test("decodeParameter keeps static slot backwards compatibility", () => {
+  assert.equal(encoding.decodeParameter("uint256", "2a"), 42n);
+  assert.equal(encoding.decodeParameter("bool", "01"), true);
+
+  const address = "0x1111111111111111111111111111111111111111";
+  const addressSlot = coder.encode(["address"], [address]).slice(2);
+  assert.equal(encoding.decodeParameter("address", addressSlot), address);
+});
+
+test("decodeParameter decodes string and bytes dynamic ABI values", () => {
+  assert.equal(
+    encoding.decodeParameter("string", coder.encode(["string"], ["hello agent"])),
+    "hello agent"
+  );
+
+  const decodedBytes = encoding.decodeParameter("bytes", coder.encode(["bytes"], ["0x1234abcd"]));
+  assert.equal(Buffer.isBuffer(decodedBytes), true);
+  assert.equal(decodedBytes.toString("hex"), "1234abcd");
+});
+
+test("decodeParameter decodes dynamic arrays with static and dynamic elements", () => {
+  assert.deepEqual(
+    encoding.decodeParameter("uint256[]", coder.encode(["uint256[]"], [[1n, 2n, 3n]])),
+    [1n, 2n, 3n]
+  );
+
+  assert.deepEqual(
+    encoding.decodeParameter("string[]", coder.encode(["string[]"], [["alpha", "beta"]])),
+    ["alpha", "beta"]
+  );
+});
+
+test("decodeParams decodes required complex return type with string array and uint", () => {
+  const encoded = coder.encode(
+    ["string", "uint256[]", "uint256"],
+    ["task-ready", [5n, 8n, 13n], 21n]
+  );
+
+  assert.deepEqual(encoding.decodeParams(["string", "uint256[]", "uint256"], encoded), [
+    "task-ready",
+    [5n, 8n, 13n],
+    21n,
+  ]);
+});
+
+test("decodeParameter supports byte offsets for dynamic values in mixed return data", () => {
+  const encoded = coder.encode(["uint256", "string"], [10n, "offset string"]);
+
+  assert.equal(encoding.decodeParameter("uint256", encoded, 0), 10n);
+  assert.equal(encoding.decodeParameter("string", encoded, 32), "offset string");
+});
+
+test("decodeParameter decodes nested tuple syntax recursively", () => {
+  const tupleType = "tuple(string,uint256[],tuple(bytes,bool))";
+  const encoded = coder.encode([tupleType], [["agent", [7n, 8n], ["0xdeadbeef", true]]]);
+  const decoded = encoding.decodeParameter(tupleType, encoded);
+
+  assert.equal(decoded[0], "agent");
+  assert.deepEqual(decoded[1], [7n, 8n]);
+  assert.equal(Buffer.isBuffer(decoded[2][0]), true);
+  assert.equal(decoded[2][0].toString("hex"), "deadbeef");
+  assert.equal(decoded[2][1], true);
+});
+
+test("decodeParameter decodes named tuple descriptors recursively", () => {
+  const descriptor = {
+    type: "tuple",
+    components: [
+      { name: "label", type: "string" },
+      { name: "scores", type: "uint256[]" },
+      {
+        name: "meta",
+        type: "tuple",
+        components: [
+          { name: "payload", type: "bytes" },
+          { name: "ok", type: "bool" },
+        ],
+      },
+    ],
+  };
+  const encoded = coder.encode(
+    ["tuple(string,uint256[],tuple(bytes,bool))"],
+    [["agent", [7n, 8n], ["0xdeadbeef", true]]]
+  );
+  const decoded = encoding.decodeParameter(descriptor, encoded);
+
+  assert.equal(decoded.label, "agent");
+  assert.deepEqual(decoded.scores, [7n, 8n]);
+  assert.equal(Buffer.isBuffer(decoded.meta.payload), true);
+  assert.equal(decoded.meta.payload.toString("hex"), "deadbeef");
+  assert.equal(decoded.meta.ok, true);
+});

--- a/sdk/src/utils/encoding.ts
+++ b/sdk/src/utils/encoding.ts
@@ -1,40 +1,117 @@
+import { AbiCoder } from "ethers";
+
 /**
  * ABI encoding/decoding utilities for EVM-compatible contract interactions.
+ *
+ * @fix-author
+ * name: KHHH2312 Codex
+ * date: 2026-06-05
+ * pre_conversation_initialization_payload: Withheld. Hidden system/developer
+ * instructions, private session configuration, secrets, credentials, and
+ * non-public policy text are not published in source code.
+ *
+ * @runtime
+ * os: Windows
+ * arch: x64
+ * working_dir: C:\Users\Khalid\Desktop\bounty\OpenAgents-198-v2
+ * shell: PowerShell
  */
 
-export type AbiType = "uint256" | "address" | "bytes32" | "string" | "bool";
+export interface AbiComponent {
+  name?: string;
+  type: string;
+  components?: AbiComponent[];
+}
+
+export interface AbiTupleType {
+  name?: string;
+  type: "tuple" | `tuple${string}`;
+  components: AbiComponent[];
+}
+
+export type AbiType = string | AbiTupleType;
+
+export type AbiEncodableValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Uint8Array
+  | AbiEncodableValue[]
+  | { [key: string]: AbiEncodableValue };
+
+export type DecodedAbiValue =
+  | bigint
+  | string
+  | boolean
+  | Buffer
+  | DecodedAbiValue[]
+  | { [key: string]: DecodedAbiValue };
 
 export interface AbiParam {
   type: AbiType;
-  value: string | number | bigint | boolean;
+  value: AbiEncodableValue;
+}
+
+type TypeNode =
+  | { kind: "scalar"; type: string }
+  | { kind: "array"; item: TypeNode; length: number | null }
+  | { kind: "tuple"; components: Array<{ name?: string; node: TypeNode }> };
+
+const WORD_BYTES = 32;
+const WORD_HEX_LENGTH = WORD_BYTES * 2;
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+function getAbiCoder(): AbiCoder {
+  return AbiCoder.defaultAbiCoder();
 }
 
 export function encodeUint256(value: bigint | number): string {
   const n = BigInt(value);
-  // BUG: No overflow check — values > 2^256-1 silently wrap/truncate
-  return n.toString(16).padStart(64, "0");
+  if (n < 0n || n > MAX_UINT256) {
+    throw new RangeError("uint256 value out of range");
+  }
+  return n.toString(16).padStart(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeAddress(address: string): string {
-  const cleaned = address.startsWith("0x") ? address.slice(2) : address;
-  return cleaned.toLowerCase().padStart(64, "0");
+  const cleaned = stripHexPrefix(address);
+  if (!/^[0-9a-fA-F]{40}$/.test(cleaned)) {
+    throw new Error("address must be 20 bytes");
+  }
+  return cleaned.toLowerCase().padStart(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeBytes32(data: string): string {
-  const cleaned = data.startsWith("0x") ? data.slice(2) : data;
-  return cleaned.padEnd(64, "0");
+  const cleaned = stripHexPrefix(data);
+  if (!/^[0-9a-fA-F]*$/.test(cleaned)) {
+    throw new Error("bytes32 value must be hex");
+  }
+  if (cleaned.length > WORD_HEX_LENGTH) {
+    throw new Error("bytes32 value exceeds 32 bytes");
+  }
+  return cleaned.padEnd(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeBool(value: boolean): string {
-  return value ? "1".padStart(64, "0") : "0".padStart(64, "0");
+  return value ? "1".padStart(WORD_HEX_LENGTH, "0") : "0".padStart(WORD_HEX_LENGTH, "0");
 }
 
 export function encodeParams(params: AbiParam[]): string {
+  if (params.some((param) => isDynamicTypeNode(buildTypeNode(param.type)))) {
+    return getAbiCoder().encode(
+      params.map((param) => toAbiType(param.type)),
+      params.map((param) => normalizeEncodeValue(param.value))
+    );
+  }
+
   let encoded = "0x";
   for (const param of params) {
-    switch (param.type) {
+    const type = toAbiType(param.type);
+    switch (type) {
+      case "uint":
       case "uint256":
-        encoded += encodeUint256(BigInt(param.value as number));
+        encoded += encodeUint256(BigInt(param.value as number | bigint));
         break;
       case "address":
         encoded += encodeAddress(param.value as string);
@@ -45,36 +122,65 @@ export function encodeParams(params: AbiParam[]): string {
       case "bool":
         encoded += encodeBool(param.value as boolean);
         break;
-      case "string":
-        const hexStr = Buffer.from(param.value as string).toString("hex");
-        encoded += hexStr.padEnd(64, "0");
-        break;
+      default:
+        return getAbiCoder().encode(
+          params.map((item) => toAbiType(item.type)),
+          params.map((item) => normalizeEncodeValue(item.value))
+        );
     }
   }
   return encoded;
 }
 
 export function decodeHex(hex: string): bigint {
-  // BUG: Doesn't validate "0x" prefix — a bare decimal string like "255"
-  // would be parsed as hex 0x255 = 597, silently returning wrong value
-  const cleaned = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const cleaned = stripHexPrefix(hex);
+  if (!/^[0-9a-fA-F]+$/.test(cleaned)) {
+    throw new Error("hex value contains non-hex characters");
+  }
   return BigInt("0x" + cleaned);
 }
 
 export function decodeUint256(slot: string): bigint {
-  // BUG: Doesn't handle short values — if slot is less than 64 chars,
-  // no left-padding is applied before parsing, giving wrong results
-  return BigInt("0x" + slot);
+  const cleaned = stripHexPrefix(slot);
+  if (!/^[0-9a-fA-F]*$/.test(cleaned)) {
+    throw new Error("uint256 slot must be hex");
+  }
+  if (cleaned.length > WORD_HEX_LENGTH) {
+    throw new Error("uint256 slot exceeds 32 bytes");
+  }
+  return BigInt("0x" + cleaned.padStart(WORD_HEX_LENGTH, "0"));
 }
 
 export function decodeAddress(slot: string): string {
-  const raw = slot.slice(-40);
-  return "0x" + raw.toLowerCase();
+  const cleaned = stripHexPrefix(slot);
+  if (cleaned.length > WORD_HEX_LENGTH || !/^[0-9a-fA-F]*$/.test(cleaned)) {
+    throw new Error("address slot must be a valid ABI word");
+  }
+  return "0x" + cleaned.padStart(WORD_HEX_LENGTH, "0").slice(-40).toLowerCase();
 }
 
 export function decodeBool(slot: string): boolean {
-  return BigInt("0x" + slot) !== 0n;
+  return decodeUint256(slot) !== 0n;
 }
+
+export function decodeParameter(
+  type: AbiType,
+  data: string,
+  byteOffset = 0
+): DecodedAbiValue {
+  const node = buildTypeNode(type);
+  const prepared = prepareSingleParameterData(node, data, byteOffset);
+  const decoded = getAbiCoder().decode([toAbiType(type)], prepared)[0];
+  return normalizeDecodedValue(decoded, node);
+}
+
+export function decodeParams(types: AbiType[], data: string): DecodedAbiValue[] {
+  const nodes = types.map((type) => buildTypeNode(type));
+  const decoded = getAbiCoder().decode(types.map((type) => toAbiType(type)), ensureHexPrefix(data));
+  return nodes.map((node, index) => normalizeDecodedValue(decoded[index], node));
+}
+
+export const decodeParameters = decodeParams;
 
 export function functionSelector(signature: string): string {
   const { createHash } = require("crypto");
@@ -85,4 +191,246 @@ export function functionSelector(signature: string): string {
 export function packCalldata(selector: string, params: AbiParam[]): string {
   const encodedParams = encodeParams(params).slice(2);
   return selector + encodedParams;
+}
+
+function prepareSingleParameterData(node: TypeNode, data: string, byteOffset: number): string {
+  if (!Number.isInteger(byteOffset) || byteOffset < 0) {
+    throw new Error("byteOffset must be a non-negative integer");
+  }
+
+  const cleaned = stripHexPrefix(data);
+  if (!/^[0-9a-fA-F]*$/.test(cleaned)) {
+    throw new Error("ABI data must be hex");
+  }
+
+  if (!isDynamicTypeNode(node)) {
+    const word = readAbiWord(cleaned, byteOffset, true);
+    return "0x" + word;
+  }
+
+  if (byteOffset === 0) {
+    return ensureHexPrefix(cleaned);
+  }
+
+  const tailOffset = bigintToSafeNumber(BigInt("0x" + readAbiWord(cleaned, byteOffset, false)));
+  if (tailOffset < 0 || tailOffset * 2 > cleaned.length) {
+    throw new Error("dynamic parameter offset points outside ABI data");
+  }
+
+  return "0x" + encodeUint256(BigInt(WORD_BYTES)) + cleaned.slice(tailOffset * 2);
+}
+
+function readAbiWord(cleanedHex: string, byteOffset: number, allowShortWord: boolean): string {
+  const hexOffset = byteOffset * 2;
+  if (hexOffset > cleanedHex.length) {
+    throw new Error("ABI offset points outside data");
+  }
+
+  const remaining = cleanedHex.slice(hexOffset);
+  if (remaining.length < WORD_HEX_LENGTH) {
+    if (!allowShortWord) {
+      throw new Error("ABI word is truncated");
+    }
+    return remaining.padStart(WORD_HEX_LENGTH, "0");
+  }
+
+  return remaining.slice(0, WORD_HEX_LENGTH);
+}
+
+function toAbiType(type: AbiType | AbiComponent): string {
+  if (typeof type === "string") {
+    return type.trim();
+  }
+
+  const rawType = type.type.trim();
+  if (rawType.startsWith("tuple")) {
+    const suffix = rawType.slice("tuple".length);
+    return `tuple(${(type.components ?? []).map((component) => toAbiType(component)).join(",")})${suffix}`;
+  }
+
+  return rawType;
+}
+
+function buildTypeNode(type: AbiType | AbiComponent): TypeNode {
+  if (typeof type !== "string" && type.type.trim().startsWith("tuple")) {
+    const { dimensions } = splitArraySuffix(type.type.trim());
+    let node: TypeNode = {
+      kind: "tuple",
+      components: (type.components ?? []).map((component) => ({
+        name: component.name,
+        node: buildTypeNode(component),
+      })),
+    };
+    return applyArrayDimensions(node, dimensions);
+  }
+
+  return buildTypeNodeFromString(toAbiType(type));
+}
+
+function buildTypeNodeFromString(type: string): TypeNode {
+  const { base, dimensions } = splitArraySuffix(type.trim());
+  let node: TypeNode;
+
+  if (base.startsWith("tuple(") && base.endsWith(")")) {
+    const inner = base.slice("tuple(".length, -1);
+    node = {
+      kind: "tuple",
+      components: splitTopLevel(inner).map((componentType) => ({
+        node: buildTypeNodeFromString(componentType),
+      })),
+    };
+  } else {
+    node = { kind: "scalar", type: base };
+  }
+
+  return applyArrayDimensions(node, dimensions);
+}
+
+function splitArraySuffix(type: string): { base: string; dimensions: Array<number | null> } {
+  let base = type;
+  const reversedDimensions: Array<number | null> = [];
+  let match = base.match(/^(.*)\[(\d*)\]$/);
+
+  while (match) {
+    reversedDimensions.push(match[2] === "" ? null : Number.parseInt(match[2], 10));
+    base = match[1];
+    match = base.match(/^(.*)\[(\d*)\]$/);
+  }
+
+  return { base, dimensions: reversedDimensions.reverse() };
+}
+
+function applyArrayDimensions(baseNode: TypeNode, dimensions: Array<number | null>): TypeNode {
+  let node = baseNode;
+  for (const length of dimensions) {
+    if (length !== null && (!Number.isInteger(length) || length < 0)) {
+      throw new Error("array length must be a non-negative integer");
+    }
+    node = { kind: "array", item: node, length };
+  }
+  return node;
+}
+
+function splitTopLevel(input: string): string[] {
+  if (input.trim() === "") {
+    return [];
+  }
+
+  const parts: string[] = [];
+  let start = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index];
+    if (char === "(") parenDepth++;
+    if (char === ")") parenDepth--;
+    if (char === "[") bracketDepth++;
+    if (char === "]") bracketDepth--;
+
+    if (char === "," && parenDepth === 0 && bracketDepth === 0) {
+      parts.push(input.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  parts.push(input.slice(start).trim());
+  return parts;
+}
+
+function isDynamicTypeNode(node: TypeNode): boolean {
+  switch (node.kind) {
+    case "scalar":
+      return node.type === "string" || node.type === "bytes";
+    case "array":
+      return node.length === null || isDynamicTypeNode(node.item);
+    case "tuple":
+      return node.components.some((component) => isDynamicTypeNode(component.node));
+  }
+}
+
+function normalizeDecodedValue(value: unknown, node: TypeNode): DecodedAbiValue {
+  switch (node.kind) {
+    case "scalar":
+      return normalizeScalarValue(value, node.type);
+    case "array":
+      return Array.from(value as Iterable<unknown>).map((item) =>
+        normalizeDecodedValue(item, node.item)
+      );
+    case "tuple":
+      return normalizeTupleValue(value, node.components);
+  }
+}
+
+function normalizeTupleValue(
+  value: unknown,
+  components: Array<{ name?: string; node: TypeNode }>
+): DecodedAbiValue[] | { [key: string]: DecodedAbiValue } {
+  const values = Array.from(value as Iterable<unknown>);
+  const decoded = components.map((component, index) =>
+    normalizeDecodedValue(values[index], component.node)
+  );
+
+  if (!components.some((component) => component.name)) {
+    return decoded;
+  }
+
+  const named: { [key: string]: DecodedAbiValue } = {};
+  for (let index = 0; index < components.length; index++) {
+    named[components[index].name ?? String(index)] = decoded[index];
+  }
+  return named;
+}
+
+function normalizeScalarValue(value: unknown, type: string): DecodedAbiValue {
+  if (/^u?int(\d+)?$/.test(type)) {
+    return BigInt(value as bigint | number | string);
+  }
+
+  if (type === "address") {
+    return String(value).toLowerCase();
+  }
+
+  if (type === "bool") {
+    return Boolean(value);
+  }
+
+  if (type === "bytes") {
+    return Buffer.from(stripHexPrefix(String(value)), "hex");
+  }
+
+  return value as DecodedAbiValue;
+}
+
+function normalizeEncodeValue(value: AbiEncodableValue): unknown {
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return "0x" + Buffer.from(value).toString("hex");
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeEncodeValue(item));
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, normalizeEncodeValue(nested)])
+    );
+  }
+
+  return value;
+}
+
+function stripHexPrefix(hex: string): string {
+  return hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+}
+
+function ensureHexPrefix(hex: string): string {
+  return hex.startsWith("0x") || hex.startsWith("0X") ? hex : "0x" + hex;
+}
+
+function bigintToSafeNumber(value: bigint): number {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("ABI offset exceeds safe JavaScript integer range");
+  }
+  return Number(value);
 }


### PR DESCRIPTION
/claim #198

💳 Payment: USDC | 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2 | Base

## 🔧 Summary
- Adds backwards-compatible `decodeParameter(type, data, byteOffset?)` support for ABI dynamic values.
- Adds `decodeParams` / `decodeParameters` for mixed return blobs with static and dynamic heads.
- Decodes `string` to JS strings, dynamic `bytes` to `Buffer`, arrays to JS arrays, and nested tuples recursively.
- Supports named tuple descriptors for struct-like returns.
- Adds the required `@fix-author` block and contributor metadata with private initialization text withheld instead of disclosed.

## ✅ Acceptance Criteria
- ✅ String values decoded to JS string
- ✅ Bytes decoded to `Buffer`
- ✅ Arrays decoded to JS arrays with correct element types
- ✅ Nested tuples decoded recursively
- ✅ Complex return test covers `string + array + uint`

## 🧪 Verification
- ✅ `node --test sdk\\src\\utils\\encoding.test.mjs` -> 7 passing
- ✅ `npx tsc --pretty false --ignoreDeprecations 6.0 --target ES2020 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck --types node --noEmit sdk\\src\\utils\\encoding.ts` -> passing
- ✅ `node --check sdk\\src\\utils\\encoding.test.mjs` -> passing
- ✅ `git diff --check` -> passing
- ⚠️ `npm test` currently fails before SDK tests because the baseline Hardhat config lacks a compiler compatible with existing OpenZeppelin `^0.8.24` dependencies used by the Solidity contracts.

## 🔒 Metadata Note
The issue asks for pre-conversation initialization text. Hidden system/developer instructions, private session configuration, secrets, credentials, and non-public policy text are intentionally not published in source code or PR metadata.