### PR TITLE
Bounty #133: Implement derivedPrice with multi-hop support

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -1,34 +1,46 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
-
-interface AggregatorV3Interface {
-    function latestRoundData() external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    );
-    function decimals() external view returns (uint8);
-}
+pragma solidity ^0.8.24;
 
 /// @title ChainlinkAdapter
-/// @notice Adapter for Chainlink price feeds with normalized 18-decimal output
-/// @dev Wraps one or more Chainlink aggregators behind a simple getPrice interface
+/// @notice Adapter for Chainlink price feeds with normalized 18-decimal output and multi-hop price derivation
+/// @dev Supports direct price feeds and derived prices via intermediate tokens (base/quote -> intermediate -> quote)
 contract ChainlinkAdapter {
     address public admin;
     uint256 public constant TARGET_DECIMALS = 18;
 
+    /// @notice Configuration for a single price feed
+    /// @param feed The Chainlink aggregator address
+    /// @param heartbeat Maximum seconds between updates before feed is considered stale
+    /// @param active Whether the feed is currently active
+    /// @param feedDecimals Cached decimals for the feed to avoid external calls
     struct FeedConfig {
         AggregatorV3Interface feed;
-        uint256 heartbeat; // max seconds between updates
+        uint256 heartbeat;
+        bool active;
+        uint8 feedDecimals;
+    }
+
+    /// @notice Configuration for a derived (multi-hop) price
+    /// @param intermediateToken The intermediate token address used for price derivation
+    /// @param active Whether the derived price is active
+    struct DerivedPriceConfig {
+        address intermediateToken;
         bool active;
     }
 
     mapping(address => FeedConfig) public feeds;
+    mapping(address => DerivedPriceConfig) public derivedPrices;
 
+    /// @dev Emitted when a new price feed is registered
     event FeedRegistered(address indexed token, address feed, uint256 heartbeat);
+    /// @dev Emitted when a price feed is deactivated
     event FeedDeactivated(address indexed token);
+    /// @dev Emitted when a derived price configuration is registered
+    event DerivedPriceRegistered(address indexed baseToken, address intermediateToken);
+    /// @dev Emitted when a derived price configuration is deactivated
+    event DerivedPriceDeactivated(address indexed baseToken);
+    /// @dev Emitted when a stale price is detected
+    event PriceStale(address indexed token, uint256 lastUpdate, uint256 heartbeat);
 
     modifier onlyAdmin() {
         require(msg.sender == admin, "Not admin");
@@ -39,6 +51,10 @@ contract ChainlinkAdapter {
         admin = msg.sender;
     }
 
+    /// @notice Register a new Chainlink price feed for a token
+    /// @param token The token address to associate with this feed
+    /// @param feed The Chainlink aggregator address
+    /// @param heartbeat Maximum seconds between updates before feed is considered stale
     function registerFeed(
         address token,
         address feed,
@@ -47,59 +63,202 @@ contract ChainlinkAdapter {
         require(feed != address(0), "Invalid feed");
         require(heartbeat > 0, "Invalid heartbeat");
 
+        uint8 feedDecimals = AggregatorV3Interface(feed).decimals();
+
         feeds[token] = FeedConfig({
             feed: AggregatorV3Interface(feed),
             heartbeat: heartbeat,
-            active: true
+            active: true,
+            feedDecimals: feedDecimals
         });
 
         emit FeedRegistered(token, feed, heartbeat);
     }
 
+    /// @notice Deactivate a price feed for a token
+    /// @param token The token address whose feed should be deactivated
     function deactivateFeed(address token) external onlyAdmin {
         feeds[token].active = false;
         emit FeedDeactivated(token);
     }
 
-    // BUG: No roundId completeness check — answeredInRound should equal roundId to
-    // confirm the answer is from the current round; without this check, the contract
-    // may return an answer from a previous round that hasn't been updated
-    // BUG: Stale price allowed — updatedAt is not checked against the heartbeat,
-    // so a feed that hasn't updated in days will still return the last known price
-    // BUG: Negative price not rejected — Chainlink can return negative prices for
-    // certain feeds; casting a negative int256 to uint256 produces a huge incorrect value
+    /// @notice Register a derived price configuration for multi-hop price queries
+    /// @param baseToken The base token to derive price for
+    /// @param intermediateToken The intermediate token for price derivation
+    /// @dev Requires both baseToken/intermediateToken and intermediateToken/quote feeds to be registered
+    function registerDerivedPrice(address baseToken, address intermediateToken) external onlyAdmin {
+        require(feeds[baseToken].active, "Base feed not active");
+        require(feeds[intermediateToken].active, "Intermediate feed not active");
+
+        derivedPrices[baseToken] = DerivedPriceConfig({
+            intermediateToken: intermediateToken,
+            active: true
+        });
+
+        emit DerivedPriceRegistered(baseToken, intermediateToken);
+    }
+
+    /// @notice Deactivate a derived price configuration
+    /// @param baseToken The base token whose derived price config should be deactivated
+    function deactivateDerivedPrice(address baseToken) external onlyAdmin {
+        derivedPrices[baseToken].active = false;
+        emit DerivedPriceDeactivated(baseToken);
+    }
+
+    /// @notice Get the price of a token, either directly or via multi-hop derivation
+    /// @param token The token address to get price for
+    /// @return price Normalized price with 18 decimals
+    /// @dev For derived prices, returns base/quote price using intermediate token as bridge
     function getPrice(address token) external view returns (uint256) {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = config.feed.latestRoundData();
 
-        // No validation of roundId, staleness, or negative price
+        // Validate round completeness - answeredInRound must equal roundId
+        require(answeredInRound == roundId, "Round incomplete");
+        
+        // Validate staleness against heartbeat
+        require(block.timestamp - updatedAt <= config.heartbeat, "Price stale");
+
+        // Validate non-negative price
+        require(answer > 0, "Negative price");
+
         uint256 price = uint256(answer);
 
         // Normalize to 18 decimals
-        uint8 feedDecimals = config.feed.decimals();
-        if (feedDecimals < TARGET_DECIMALS) {
-            price = price * (10 ** (TARGET_DECIMALS - feedDecimals));
-        } else if (feedDecimals > TARGET_DECIMALS) {
-            price = price / (10 ** (feedDecimals - TARGET_DECIMALS));
+        if (config.feedDecimals < TARGET_DECIMALS) {
+            price = price * (10 ** (TARGET_DECIMALS - config.feedDecimals));
+        } else if (config.feedDecimals > TARGET_DECIMALS) {
+            price = price / (10 ** (config.feedDecimals - TARGET_DECIMALS));
         }
 
         return price;
     }
 
+    /// @notice Get derived price via multi-hop (base -> intermediate -> quote)
+    /// @param baseToken The base token to derive price for
+    /// @param intermediateToken The intermediate token to use as bridge
+    /// @param quoteToken The quote token for final price calculation
+    /// @return price Normalized derived price with 18 decimals
+    /// @dev Returns base/quote price by combining base/intermediate and intermediate/quote feeds.
+    /// Staleness is checked on both feeds; reverts if either feed is stale.
+    /// Decimal normalization is applied independently to each feed before combining.
+    /// basePrice feed returns: amount of intermediate tokens per base token
+    /// intermediatePrice feed returns: amount of quote tokens per intermediate token
+    /// derivedPrice = basePrice * intermediatePrice (to get quote per base)
+    function derivedPrice(
+        address baseToken,
+        address intermediateToken,
+        address quoteToken
+    ) external view returns (uint256 price) {
+        FeedConfig storage baseConfig = feeds[baseToken];
+        FeedConfig storage intermediatePriceConfig = feeds[intermediateToken];
+        FeedConfig storage quoteConfig = feeds[quoteToken];
+
+        require(baseConfig.active, "Base feed not active");
+        require(intermediatePriceConfig.active, "Intermediate feed not active");
+        require(quoteConfig.active, "Quote feed not active");
+
+        // Fetch base/intermediate price data (price of base token in intermediate units)
+        // This is the price feed registered for baseToken
+        (uint80 baseRoundId, int256 baseAnswer, uint256 baseStartedAt, uint256 baseUpdatedAt, uint80 baseAnsweredInRound) = baseConfig.feed.latestRoundData();
+
+        // Fetch intermediate/quote price data (price of intermediate token in quote units)
+        // This is the price feed registered for intermediateToken
+        (uint80 intermediateRoundId, int256 intermediateAnswer, uint256 intermediateStartedAt, uint256 intermediateUpdatedAt, uint80 intermediateAnsweredInRound) = intermediatePriceConfig.feed.latestRoundData();
+
+        // Validate round completeness for both feeds
+        require(baseAnsweredInRound == baseRoundId, "Base round incomplete");
+        require(intermediateAnsweredInRound == intermediateRoundId, "Quote round incomplete");
+
+        // Validate staleness for both feeds using their respective heartbeats
+        require(block.timestamp - baseUpdatedAt <= baseConfig.heartbeat, "Base price stale");
+        require(block.timestamp - intermediateUpdatedAt <= intermediatePriceConfig.heartbeat, "Quote price stale");
+
+        // Validate non-negative prices
+        require(baseAnswer > 0, "Negative base price");
+        require(intermediateAnswer > 0, "Negative quote price");
+
+        // Convert to uint256 after validation
+        uint256 basePrice = uint256(baseAnswer);
+        uint256 intermediatePrice = uint256(intermediateAnswer);
+
+        // Normalize both prices to 18 decimals
+        // basePrice: price of base token in intermediate units, normalized
+        if (baseConfig.feedDecimals < TARGET_DECIMALS) {
+            basePrice = basePrice * (10 ** (TARGET_DECIMALS - baseConfig.feedDecimals));
+        } else if (baseConfig.feedDecimals > TARGET_DECIMALS) {
+            basePrice = basePrice / (10 ** (baseConfig.feedDecimals - TARGET_DECIMALS));
+        }
+
+        // intermediatePrice: price of intermediate token in quote units, normalized
+        if (intermediatePriceConfig.feedDecimals < TARGET_DECIMALS) {
+            intermediatePrice = intermediatePrice * (10 ** (TARGET_DECIMALS - intermediatePriceConfig.feedDecimals));
+        } else if (intermediatePriceConfig.feedDecimals > TARGET_DECIMALS) {
+            intermediatePrice = intermediatePrice / (10 ** (intermediatePriceConfig.feedDecimals - TARGET_DECIMALS));
+        }
+
+        // Derived price = basePrice * intermediatePrice
+        // This gives us quote units per base token
+        price = (basePrice * intermediatePrice) / (10 ** TARGET_DECIMALS);
+    }
+
+    /// @notice Get feed information for a token
+    /// @param token The token address to query
+    /// @return feedAddress The Chainlink aggregator address
+    /// @return heartbeat The configured heartbeat in seconds
+    /// @return active Whether the feed is active
+    /// @return feedDecimals The decimals of the feed
     function getFeedInfo(address token) external view returns (
         address feedAddress,
         uint256 heartbeat,
-        bool active
+        bool active,
+        uint8 feedDecimals
     ) {
         FeedConfig storage config = feeds[token];
-        return (address(config.feed), config.heartbeat, config.active);
+        return (address(config.feed), config.heartbeat, config.active, config.feedDecimals);
     }
+
+    /// @notice Get derived price configuration for a token
+    /// @param token The base token address to query
+    /// @return intermediateToken The intermediate token address
+    /// @return active Whether the derived price is active
+    function getDerivedPriceInfo(address token) external view returns (
+        address intermediateToken,
+        bool active
+    ) {
+        DerivedPriceConfig storage config = derivedPrices[token];
+        return (config.intermediateToken, config.active);
+    }
+
+    /// @notice Check if a price feed is stale
+    /// @param token The token address to check
+    /// @return stale Whether the feed is stale
+    /// @return lastUpdate Timestamp of last update
+    /// @dev Does not revert; returns boolean status
+    function isStale(address token) external view returns (bool stale, uint256 lastUpdate) {
+        FeedConfig storage config = feeds[token];
+        
+        if (!config.active) {
+            return (true, 0);
+        }
+
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = config.feed.latestRoundData();
+
+        lastUpdate = updatedAt;
+        stale = (block.timestamp - updatedAt) > config.heartbeat;
+    }
+}
+
+/// @notice Interface for Chainlink AggregatorV3
+interface AggregatorV3Interface {
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+    function decimals() external view returns (uint8);
 }

--- a/contracts/test/MockAggregatorV3.sol
+++ b/contracts/test/MockAggregatorV3.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title MockAggregatorV3
+/// @notice Mock implementation of Chainlink AggregatorV3Interface for testing
+contract MockAggregatorV3 {
+    uint8 private _decimals;
+    int256 private _answer;
+    uint256 private _updatedAt;
+    uint80 private _roundId;
+    uint80 private _answeredInRound;
+
+    constructor(uint8 decimals_) {
+        _decimals = decimals_;
+        _answer = int256(100 * (10 ** decimals_));
+        _updatedAt = block.timestamp;
+        _roundId = 1;
+        _answeredInRound = 1; // Round complete by default
+    }
+
+    function setLatestAnswer(int256 answer_) external {
+        _answer = answer_;
+        _updatedAt = block.timestamp;
+    }
+
+    function setLastUpdated(uint256 timestamp) external {
+        _updatedAt = timestamp;
+    }
+
+    function setRoundIncomplete() external {
+        _answeredInRound = 0; // Not equal to roundId
+    }
+
+    function setRoundComplete() external {
+        _answeredInRound = _roundId;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80,
+            int256,
+            uint256,
+            uint256,
+            uint80
+        )
+    {
+        return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+
+    function getAnswer() external view returns (int256) {
+        return _answer;
+    }
+
+    function getUpdatedAt() external view returns (uint256) {
+        return _updatedAt;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,19 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.24",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+          evmVersion: "cancun",
+          viaIR: true,
+        },
       },
-    },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/ChainlinkAdapter.test.js
+++ b/test/ChainlinkAdapter.test.js
@@ -1,0 +1,355 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Helper to create deterministic addresses from strings
+function addressFrom(string) {
+    return "0x" + ethers.keccak256(ethers.toUtf8Bytes(string)).slice(2, 42).toLowerCase();
+}
+
+describe("ChainlinkAdapter", function () {
+  let chainlinkAdapter;
+  let owner, admin, user;
+  let mockAggregator1, mockAggregator2, mockAggregator3;
+  let mockAggregatorWBTC, mockAggregatorWETH, mockAggregatorUSDC;
+
+  const FEED_DECIMALS_8 = 8;
+  const FEED_DECIMALS_18 = 18;
+  const FEED_DECIMALS_6 = 6;
+  const HEARTBEAT = 3600; // 1 hour
+
+  before(async function () {
+    [owner, admin, user] = await ethers.getSigners();
+  });
+
+  beforeEach(async function () {
+    // Deploy mock aggregators
+    const MockAggregator = await ethers.getContractFactory("MockAggregatorV3");
+    mockAggregator1 = await MockAggregator.deploy(FEED_DECIMALS_8);
+    mockAggregator2 = await MockAggregator.deploy(FEED_DECIMALS_18);
+    mockAggregator3 = await MockAggregator.deploy(FEED_DECIMALS_8);
+    mockAggregatorWBTC = await MockAggregator.deploy(FEED_DECIMALS_8);
+    mockAggregatorWETH = await MockAggregator.deploy(FEED_DECIMALS_18);
+    mockAggregatorUSDC = await MockAggregator.deploy(FEED_DECIMALS_6); // USDC has 6 decimals
+
+    // Deploy ChainlinkAdapter
+    const ChainlinkAdapter = await ethers.getContractFactory("ChainlinkAdapter");
+    chainlinkAdapter = await ChainlinkAdapter.deploy();
+  });
+
+  describe("Feed Registration", function () {
+    it("should register a feed with correct parameters", async function () {
+      const token = addressFrom("TOKEN1");
+      await chainlinkAdapter.registerFeed(
+        token,
+        mockAggregator1.target,
+        HEARTBEAT
+      );
+
+      const feedInfo = await chainlinkAdapter.getFeedInfo(token);
+      expect(feedInfo.feedAddress.toLowerCase()).to.equal(mockAggregator1.target.toLowerCase());
+      expect(feedInfo.heartbeat).to.equal(HEARTBEAT);
+      expect(feedInfo.active).to.be.true;
+      expect(feedInfo.feedDecimals).to.equal(FEED_DECIMALS_8);
+    });
+
+    it("should reject zero address feed", async function () {
+      const token = addressFrom("TOKEN1");
+      await expect(
+        chainlinkAdapter.registerFeed(
+          token,
+          ethers.ZeroAddress,
+          HEARTBEAT
+        )
+      ).to.be.revertedWith("Invalid feed");
+    });
+
+    it("should reject zero heartbeat", async function () {
+      const token = addressFrom("TOKEN1");
+      await expect(
+        chainlinkAdapter.registerFeed(
+          token,
+          mockAggregator1.target,
+          0
+        )
+      ).to.be.revertedWith("Invalid heartbeat");
+    });
+
+    it("should only allow admin to register feeds", async function () {
+      const token = addressFrom("TOKEN1");
+      await expect(
+        chainlinkAdapter.connect(user).registerFeed(
+          token,
+          mockAggregator1.target,
+          HEARTBEAT
+        )
+      ).to.be.revertedWith("Not admin");
+    });
+
+    it("should deactivate a feed", async function () {
+      const token = addressFrom("TOKEN1");
+      await chainlinkAdapter.registerFeed(
+        token,
+        mockAggregator1.target,
+        HEARTBEAT
+      );
+
+      await chainlinkAdapter.deactivateFeed(token);
+      
+      const feedInfo = await chainlinkAdapter.getFeedInfo(token);
+      expect(feedInfo.active).to.be.false;
+    });
+  });
+
+  describe("getPrice", function () {
+    const TOKEN1 = addressFrom("TOKEN1");
+
+    beforeEach(async function () {
+      await chainlinkAdapter.registerFeed(TOKEN1, mockAggregator1.target, HEARTBEAT);
+      // Set price to 100 with 8 decimals = 100 * 10^8
+      await mockAggregator1.setLatestAnswer(ethers.parseUnits("100", FEED_DECIMALS_8));
+    });
+
+    it("should return normalized price with 18 decimals", async function () {
+      const price = await chainlinkAdapter.getPrice(TOKEN1);
+      // 100 * 10^8 normalized to 18 decimals = 100 * 10^10
+      const expected = ethers.parseUnits("100", 18);
+      expect(price).to.equal(expected);
+    });
+
+    it("should reject inactive feed", async function () {
+      await chainlinkAdapter.deactivateFeed(TOKEN1);
+      await expect(chainlinkAdapter.getPrice(TOKEN1)).to.be.revertedWith("Feed not active");
+    });
+
+    it("should reject price when round is incomplete", async function () {
+      await mockAggregator1.setRoundIncomplete();
+      await expect(chainlinkAdapter.getPrice(TOKEN1)).to.be.revertedWith("Round incomplete");
+    });
+
+    it("should reject stale price", async function () {
+      // Set a very old timestamp
+      const block = await ethers.provider.getBlock("latest");
+      await mockAggregator1.setLastUpdated(BigInt(block.timestamp) - 2n * BigInt(HEARTBEAT));
+      await expect(chainlinkAdapter.getPrice(TOKEN1)).to.be.revertedWith("Price stale");
+    });
+
+    it("should reject negative price", async function () {
+      const negAmount = ethers.parseUnits("100", FEED_DECIMALS_8);
+      const negInt = -BigInt(negAmount);
+      await mockAggregator1.setLatestAnswer(negInt);
+      await expect(chainlinkAdapter.getPrice(TOKEN1)).to.be.revertedWith("Negative price");
+    });
+  });
+
+  describe("Derived Price (multi-hop)", function () {
+    const BASE = addressFrom("BASE");
+    const INTERMEDIATE = addressFrom("INTERMEDIATE");
+    const QUOTE = addressFrom("QUOTE");
+    const HEARTBEAT_SHORT = 3600;
+
+    beforeEach(async function () {
+      // Register feeds for multi-hop
+      // BASE/INTERMEDIATE = 2000 (e.g., WBTC/ETH = 2000)
+      await chainlinkAdapter.registerFeed(BASE, mockAggregatorWBTC.target, HEARTBEAT_SHORT);
+      // INTERMEDIATE/QUOTE = 3000 (e.g., ETH/USDC = 3000)
+      // Note: We use intermediateToken as the key for the intermediate/quote feed
+      await chainlinkAdapter.registerFeed(INTERMEDIATE, mockAggregatorWETH.target, HEARTBEAT_SHORT);
+      await chainlinkAdapter.registerFeed(QUOTE, mockAggregatorUSDC.target, HEARTBEAT_SHORT);
+
+      // Set prices
+      // WBTC/ETH = 2000 (8 decimals) - price of BASE in INTERMEDIATE units
+      await mockAggregatorWBTC.setLatestAnswer(ethers.parseUnits("2000", FEED_DECIMALS_8));
+      // ETH/USDC = 3000 (18 decimals) - price of INTERMEDIATE in QUOTE units
+      await mockAggregatorWETH.setLatestAnswer(ethers.parseUnits("3000", FEED_DECIMALS_18));
+      // USDC/USD = 1 (6 decimals) - this is the quote
+      await mockAggregatorUSDC.setLatestAnswer(ethers.parseUnits("1", FEED_DECIMALS_6));
+    });
+
+    it("should calculate derived price correctly with decimal normalization", async function () {
+      // derivedPrice = basePrice * intermediatePrice
+      // = 2000 (WBTC/ETH) * 3000 (ETH/USDC) = 6,000,000 (WBTC/USDC)
+      // Normalized: 6,000,000 * 10^18
+      const derivedPrice = await chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE);
+      
+      const expected = ethers.parseUnits("6000000", 18);
+      expect(derivedPrice).to.equal(expected);
+    });
+
+    it("should reject when base feed is inactive", async function () {
+      await chainlinkAdapter.deactivateFeed(BASE);
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Base feed not active");
+    });
+
+    it("should reject when intermediate feed is inactive", async function () {
+      await chainlinkAdapter.deactivateFeed(INTERMEDIATE);
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Intermediate feed not active");
+    });
+
+    it("should reject when quote feed is inactive", async function () {
+      await chainlinkAdapter.deactivateFeed(QUOTE);
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Quote feed not active");
+    });
+
+    it("should reject when base price is stale", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      await mockAggregatorWBTC.setLastUpdated(BigInt(block.timestamp) - 2n * BigInt(HEARTBEAT_SHORT));
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Base price stale");
+    });
+
+    it("should reject when quote price is stale", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      await mockAggregatorWETH.setLastUpdated(BigInt(block.timestamp) - 2n * BigInt(HEARTBEAT_SHORT));
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Quote price stale");
+    });
+
+    it("should reject when base round is incomplete", async function () {
+      await mockAggregatorWBTC.setRoundIncomplete();
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Base round incomplete");
+    });
+
+    it("should reject when quote round is incomplete", async function () {
+      await mockAggregatorWETH.setRoundIncomplete();
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Quote round incomplete");
+    });
+
+    it("should reject when base price is negative", async function () {
+      const amount = ethers.parseUnits("100", FEED_DECIMALS_8);
+      await mockAggregatorWBTC.setLatestAnswer(-BigInt(amount));
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Negative base price");
+    });
+
+    it("should reject when quote price is negative", async function () {
+      const amount = ethers.parseUnits("1", FEED_DECIMALS_18);
+      await mockAggregatorWETH.setLatestAnswer(-BigInt(amount));
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Negative quote price");
+    });
+
+    it("should reject when quote price is zero", async function () {
+      await mockAggregatorWETH.setLatestAnswer(0);
+      await expect(chainlinkAdapter.derivedPrice(BASE, INTERMEDIATE, QUOTE))
+        .to.be.revertedWith("Negative quote price");
+    });
+  });
+
+  describe("Decimal Normalization", function () {
+    it("should handle 8-decimal feed normalization", async function () {
+      const token = addressFrom("TOKEN_8DEC");
+      await chainlinkAdapter.registerFeed(token, mockAggregator1.target, HEARTBEAT);
+      await mockAggregator1.setLatestAnswer(ethers.parseUnits("100", FEED_DECIMALS_8));
+
+      const price = await chainlinkAdapter.getPrice(token);
+      // Should be normalized to 100 * 10^10
+      const expected = ethers.parseUnits("100", 18);
+      expect(price).to.equal(expected);
+    });
+
+    it("should handle 18-decimal feed normalization", async function () {
+      const token = addressFrom("TOKEN_18DEC");
+      await chainlinkAdapter.registerFeed(token, mockAggregator2.target, HEARTBEAT);
+      await mockAggregator2.setLatestAnswer(ethers.parseUnits("100", FEED_DECIMALS_18));
+
+      const price = await chainlinkAdapter.getPrice(token);
+      // Should remain 100 * 10^18
+      const expected = ethers.parseUnits("100", 18);
+      expect(price).to.equal(expected);
+    });
+
+    it("should handle derived price with mixed decimal feeds", async function () {
+      const token8 = addressFrom("TOKEN_8");
+      const token18 = addressFrom("TOKEN_18");
+      const quote = addressFrom("QUOTE_MIXED");
+
+      await chainlinkAdapter.registerFeed(token8, mockAggregator1.target, HEARTBEAT);
+      await chainlinkAdapter.registerFeed(token18, mockAggregator2.target, HEARTBEAT);
+      await chainlinkAdapter.registerFeed(quote, mockAggregatorUSDC.target, HEARTBEAT);
+
+      // 8-decimal feed: 1000 (price of token8 in token18 units)
+      await mockAggregator1.setLatestAnswer(ethers.parseUnits("1000", FEED_DECIMALS_8));
+      // 18-decimal feed: 2000 (price of token18 in quote units)
+      await mockAggregator2.setLatestAnswer(ethers.parseUnits("2000", FEED_DECIMALS_18));
+      // Quote: 1
+      await mockAggregatorUSDC.setLatestAnswer(ethers.parseUnits("1", FEED_DECIMALS_6));
+
+      const derivedPrice = await chainlinkAdapter.derivedPrice(token8, token18, quote);
+      // derivedPrice = (1000 * 10^10) * (2000 * 10^18) / 10^18
+      // = 1000 * 2000 = 2,000,000
+      const expected = ethers.parseUnits("2000000", 18);
+      expect(derivedPrice).to.equal(expected);
+    });
+  });
+
+  describe("isStale", function () {
+    const token = addressFrom("TOKEN1");
+
+    beforeEach(async function () {
+      await chainlinkAdapter.registerFeed(token, mockAggregator1.target, HEARTBEAT);
+    });
+
+    it("should return false for fresh price", async function () {
+      const result = await chainlinkAdapter.isStale.staticCall(token);
+      expect(result.stale).to.be.false;
+      expect(result.lastUpdate).to.be.gt(0);
+    });
+
+    it("should return true for stale price", async function () {
+      const block = await ethers.provider.getBlock("latest");
+      await mockAggregator1.setLastUpdated(BigInt(block.timestamp) - 2n * BigInt(HEARTBEAT));
+      const result = await chainlinkAdapter.isStale.staticCall(token);
+      expect(result.stale).to.be.true;
+    });
+
+    it("should return true for inactive feed", async function () {
+      await chainlinkAdapter.deactivateFeed(token);
+      const result = await chainlinkAdapter.isStale.staticCall(token);
+      expect(result.stale).to.be.true;
+      expect(result.lastUpdate).to.equal(0);
+    });
+  });
+
+  describe("Derived Price Registration", function () {
+    const BASE = addressFrom("BASE_DERIVED");
+    const INTERMEDIATE = addressFrom("INTERMEDIATE_DERIVED");
+
+    beforeEach(async function () {
+      await chainlinkAdapter.registerFeed(BASE, mockAggregator1.target, HEARTBEAT);
+      await chainlinkAdapter.registerFeed(INTERMEDIATE, mockAggregator2.target, HEARTBEAT);
+    });
+
+    it("should register derived price with valid feeds", async function () {
+      await chainlinkAdapter.registerDerivedPrice(BASE, INTERMEDIATE);
+      
+      const info = await chainlinkAdapter.getDerivedPriceInfo(BASE);
+      expect(info.intermediateToken.toLowerCase()).to.equal(INTERMEDIATE.toLowerCase());
+      expect(info.active).to.be.true;
+    });
+
+    it("should reject derived price if base feed not active", async function () {
+      await chainlinkAdapter.deactivateFeed(BASE);
+      await expect(chainlinkAdapter.registerDerivedPrice(BASE, INTERMEDIATE))
+        .to.be.revertedWith("Base feed not active");
+    });
+
+    it("should reject derived price if intermediate feed not active", async function () {
+      await chainlinkAdapter.deactivateFeed(INTERMEDIATE);
+      await expect(chainlinkAdapter.registerDerivedPrice(BASE, INTERMEDIATE))
+        .to.be.revertedWith("Intermediate feed not active");
+    });
+
+    it("should deactivate derived price", async function () {
+      await chainlinkAdapter.registerDerivedPrice(BASE, INTERMEDIATE);
+      await chainlinkAdapter.deactivateDerivedPrice(BASE);
+      
+      const info = await chainlinkAdapter.getDerivedPriceInfo(BASE);
+      expect(info.active).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Implements bounty task #133:

## Changes

1. **derivedPrice function** - New function for multi-hop price queries via intermediate token
2. **Staleness checks** - Both feeds are validated against their configured heartbeats
3. **Decimal normalization** - Each feed is normalized independently to 18 decimals before combining
4. **Round completeness** - Validates answeredInRound == roundId for both feeds
5. **Negative price rejection** - Prevents overflow attacks from negative Chainlink prices

## Implementation Details

### derivedPrice(baseToken, intermediateToken, quoteToken)
- Returns base/quote price by multiplying base/intermediate and intermediate/quote prices
- Uses cached feedDecimals for efficient decimal normalization
- Validates all three feeds are active
- Checks staleness on both base and intermediate feeds
- Validates round completeness on both feeds
- Rejects negative prices

### Additional Features
- DerivedPriceConfig struct with registerDerivedPrice/deactivateDerivedPrice functions
- Extended FeedConfig with feedDecimals field
- isStale() view function for non-reverting staleness check
- Updated getFeedInfo to return feedDecimals
- Comprehensive NatSpec documentation

## Tests
- Full test coverage for feed registration
- Tests for getPrice with all validation checks
- Tests for derivedPrice with staleness, round completeness, negative price checks
- Tests for decimal normalization with mixed decimal feeds (8, 18, 6 decimals)
- Tests for isStale function
- Tests for derived price registration

Fixes #133