### PR TITLE
fix: add migrateToken function to VestingWallet (fixes #128)

### DIFF
--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+// =============================================================================
+// Contributor: douxin666
+// Platform: Hermes Agent (Nous Research)
+// Runtime: Windows 10, x86_64, bash (MSYS), Python 3.11
+// Task: Implement migrateToken for VestingWallet (Issue #128)
+// =============================================================================
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -25,6 +25,7 @@ contract VestingWallet {
 
     event TokensReleased(address indexed beneficiary, uint256 amount);
     event VestingRevoked(address indexed token, uint256 refund);
+    event TokenMigrated(address indexed oldToken, address indexed newToken, uint256 remainingAmount);
 
     // BUG: No zero-address validation on beneficiary — if beneficiary is set to
     // address(0), all vested tokens are sent to the zero address (burned) on release.
@@ -95,6 +96,24 @@ contract VestingWallet {
 
         token.safeTransfer(owner, refund);
         emit VestingRevoked(address(token), refund);
+    }
+
+
+    /// @notice Migrate to a new token address (e.g., after a token upgrade).
+    /// @param newToken The address of the new token contract.
+    function migrateToken(address newToken) external {
+        require(msg.sender == owner, "Vesting: not owner");
+        require(newToken != address(0), "Vesting: zero address");
+        require(newToken != address(token), "Vesting: same token");
+
+        uint256 remaining = totalAllocation - released;
+        uint256 newBalance = IERC20(newToken).balanceOf(address(this));
+        require(newBalance >= remaining, "Vesting: insufficient new token balance");
+
+        address oldToken = address(token);
+        token = IERC20(newToken);
+
+        emit TokenMigrated(oldToken, newToken, remaining);
     }
 
     /// @notice Get the releasable (vested but not yet released) token amount.


### PR DESCRIPTION
## Summary
Implements #128

Adds `migrateToken(address newToken)` owner function to handle token contract upgrades.

### Changes
- Add `TokenMigrated` event
- Add `migrateToken()` with new token balance verification
- Owner-only access
- Validates: non-zero address, different token, sufficient balance

### Testing
- Owner can migrate to new token
- Reverts on zero address
- Reverts on same token
- Reverts on non-owner call