### PR TITLE
fix: Replace onlyValidator with onlyOwner and enforce governance in BridgeValidator

### DIFF
--- a/contracts/bridge/BridgeValidator.sol
+++ b/contracts/bridge/BridgeValidator.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/**
+ * @contributor Hermes Agent
+ * @platform-config (Standard Hermes Autonomy Mode Configuration)
+ * @env Linux, amd64, /home/Artur, /home/Artur/OpenAgents, bash
+ * @timestamp 2026-06-16
+ */
+
 /// @title BridgeValidator
 /// @notice Manages the validator set for a cross-chain bridge protocol.
 /// @dev Validators are assigned weights; consensus requires a threshold of total weight.
@@ -41,12 +48,12 @@ contract BridgeValidator {
     /// @notice Add a new validator with a given weight.
     /// @param validator Address of the new validator.
     /// @param weight Voting weight assigned to the validator.
-    // BUG: Validators can add themselves — the onlyValidator modifier allows any
-    // existing validator to add new validators (including themselves again with
-    // more weight), bypassing owner governance over the validator set.
-    function addValidator(address validator, uint128 weight) external onlyValidator {
+    function addValidator(address validator, uint128 weight) external onlyOwner {
         require(!validators[validator].isActive, "BridgeValidator: already active");
         require(weight > 0, "BridgeValidator: zero weight");
+        
+        // Bound weight to prevent overflow/meaningless thresholds
+        require(weight <= 1e18, "BridgeValidator: weight too high");
 
         validators[validator] = Validator({
             isActive: true,
@@ -54,10 +61,6 @@ contract BridgeValidator {
             addedAt: block.timestamp
         });
 
-        // BUG: Weight overflow — totalWeight is uint256 but weight is uint128.
-        // However, repeated additions without removals can push totalWeight past
-        // the point where threshold checks become meaningless (totalWeight wraps
-        // or becomes so large that threshold ratio breaks).
         totalWeight += weight;
         validatorList.push(validator);
 
@@ -66,10 +69,9 @@ contract BridgeValidator {
 
     /// @notice Remove a validator from the active set.
     /// @param validator Address to remove.
-    // BUG: No minimum validator count check — validators can be removed until the
-    // set is empty, bricking the bridge since no one can sign transactions.
     function removeValidator(address validator) external onlyOwner {
         require(validators[validator].isActive, "BridgeValidator: not active");
+        require(validatorList.length > 3, "BridgeValidator: minimum 3 validators required");
 
         totalWeight -= validators[validator].weight;
         validators[validator].isActive = false;
@@ -84,6 +86,7 @@ contract BridgeValidator {
     function updateWeight(address validator, uint128 newWeight) external onlyOwner {
         require(validators[validator].isActive, "BridgeValidator: not active");
         require(newWeight > 0, "BridgeValidator: zero weight");
+        require(newWeight <= 1e18, "BridgeValidator: weight too high");
 
         uint128 oldWeight = validators[validator].weight;
         totalWeight = totalWeight - oldWeight + newWeight;
@@ -125,6 +128,7 @@ contract BridgeValidator {
     function bootstrap(address validator, uint128 weight) external onlyOwner {
         require(validatorList.length == 0, "BridgeValidator: already bootstrapped");
         require(weight > 0, "BridgeValidator: zero weight");
+        require(weight <= 1e18, "BridgeValidator: weight too high");
         validators[validator] = Validator({ isActive: true, weight: weight, addedAt: block.timestamp });
         totalWeight += weight;
         validatorList.push(validator);


### PR DESCRIPTION
This PR replaces the  modifier with  in  to prevent validator self-addition. It also enforces a minimum of 3 validators upon removal and bounds the validator weight to prevent overflow/manipulation.