### PR TITLE
fix(staking): MultiTokenStaking — poolExists guard, setPoolAllocPoint, overflow safety

### DIFF
--- a/contracts/oracle/ChainlinkAdapter.sol
+++ b/contracts/oracle/ChainlinkAdapter.sol
@@ -72,13 +72,9 @@ contract ChainlinkAdapter {
         FeedConfig storage config = feeds[token];
         require(config.active, "Feed not active");
 
-        (
-            uint80 /* roundId */,
-            int256 answer,
-            /* uint256 startedAt */,
-            uint256 /* updatedAt */,
-            uint80 /* answeredInRound */
-        ) = config.feed.latestRoundData();
+        (uint80 roundId, int256 answer, , uint256 updatedAt, uint80 answeredInRound) = config.feed.latestRoundData();
+        // Silence unused variables
+        roundId; updatedAt; answeredInRound;
 
         // No validation of roundId, staleness, or negative price
         uint256 price = uint256(answer);

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -30,10 +30,13 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     uint256 public rewardPerSecond;
     uint256 public totalAllocPoint;
 
+    mapping(address => bool) public poolExists;
+
     PoolInfo[] public poolInfo;
     mapping(uint256 => mapping(address => UserInfo)) public userInfo;
 
     event PoolAdded(uint256 indexed pid, address token, uint256 allocPoint);
+    event PoolUpdated(uint256 indexed pid, uint256 oldAllocPoint, uint256 newAllocPoint);
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
@@ -48,10 +51,10 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     /// @notice Add a new staking pool.
     /// @param _allocPoint Allocation weight for reward distribution.
     /// @param _stakeToken The ERC20 token to be staked in this pool.
-    // BUG: No duplicate token check — the same token can be added multiple times,
-    // causing reward accounting to break as totalAllocPoint inflates and existing
-    // stakers in the original pool get diluted unexpectedly.
     function addPool(uint256 _allocPoint, address _stakeToken) external onlyOwner {
+        require(_stakeToken != address(0), "Zero address");
+        require(!poolExists[_stakeToken], "Pool exists");
+        poolExists[_stakeToken] = true;
         totalAllocPoint += _allocPoint;
         poolInfo.push(PoolInfo({
             stakeToken: IERC20(_stakeToken),
@@ -61,6 +64,17 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
             totalStaked: 0
         }));
         emit PoolAdded(poolInfo.length - 1, _stakeToken, _allocPoint);
+    }
+
+    /// @notice Update the allocation weight of an existing pool.
+    /// @param pid Pool ID to update.
+    /// @param _allocPoint New allocation weight.
+    function setPoolAllocPoint(uint256 pid, uint256 _allocPoint) external onlyOwner {
+        PoolInfo storage pool = poolInfo[pid];
+        require(address(pool.stakeToken) != address(0), "Pool not exist");
+        emit PoolUpdated(pid, pool.allocPoint, _allocPoint);
+        totalAllocPoint = totalAllocPoint - pool.allocPoint + _allocPoint;
+        pool.allocPoint = _allocPoint;
     }
 
     /// @notice Update reward variables for a given pool.
@@ -75,10 +89,10 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
 
         uint256 elapsed = block.timestamp - pool.lastRewardTime;
-        // BUG: Reward calculation can overflow for large elapsed * rewardPerSecond * allocPoint
-        // values. With high rewardPerSecond (e.g., 1e18) and long time gaps, the intermediate
-        // multiplication exceeds uint256 before the division by totalAllocPoint.
-        uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
+        // BUGFIX: Reorder multiplication to reduce overflow risk.
+        // Using (elapsed * pool.allocPoint / totalAllocPoint) * rewardPerSecond
+        // limits intermediate value since pool.allocPoint <= totalAllocPoint.
+        uint256 reward = elapsed * pool.allocPoint / totalAllocPoint * rewardPerSecond;
         pool.accRewardPerShare += reward * 1e12 / pool.totalStaked;
         pool.lastRewardTime = block.timestamp;
     }
@@ -139,7 +153,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         uint256 accRewardPerShare = pool.accRewardPerShare;
         if (block.timestamp > pool.lastRewardTime && pool.totalStaked > 0) {
             uint256 elapsed = block.timestamp - pool.lastRewardTime;
-            uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
+            uint256 reward = elapsed * pool.allocPoint / totalAllocPoint * rewardPerSecond;
             accRewardPerShare += reward * 1e12 / pool.totalStaked;
         }
         return user.amount * accRewardPerShare / 1e12 - user.rewardDebt;

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+        _mint(msg.sender, 1_000_000 * 10 ** decimals());
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,22 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: { enabled: true, runs: 200 },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          evmVersion: "cancun",
+          viaIR: true,
+          optimizer: { enabled: true, runs: 200 },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/MultiTokenStaking.test.js
+++ b/test/MultiTokenStaking.test.js
@@ -1,0 +1,195 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("MultiTokenStaking", function () {
+  let staking, tokenA, tokenB, rewardToken;
+  let owner, user1, user2;
+
+  beforeEach(async function () {
+    [owner, user1, user2] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    tokenA = await MockERC20.deploy("Token A", "TKA");
+    tokenB = await MockERC20.deploy("Token B", "TKB");
+    rewardToken = await MockERC20.deploy("Reward", "RWD");
+
+    const MultiTokenStaking = await ethers.getContractFactory("MultiTokenStaking");
+    staking = await MultiTokenStaking.deploy(rewardToken.target, ethers.parseEther("1"));
+  });
+
+  describe("addPool", function () {
+    it("should add a pool", async function () {
+      await staking.addPool(100, tokenA.target);
+      const pool = await staking.poolInfo(0);
+      expect(pool.stakeToken).to.equal(tokenA.target);
+      expect(pool.allocPoint).to.equal(100);
+      expect(pool.totalStaked).to.equal(0);
+    });
+
+    it("should reject zero address", async function () {
+      await expect(staking.addPool(100, ethers.ZeroAddress))
+        .to.be.revertedWith("Zero address");
+    });
+
+    it("should reject duplicate token", async function () {
+      await staking.addPool(100, tokenA.target);
+      await expect(staking.addPool(50, tokenA.target))
+        .to.be.revertedWith("Pool exists");
+    });
+
+    it("should track totalAllocPoint", async function () {
+      await staking.addPool(100, tokenA.target);
+      await staking.addPool(200, tokenB.target);
+      expect(await staking.totalAllocPoint()).to.equal(300);
+    });
+
+    it("should only allow owner to add pool", async function () {
+      await expect(staking.connect(user1).addPool(100, tokenA.target))
+        .to.be.revertedWithCustomError(staking, "OwnableUnauthorizedAccount");
+    });
+  });
+
+  describe("setPoolAllocPoint", function () {
+    beforeEach(async function () {
+      await staking.addPool(100, tokenA.target);
+      await staking.addPool(200, tokenB.target);
+    });
+
+    it("should update allocPoint and totalAllocPoint", async function () {
+      await staking.setPoolAllocPoint(0, 300);
+      const pool = await staking.poolInfo(0);
+      expect(pool.allocPoint).to.equal(300);
+      expect(await staking.totalAllocPoint()).to.equal(500);
+    });
+
+    it("should only allow owner", async function () {
+      await expect(staking.connect(user1).setPoolAllocPoint(0, 50))
+        .to.be.revertedWithCustomError(staking, "OwnableUnauthorizedAccount");
+    });
+
+    it("should emit PoolUpdated event", async function () {
+      await expect(staking.setPoolAllocPoint(0, 300))
+        .to.emit(staking, "PoolUpdated")
+        .withArgs(0, 100, 300);
+    });
+  });
+
+  describe("deposit", function () {
+    beforeEach(async function () {
+      await staking.addPool(100, tokenA.target);
+      await tokenA.transfer(user1.address, ethers.parseEther("1000"));
+      await tokenA.connect(user1).approve(staking.target, ethers.parseEther("100"));
+    });
+
+    it("should stake tokens", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("100"));
+      const userInfo = await staking.userInfo(0, user1.address);
+      expect(userInfo.amount).to.equal(ethers.parseEther("100"));
+    });
+
+    it("should increase totalStaked", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("100"));
+      const pool = await staking.poolInfo(0);
+      expect(pool.totalStaked).to.equal(ethers.parseEther("100"));
+    });
+
+    it("should harvest pending rewards on second deposit", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("100"));
+      // Fund reward token to contract
+      await rewardToken.transfer(staking.target, ethers.parseEther("100000"));
+      // Advance time so rewards accrue (will trigger updatePool on next deposit)
+      await ethers.provider.send("evm_increaseTime", [3600]);
+      await ethers.provider.send("evm_mine");
+      // Second deposit triggers harvest
+      await expect(staking.connect(user1).deposit(0, ethers.parseEther("0")))
+        .to.emit(staking, "Harvest");
+    });
+  });
+
+  describe("withdraw", function () {
+    beforeEach(async function () {
+      await staking.addPool(100, tokenA.target);
+      await tokenA.transfer(user1.address, ethers.parseEther("1000"));
+      await tokenA.connect(user1).approve(staking.target, ethers.parseEther("500"));
+      // Fund reward contract so harvest on withdraw doesn't revert
+      await rewardToken.transfer(staking.target, ethers.parseEther("100000"));
+    });
+
+    it("should withdraw staked tokens", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("200"));
+      await staking.connect(user1).withdraw(0, ethers.parseEther("100"));
+      const userInfo = await staking.userInfo(0, user1.address);
+      expect(userInfo.amount).to.equal(ethers.parseEther("100"));
+    });
+
+    it("should reject insufficient balance", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("200"));
+      await expect(staking.connect(user1).withdraw(0, ethers.parseEther("300")))
+        .to.be.revertedWith("MultiStaking: insufficient balance");
+    });
+
+    it("should harvest on withdraw", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("200"));
+      await ethers.provider.send("evm_increaseTime", [3600]);
+      await ethers.provider.send("evm_mine");
+      await expect(staking.connect(user1).withdraw(0, ethers.parseEther("50")))
+        .to.emit(staking, "Harvest");
+    });
+  });
+
+  describe("reward distribution", function () {
+    beforeEach(async function () {
+      await staking.addPool(100, tokenA.target);
+      await staking.addPool(300, tokenB.target);
+      await tokenA.transfer(user1.address, ethers.parseEther("1000"));
+      await tokenB.transfer(user2.address, ethers.parseEther("1000"));
+      await tokenA.connect(user1).approve(staking.target, ethers.parseEther("500"));
+      await tokenB.connect(user2).approve(staking.target, ethers.parseEther("500"));
+    });
+
+    it("should distribute rewards proportionally across pools", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("100"));
+      await staking.connect(user2).deposit(1, ethers.parseEther("100"));
+
+      await rewardToken.transfer(staking.target, ethers.parseEther("10000"));
+      await ethers.provider.send("evm_increaseTime", [86400]);
+      await ethers.provider.send("evm_mine");
+
+      const pending0 = await staking.pendingReward(0, user1.address);
+      const pending1 = await staking.pendingReward(1, user2.address);
+      expect(pending0).to.be.gt(0);
+      expect(pending1).to.be.gt(0);
+      // Pool1 (300 allocPoint) should get ~3x the reward of pool0 (100 allocPoint)
+      const ratio = Number(pending1) / Number(pending0);
+      expect(ratio).to.be.closeTo(3, 0.5);
+    });
+
+    it("should stop accruing rewards when totalStaked is 0", async function () {
+      await staking.connect(user1).deposit(0, ethers.parseEther("100"));
+      await rewardToken.transfer(staking.target, ethers.parseEther("10000"));
+
+      // Advance time and mine so rewards accrue
+      await ethers.provider.send("evm_increaseTime", [3600]);
+      await ethers.provider.send("evm_mine");
+
+      const pendingBefore = await staking.pendingReward(0, user1.address);
+      expect(pendingBefore).to.be.gt(0);
+
+      // Withdraw all — totalStaked becomes 0
+      // This also harvests pending rewards
+      await staking.connect(user1).withdraw(0, ethers.parseEther("100"));
+
+      // Advance time further
+      await ethers.provider.send("evm_increaseTime", [3600]);
+      await ethers.provider.send("evm_mine");
+
+      // accRewardPerShare should not have increased since totalStaked was 0
+      const pool = await staking.poolInfo(0);
+      // Since updatePool skips reward when totalStaked=0,
+      // lastRewardTime advances to block.timestamp
+      // So pending for the withdrawn user (now amount=0) = 0
+      pendingAfter = await staking.pendingReward(0, user1.address);
+      expect(pendingAfter).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `mapping(address => bool) poolExists` to prevent duplicate pool creation in `addPool()`
- Add `setPoolAllocPoint()` for dynamic pool weight adjustment
- Fix `updatePool()` multiplication order to prevent uint256 overflow
- Fix `pendingReward()` multiplication order to prevent uint256 overflow
- Add `PoolUpdated` event for alloc point changes
- Fix ChainlinkAdapter tuple destructuring for Solidity 0.8.20 compatibility
- Add multi-compiler support (0.8.20 + 0.8.24 Cancun) for OZ v5 dependencies

## Bugs Fixed

### B1 — Duplicate pool creation
`addPool()` had no guard against creating multiple pools with the same stake token.
**Fix**: Added `mapping(address => bool) poolExists` with `require(!poolExists[_stakeToken], "Pool exists")`.

### B2 — Missing pool weight update
No function to update pool allocation weights after creation.
**Fix**: Added `setPoolAllocPoint(pid, _allocPoint)` with `onlyOwner`, emits `PoolUpdated` event.

### B3 — Integer overflow in updatePool
```
Before: elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint — intermediate can overflow
After:  elapsed * pool.allocPoint / totalAllocPoint * rewardPerSecond — bounded intermediate
```

### B4 — Same overflow pattern in pendingReward
Fixed the same multiplication ordering issue in the view function.

## Test Plan
16 tests 16/16 PASS:
- Pool creation with duplicate / zero-address / owner-only guards
- setPoolAllocPoint weight update + event emission
- Deposit with and without harvest trigger
- Withdraw with balance check and harvest
- Proportional multi-pool reward distribution
- Reward freeze when totalStaked = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)