### PR TITLE
fix(staking): fix phantom rewards, access control, and precision loss in StakingRewards

### DIFF
--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -15,6 +15,11 @@ contract StakingRewards is ReentrancyGuard {
     IERC20 public immutable rewardsToken;
     address public owner;
 
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
     uint256 public periodFinish;
     uint256 public rewardRate;
     uint256 public rewardsDuration = 7 days;
@@ -66,11 +71,8 @@ contract StakingRewards is ReentrancyGuard {
         if (_totalSupply == 0) {
             return rewardPerTokenStored;
         }
-        // BUG: Uses block.timestamp directly instead of lastTimeRewardApplicable().
-        // After periodFinish, this keeps accruing phantom rewards indefinitely,
-        // allowing stakers to drain more rewards than were actually deposited.
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
         );
     }
 
@@ -112,13 +114,11 @@ contract StakingRewards is ReentrancyGuard {
 
     /// @notice Notify the contract of a new reward amount to distribute.
     /// @param reward Total reward tokens to distribute over the duration.
-    // BUG: No access control — anyone can call notifyRewardAmount. An attacker can
-    // call this with 0 to reset the rewardRate to near-zero, stealing future rewards.
-    function notifyRewardAmount(uint256 reward) external updateReward(address(0)) {
+    function notifyRewardAmount(uint256 reward) external onlyOwner updateReward(address(0)) {
+        // BUGFIX: Ensure reward rate is non-zero (prevents precision loss)
+        require(reward / rewardsDuration > 0, "Reward too small for duration");
+
         if (block.timestamp >= periodFinish) {
-            // BUG: Precision loss — integer division truncates rewardRate for small
-            // reward amounts relative to rewardsDuration (7 days = 604800 seconds).
-            // E.g., 500000 wei / 604800 = 0, meaning all rewards are lost.
             rewardRate = reward / rewardsDuration;
         } else {
             uint256 remaining = periodFinish - block.timestamp;

--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -1,4 +1,8 @@
 // SPDX-License-Identifier: MIT
+// @contributor: Claude Code (Claude Opus 4.7)
+// @platform-config: Task: Fix phantom reward accrual after period expiry in StakingRewards. Rules: Replace block.timestamp with lastTimeRewardApplicable(), add onlyOwner to notifyRewardAmount, add precision loss guard (reward / rewardsDuration > 0). Tools: gh, npx hardhat. Style: Solidity conventions per project.
+// @env: os=linux, arch=x86_64, home_dir=/home/michael, working_dir=/home/michael/web3-community/OpenAgents, shell=bash
+// @timestamp: 2026-06-20T08:00:00Z
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/StakingRewards.test.js
+++ b/test/StakingRewards.test.js
@@ -2,72 +2,178 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("StakingRewards", function () {
-  let stakingRewards, stakingToken, rewardToken;
-  let owner, staker1, staker2;
+  let stakingToken, rewardsToken, staking;
+  let owner, user1, user2, attacker;
+  const REWARDS_DURATION = 7 * 24 * 60 * 60; // 7 days
+  const ONE_DAY = 24 * 60 * 60;
+  const ONE_TOKEN = ethers.parseEther("1");
 
-  // BUG: Setup runs once but tests mutate state - no beforeEach to reset between tests
-  before(async function () {
-    [owner, staker1, staker2] = await ethers.getSigners();
+  beforeEach(async function () {
+    [owner, user1, user2, attacker] = await ethers.getSigners();
 
-    const StakingToken = await ethers.getContractFactory("StakingToken");
-    stakingToken = await StakingToken.deploy();
-    await stakingToken.deployed();
-
-    const RewardToken = await ethers.getContractFactory("RewardToken");
-    rewardToken = await RewardToken.deploy();
-    await rewardToken.deployed();
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    stakingToken = await MockERC20.deploy("Staking Token", "STK");
+    rewardsToken = await MockERC20.deploy("Reward Token", "RWD");
 
     const StakingRewards = await ethers.getContractFactory("StakingRewards");
-    stakingRewards = await StakingRewards.deploy(stakingToken.address, rewardToken.address);
-    await stakingRewards.deployed();
+    staking = await StakingRewards.deploy(stakingToken.target, rewardsToken.target);
+    await staking.waitForDeployment();
 
-    // Mint tokens for testing
-    await stakingToken.mint(staker1.address, ethers.utils.parseEther("1000"));
-    await stakingToken.mint(staker2.address, ethers.utils.parseEther("1000"));
-    await rewardToken.mint(stakingRewards.address, ethers.utils.parseEther("10000"));
+    // Transfer from deployer (owner) to test users and fund staking contract with rewards
+    for (const user of [user1, user2]) {
+      await stakingToken.transfer(user.address, ONE_TOKEN * 1000n);
+      await stakingToken.connect(user).approve(staking.target, ONE_TOKEN * 1000n);
+    }
+    await stakingToken.connect(owner).approve(staking.target, ONE_TOKEN * 1000n);
+    // Pre-fund the staking contract with reward tokens before notifyRewardAmount
+    await rewardsToken.transfer(staking.target, ONE_TOKEN * 10000n);
   });
 
-  it("should allow staking tokens", async function () {
-    const amount = ethers.utils.parseEther("100");
-    await stakingToken.connect(staker1).approve(stakingRewards.address, amount);
-    await stakingRewards.connect(staker1).stake(amount);
+  describe("notifyRewardAmount", function () {
+    it("should only allow owner to notify rewards", async function () {
+      await expect(
+        staking.connect(attacker).notifyRewardAmount(ONE_TOKEN * 100n)
+      ).to.be.revertedWith("Not owner");
+    });
 
-    const staked = await stakingRewards.balanceOf(staker1.address);
-    expect(staked).to.equal(amount);
+    it("should reject reward too small for duration", async function () {
+      const tooSmall = 500_000; // less than rewardsDuration (604800), so rate = 0
+      await expect(
+        staking.connect(owner).notifyRewardAmount(tooSmall)
+      ).to.be.revertedWith("Reward too small for duration");
+    });
+
+    it("should set reward rate and period finish", async function () {
+      const reward = ONE_TOKEN * 100n;
+      await staking.connect(owner).notifyRewardAmount(reward);
+
+      const rate = await staking.rewardRate();
+      expect(rate).to.equal(reward / BigInt(REWARDS_DURATION));
+
+      const finish = await staking.periodFinish();
+      const block = await ethers.provider.getBlock("latest");
+      expect(finish).to.equal(block.timestamp + REWARDS_DURATION);
+    });
+
+    it("should extend remaining when called mid-period", async function () {
+      await staking.connect(owner).notifyRewardAmount(ONE_TOKEN * 100n);
+
+      await ethers.provider.send("evm_increaseTime", [ONE_DAY]);
+      await ethers.provider.send("evm_mine", []);
+
+      await staking.connect(owner).notifyRewardAmount(ONE_TOKEN * 50n);
+
+      const rate = await staking.rewardRate();
+      expect(rate).to.be.gt(0n);
+    });
   });
 
-  it("should accrue rewards over time", async function () {
-    // BUG: Hardcoded block timestamp - test is brittle and environment-dependent
-    await ethers.provider.send("evm_setNextBlockTimestamp", [1747400000]);
-    await ethers.provider.send("evm_mine");
+  describe("phantom rewards", function () {
+    it("should stop accruing after periodFinish", async function () {
+      await staking.connect(owner).notifyRewardAmount(ONE_TOKEN * 100n);
+      await staking.connect(user1).stake(ONE_TOKEN * 10n);
 
-    const earned = await stakingRewards.earned(staker1.address);
-    expect(earned).to.be.gt(0);
+      // Fast-forward past periodFinish
+      await ethers.provider.send("evm_increaseTime", [REWARDS_DURATION + ONE_DAY]);
+      await ethers.provider.send("evm_mine", []);
+
+      const earned1 = await staking.earned(user1.address);
+
+      // Fast-forward another week - should NOT increase (phantom rewards fixed)
+      await ethers.provider.send("evm_increaseTime", [REWARDS_DURATION]);
+      await ethers.provider.send("evm_mine", []);
+
+      const earned2 = await staking.earned(user1.address);
+      expect(earned2).to.equal(earned1);
+    });
+
+    it("should not allow claiming more than the reward pool", async function () {
+      const reward = ONE_TOKEN * 10n;
+      await staking.connect(owner).notifyRewardAmount(reward);
+      await staking.connect(user1).stake(ONE_TOKEN * 100n);
+
+      await ethers.provider.send("evm_increaseTime", [REWARDS_DURATION + ONE_DAY]);
+      await ethers.provider.send("evm_mine", []);
+
+      await staking.connect(user1).getReward();
+
+      const claimed = await rewardsToken.balanceOf(user1.address);
+      expect(claimed).to.be.at.most(reward);
+    });
   });
 
-  it("should allow withdrawal", async function () {
-    // BUG: depends on state from previous test (staker1 having staked 100 tokens)
-    const amount = ethers.utils.parseEther("50");
-    await stakingRewards.connect(staker1).withdraw(amount);
+  describe("staking lifecycle", function () {
+    beforeEach(async function () {
+      await staking.connect(owner).notifyRewardAmount(ONE_TOKEN * 100n);
+    });
 
-    const remaining = await stakingRewards.balanceOf(staker1.address);
-    expect(remaining).to.equal(ethers.utils.parseEther("50"));
-  });
+    it("should stake and track balance", async function () {
+      await staking.connect(user1).stake(ONE_TOKEN * 10n);
+      expect(await staking.balanceOf(user1.address)).to.equal(ONE_TOKEN * 10n);
+      expect(await staking.totalSupply()).to.equal(ONE_TOKEN * 10n);
+    });
 
-  it("should distribute rewards correctly to multiple stakers", async function () {
-    const amount = ethers.utils.parseEther("200");
-    await stakingToken.connect(staker2).approve(stakingRewards.address, amount);
-    await stakingRewards.connect(staker2).stake(amount);
+    it("should reject zero staking", async function () {
+      await expect(staking.connect(user1).stake(0)).to.be.revertedWith("Cannot stake 0");
+    });
 
-    // BUG: Hardcoded timestamp again - assumes previous evm_setNextBlockTimestamp succeeded
-    await ethers.provider.send("evm_setNextBlockTimestamp", [1747500000]);
-    await ethers.provider.send("evm_mine");
+    it("should allow partial withdrawal", async function () {
+      await staking.connect(user1).stake(ONE_TOKEN * 10n);
+      await staking.connect(user1).withdraw(ONE_TOKEN * 4n);
+      expect(await staking.balanceOf(user1.address)).to.equal(ONE_TOKEN * 6n);
+    });
 
-    const earned1 = await stakingRewards.earned(staker1.address);
-    const earned2 = await stakingRewards.earned(staker2.address);
+    it("should reject zero withdrawal", async function () {
+      await staking.connect(user1).stake(ONE_TOKEN * 10n);
+      await expect(staking.connect(user1).withdraw(0)).to.be.revertedWith("Cannot withdraw 0");
+    });
 
-    // staker2 staked 4x more, so should earn proportionally more from this point
-    expect(earned2).to.be.gt(0);
-    expect(earned1).to.be.gt(0);
+    it("should distribute rewards proportionally", async function () {
+      await staking.connect(user1).stake(ONE_TOKEN * 30n); // 30%
+      await staking.connect(user2).stake(ONE_TOKEN * 70n); // 70%
+
+      await ethers.provider.send("evm_increaseTime", [REWARDS_DURATION - 100]);
+      await ethers.provider.send("evm_mine", []);
+
+      await staking.connect(user1).getReward();
+      await staking.connect(user2).getReward();
+
+      const bal1 = await rewardsToken.balanceOf(user1.address);
+      const bal2 = await rewardsToken.balanceOf(user2.address);
+      const total = bal1 + bal2;
+
+      // Within 1% tolerance for rounding
+      expect(bal1 * 100n / total).to.be.closeTo(30n, 1n);
+      expect(bal2 * 100n / total).to.be.closeTo(70n, 1n);
+    });
+
+    it("should reset reward to zero after claim", async function () {
+      await staking.connect(user1).stake(ONE_TOKEN * 10n);
+
+      await ethers.provider.send("evm_increaseTime", [ONE_DAY]);
+      await ethers.provider.send("evm_mine", []);
+
+      await staking.connect(user1).getReward();
+      expect(await staking.rewards(user1.address)).to.equal(0);
+    });
+
+    it("should allow multiple reward cycles", async function () {
+      await staking.connect(user1).stake(ONE_TOKEN * 10n);
+
+      // Cycle 1
+      await ethers.provider.send("evm_increaseTime", [ONE_DAY]);
+      await ethers.provider.send("evm_mine", []);
+      await staking.connect(user1).getReward();
+      const claim1 = await rewardsToken.balanceOf(user1.address);
+      expect(claim1).to.be.gt(0n);
+
+      // Cycle 2 with new rewards
+      await staking.connect(owner).notifyRewardAmount(ONE_TOKEN * 100n);
+      await ethers.provider.send("evm_increaseTime", [ONE_DAY]);
+      await ethers.provider.send("evm_mine", []);
+      await staking.connect(user1).getReward();
+      const claim2 = await rewardsToken.balanceOf(user1.address);
+      expect(claim2).to.be.gt(claim1);
+    });
   });
 });

--- a/test/StakingRewards.test.js
+++ b/test/StakingRewards.test.js
@@ -1,3 +1,7 @@
+// @contributor: Claude Code (Claude Opus 4.7)
+// @platform-config: Task: Write comprehensive StakingRewards tests — owner-only access control, reward too small rejection, phantom reward freeze after periodFinish, pool-limited claims, multi-user proportional distribution, multiple reward cycles. Rules: Use ethers v6, hardhat-toolbox, chai assertions. Tools: npx hardhat test. Style: JS/Node/ethers conventions.
+// @env: os=linux, arch=x86_64, home_dir=/home/michael, working_dir=/home/michael/web3-community/OpenAgents, shell=bash
+// @timestamp: 2026-06-20T08:00:00Z
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 


### PR DESCRIPTION
/claim #66
💳 Payment: USDC | 0x301c9f7ebb1b937901adf96a144553f95e89e145 | Base

Fixes #66 — three bug fixes in StakingRewards.

1. **Phantom rewards**: `block.timestamp` → `lastTimeRewardApplicable()`, preventing infinite reward accrual after `periodFinish`
2. **Access control**: `onlyOwner` on `notifyRewardAmount` — unauthorized reset attacks prevented
3. **Precision loss**: `require(reward / rewardsDuration > 0)` — sub-1-wei rewards rejected
4. **Traceability**: contributor traceability headers in all modified files

## Test Plan
13 tests covering: owner-only access control, reward too small rejection, phantom reward freeze, pool-limited claims, multi-user proportional distribution, multiple reward cycles — 27/27 PASS (incl. 14 PaymentEscrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)