### PR TITLE
fix: Pin JWT to HS256, add revocation and refresh endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,12 @@
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Depends
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
+from api.middleware.auth import (
+    decode_token, create_access_token, revoke_token,
+    get_current_user, REFRESH_TOKEN_EXPIRE_DAYS, ACCESS_TOKEN_EXPIRE_MINUTES,
+)
+from fastapi.security import HTTPBearer
 
 app = FastAPI(
     title="OpenAgents API",
@@ -39,9 +44,45 @@ class LeaderboardEntry(BaseModel):
     success_rate: float
 
 
+class TokenRefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenRevokeRequest(BaseModel):
+    token: str
+
+
+class TokenRefreshResponse(BaseModel):
+    token: str
+    expires_in: int
+
+
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+
+
+@app.post("/auth/refresh", response_model=TokenRefreshResponse)
+async def refresh_token(body: TokenRefreshRequest):
+    payload = decode_token(body.refresh_token)
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid token type")
+    data = {
+        "sub": payload.get("sub"),
+        "address": payload.get("address"),
+        "roles": payload.get("roles", []),
+    }
+    new_token = create_access_token(data)
+    return TokenRefreshResponse(token=new_token, expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60)
+
+
+@app.post("/auth/revoke")
+async def revoke(body: TokenRevokeRequest, user: dict = Depends(get_current_user)):
+    payload = decode_token(body.token)
+    jti = payload.get("jti")
+    if jti:
+        revoke_token(jti)
+    return {"status": "revoked"}
 
 
 @app.get("/agents", response_model=list[AgentResponse])

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,41 +1,71 @@
-"""JWT authentication middleware for the OpenAgents API."""
+# @generated-by: OpenCode AI Agent
+# @timestamp: 2026-06-22T12:00:00Z
+# @startup-config: You are opencode, an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user. IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files. When the user directly asks about opencode (eg 'can opencode do...', 'does opencode have...') or asks in second person (eg 'are you able...', 'can you do...'), first use the WebFetch tool to gather information to answer the question from opencode docs at https://opencode.ai
+# @runtime: os=Linux, arch=x86_64, home=/home/agy, cwd=/home/agy/bounty_hunter
 
 import jwt
 import os
+import uuid
+import logging
 from fastapi import Request, HTTPException, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from datetime import datetime, timedelta
 from typing import Optional
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+logger = logging.getLogger(__name__)
+
+JWT_SECRET = os.environ.get("JWT_SECRET")
+if JWT_SECRET is None:
+    JWT_SECRET = "dev-secret-change-in-production"
+    logger.warning("JWT_SECRET not set, using insecure fallback — set JWT_SECRET in production")
+
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 security = HTTPBearer()
 
+_revoked_tokens: set = set()
+
+
+def revoke_token(jti: str) -> None:
+    _revoked_tokens.add(jti)
+
+
+def is_token_revoked(jti: str) -> bool:
+    return jti in _revoked_tokens
+
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
+    to_encode.update({
+        "exp": expire,
+        "iat": datetime.utcnow(),
+        "type": "access",
+        "jti": uuid.uuid4().hex,
+    })
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def create_refresh_token(data: dict) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
+    to_encode.update({
+        "exp": expire,
+        "iat": datetime.utcnow(),
+        "type": "refresh",
+        "jti": uuid.uuid4().hex,
+    })
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def decode_token(token: str) -> dict:
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        jti = payload.get("jti")
+        if jti and is_token_revoked(jti):
+            raise HTTPException(status_code=401, detail="Token has been revoked")
         return payload
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
@@ -52,8 +82,6 @@ async def get_current_user(
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
 
-    # BUG: No token revocation check — logged-out or compromised tokens
-    # remain valid until they naturally expire
     user_data = {
         "id": payload.get("sub"),
         "address": payload.get("address"),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0
 web3>=7.6.0
+pyjwt>=2.8.0
+pytest>=7.4.0
+pytest-httpx>=0.30.0

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,146 @@
+import jwt
+import time
+import os
+import uuid
+from unittest.mock import patch
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from api.middleware.auth import (
+    JWT_SECRET, JWT_ALGORITHM,
+    create_access_token, create_refresh_token, decode_token,
+    get_current_user, generate_login_tokens, revoke_token, is_token_revoked,
+    _revoked_tokens, ACCESS_TOKEN_EXPIRE_MINUTES,
+)
+from fastapi.security import HTTPAuthorizationCredentials
+
+
+class TestAlgorithmNone:
+    def test_rejects_none_algorithm(self):
+        forged = jwt.encode({"sub": "test"}, key="", algorithm="none")
+        with pytest.raises(HTTPException) as exc:
+            decode_token(forged)
+        assert exc.value.status_code == 401
+
+    def test_valid_hs256_succeeds(self):
+        token = create_access_token({"sub": "user1", "address": "0x123"})
+        payload = decode_token(token)
+        assert payload["sub"] == "user1"
+        assert payload["type"] == "access"
+
+
+class TestMissingSecret:
+    def test_does_not_crash_on_missing_env(self):
+        with patch.dict(os.environ, {}, clear=True):
+            import importlib
+            import api.middleware.auth
+            importlib.reload(api.middleware.auth)
+            secret = api.middleware.auth.JWT_SECRET
+            assert secret is not None
+
+
+class TestTokenRevocation:
+    def test_revoked_token_is_rejected(self):
+        token = create_access_token({"sub": "user1"})
+        payload = decode_token(token)
+        jti = payload["jti"]
+        revoke_token(jti)
+        assert is_token_revoked(jti) is True
+        with pytest.raises(HTTPException) as exc:
+            decode_token(token)
+        assert exc.value.detail == "Token has been revoked"
+
+    def test_unrevoked_token_still_valid(self):
+        token = create_access_token({"sub": "user1"})
+        payload = decode_token(token)
+        assert payload["sub"] == "user1"
+
+    def test_revocation_does_not_affect_other_tokens(self):
+        t1 = create_access_token({"sub": "a"})
+        t2 = create_access_token({"sub": "b"})
+        p1 = decode_token(t1)
+        p2 = decode_token(t2)
+        revoke_token(p1["jti"])
+        with pytest.raises(HTTPException):
+            decode_token(t1)
+        decode_token(t2)
+
+
+class TestExpiredToken:
+    def test_expired_token_is_rejected(self):
+        payload = {
+            "sub": "user1",
+            "exp": datetime.utcnow() - timedelta(hours=1),
+            "iat": datetime.utcnow() - timedelta(hours=2),
+            "type": "access",
+            "jti": uuid.uuid4().hex,
+        }
+        expired = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+        with pytest.raises(HTTPException) as exc:
+            decode_token(expired)
+        assert exc.value.detail == "Token has expired"
+
+
+class TestRefreshToken:
+    def test_refresh_token_has_correct_type(self):
+        token = create_refresh_token({"sub": "user1"})
+        payload = decode_token(token)
+        assert payload["type"] == "refresh"
+
+    def test_access_token_type_is_access(self):
+        token = create_access_token({"sub": "user1"})
+        payload = decode_token(token)
+        assert payload["type"] == "access"
+
+
+class TestJtiPresent:
+    def test_access_token_has_jti(self):
+        token = create_access_token({"sub": "user1"})
+        payload = decode_token(token)
+        assert "jti" in payload
+
+    def test_refresh_token_has_jti(self):
+        token = create_refresh_token({"sub": "user1"})
+        payload = decode_token(token)
+        assert "jti" in payload
+
+
+class TestRevokedTokensSet:
+    def test_revoked_tokens_is_set(self):
+        assert isinstance(_revoked_tokens, set)
+
+
+class TestGenerateLoginTokens:
+    def test_structure(self):
+        result = generate_login_tokens("user1", "0x123", ["admin"])
+        assert "token" in result
+        assert "refresh_token" in result
+        assert result["expires_in"] == ACCESS_TOKEN_EXPIRE_MINUTES * 60
+        payload = decode_token(result["token"])
+        assert payload["sub"] == "user1"
+        assert payload["address"] == "0x123"
+        assert payload["roles"] == ["admin"]
+
+
+class TestInvalidSignature:
+    def test_wrong_secret_rejected(self):
+        token = jwt.encode(
+            {"sub": "test", "exp": datetime.utcnow() + timedelta(hours=1)},
+            "wrong-secret",
+            algorithm="HS256",
+        )
+        with pytest.raises(HTTPException) as exc:
+            decode_token(token)
+        assert exc.value.status_code == 401
+
+
+class TestMissingSub:
+    def test_token_without_sub_rejected_by_current_user(self):
+        token = create_access_token({"address": "0x123"})
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(get_current_user(creds))
+        assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary

Fixes #100 — JWT auth middleware accepts `none` algorithm.

### Changes

1. **Pin algorithm to HS256**: Removed `"none"` from `jwt.decode()` algorithms list — `alg=none` tokens are now rejected
2. **Graceful env fallback**: `JWT_SECRET` now uses `os.environ.get()` with a dev fallback + warning instead of crashing
3. **Token revocation**: Added JWT ID (`jti`) via `uuid` to every token, with in-memory revocation set and `revoke_token()` / `is_token_revoked()` functions
4. **Auth endpoints**:
   - `POST /auth/refresh` — exchange refresh token for new access token
   - `POST /auth/revoke` — revoke a token by JTI (requires auth)
5. **Tests**: 15 tests covering all acceptance criteria:
   - `none` algorithm rejected
   - Valid HS256 succeeds
   - Missing env does not crash
   - Revoked tokens rejected
   - Expired tokens rejected
   - Token types verified
   - JTI present in all tokens
   - Invalid signature rejected
   - Missing `sub` rejected

### Verification

- `python -m pytest api/tests/test_auth.py -q` — 15 passed
- `git diff --check` — whitespace clean

### Payment

/claim #100
Method: PayPal
Address: n6085530@gmail.com