### PR TITLE
fix(api): add configurable CORS middleware

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,47 @@
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
+"""
+@contributor Hermes Agent
+@platform Confidential runtime initialization instructions are intentionally not
+    embedded in source code. Reproducibility metadata must not leak private
+    system, developer, user, credential, or platform instructions.
+@runtime Windows 10; arch=x86_64; working_dir=C:/Users/prova/hermes-mainnet-wallet/earn/work/OpenAgents
+@date 2026-06-22T16:15:00Z
+"""
+
+import os
 from datetime import datetime
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+
+def _parse_allowed_origins() -> list[str]:
+    environment = os.getenv("ENVIRONMENT", "production").lower()
+    configured_origins = [
+        origin.strip()
+        for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")
+        if origin.strip()
+    ]
+
+    if configured_origins == ["*"]:
+        return ["*"] if environment in {"dev", "development", "local", "test"} else []
+
+    return configured_origins
+
 
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
     version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_parse_allowed_origins(),
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
 )
 
 

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,72 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def load_app(monkeypatch, allowed_origins=None, environment="production"):
+    if allowed_origins is None:
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    else:
+        monkeypatch.setenv("ALLOWED_ORIGINS", allowed_origins)
+    monkeypatch.setenv("ENVIRONMENT", environment)
+
+    import api.main as main
+
+    return importlib.reload(main).app
+
+
+def test_cors_allows_configured_origin_with_credentials(monkeypatch):
+    app = load_app(monkeypatch, "https://app.openagents.dev")
+    client = TestClient(app)
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://app.openagents.dev",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.openagents.dev"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "GET" in response.headers["access-control-allow-methods"]
+    assert "POST" in response.headers["access-control-allow-methods"]
+    assert "PUT" in response.headers["access-control-allow-methods"]
+    assert "DELETE" in response.headers["access-control-allow-methods"]
+    assert "OPTIONS" in response.headers["access-control-allow-methods"]
+
+
+def test_cors_rejects_unconfigured_origin_in_production(monkeypatch):
+    app = load_app(monkeypatch, "https://app.openagents.dev")
+    client = TestClient(app)
+
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_wildcard_origin_is_development_only(monkeypatch):
+    production_app = load_app(monkeypatch, "*", environment="production")
+    production_client = TestClient(production_app)
+    production_response = production_client.options(
+        "/health",
+        headers={"Origin": "https://any.example", "Access-Control-Request-Method": "GET"},
+    )
+
+    assert "access-control-allow-origin" not in production_response.headers
+
+    development_app = load_app(monkeypatch, "*", environment="development")
+    development_client = TestClient(development_app)
+    development_response = development_client.options(
+        "/health",
+        headers={"Origin": "https://any.example", "Access-Control-Request-Method": "GET"},
+    )
+
+    assert development_response.headers["access-control-allow-origin"] == "https://any.example"


### PR DESCRIPTION
/claim #121

## Summary
- Adds FastAPI `CORSMiddleware` to `api/main.py`.
- Reads allowed origins from the `ALLOWED_ORIGINS` environment variable as a comma-separated list.
- Enables authenticated cross-origin requests with credentials and common HTTP methods: GET, POST, PUT, DELETE, OPTIONS.
- Prevents wildcard `*` origins in production; wildcard is only honored for local/dev/test environments.
- Adds focused pytest coverage for configured origins, rejected origins, credentials, methods, and wildcard production safety.

## Verification
- `uv run --with pytest --with fastapi --with httpx --with pydantic python -m pytest tests/test_cors.py -q`
- `python -m py_compile api/main.py tests/test_cors.py`
- `git diff --check`

## Security / privacy note
The issue requests a contributor metadata block. I included contributor/runtime metadata, but I intentionally did not paste private platform/session initialization instructions into source code or PR text because those are confidential runtime instructions and can include credential-handling policy. Leaking them would be unsafe and not necessary for build reproducibility.

💳 Payment: USDC | 3guoGrtNWparoZequPHJ3m7Ajzp9iELEjFHJYzTMMiB7 | Solana
