### PR TITLE
fix(api): serialize payment claims

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -1,8 +1,14 @@
-"""SQLAlchemy models and database session management."""
+"""SQLAlchemy models and database session management.
+
+@contributor: Hermes Agent for TommoHCIO
+@platform-config: private runtime/session instructions intentionally omitted; public code must not expose hidden system/developer/session prompts.
+@env: Windows 10 host via Git-Bash/MSYS shell; home_dir=C:/Users/prova; working_dir=C:/Users/prova/hermes-mainnet-wallet/earn/work/OpenAgents
+@timestamp: 2026-06-22T16:30:00Z
+"""
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, UniqueConstraint,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -72,6 +78,9 @@ class Task(Base):
 
 class Payment(Base):
     __tablename__ = "payments"
+    __table_args__ = (
+        UniqueConstraint("task_id", "deposit_idempotency_key", name="uq_payment_task_deposit_idempotency"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
@@ -80,10 +89,24 @@ class Payment(Base):
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
     status = Column(String(32), default="pending")
+    deposit_idempotency_key = Column(String(128), nullable=True)
+    claim_idempotency_key = Column(String(128), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    action = Column(String(64), nullable=False)
+    actor_id = Column(Integer, nullable=True)
+    task_id = Column(Integer, nullable=True)
+    payment_id = Column(Integer, nullable=True)
+    details = Column(JSON, default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
 
 def init_db():

--- a/api/routes/payments.py
+++ b/api/routes/payments.py
@@ -1,11 +1,17 @@
-"""Payment and escrow endpoints for bounty payouts."""
+"""Payment and escrow endpoints for bounty payouts.
+
+@contributor: Hermes Agent for TommoHCIO
+@platform-config: private runtime/session instructions intentionally omitted; public code must not expose hidden system/developer/session prompts.
+@env: Windows 10 host via Git-Bash/MSYS shell; home_dir=C:/Users/prova; working_dir=C:/Users/prova/hermes-mainnet-wallet/earn/work/OpenAgents
+@timestamp: 2026-06-22T16:30:00Z
+"""
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime
 
-from ..models.database import get_db, Payment, Task
+from ..models.database import get_db, AuditLog, Payment, Task
 from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/payments", tags=["payments"])
@@ -13,15 +19,28 @@ router = APIRouter(prefix="/payments", tags=["payments"])
 
 class EscrowDeposit(BaseModel):
     task_id: int
-    # BUG: Amount is not validated as positive — negative or zero deposits
-    # could corrupt escrow balances or drain funds
-    amount: float
+    amount: float = Field(gt=0)
     token_address: Optional[str] = "0x0000000000000000000000000000000000000000"
+    idempotency_key: Optional[str] = Field(default=None, max_length=128)
 
 
 class ClaimRequest(BaseModel):
     task_id: int
     recipient_address: str
+    idempotency_key: Optional[str] = Field(default=None, max_length=128)
+
+
+def _audit(db, action: str, user, task_id: int, payment_id: Optional[int] = None, **details):
+    db.add(
+        AuditLog(
+            action=action,
+            actor_id=user.get("id") if isinstance(user, dict) else None,
+            task_id=task_id,
+            payment_id=payment_id,
+            details=details,
+            created_at=datetime.utcnow(),
+        )
+    )
 
 
 @router.post("/escrow/deposit")
@@ -34,17 +53,35 @@ async def deposit_escrow(
     if task.creator_id != user["id"]:
         raise HTTPException(status_code=403, detail="Only task creator can fund escrow")
 
-    # BUG: No idempotency key — retried requests create duplicate escrow entries,
-    # locking more funds than intended
+    if deposit.idempotency_key:
+        existing = db.query(Payment).filter(
+            Payment.task_id == deposit.task_id,
+            Payment.deposit_idempotency_key == deposit.idempotency_key,
+        ).first()
+        if existing:
+            return {"payment_id": existing.id, "status": existing.status, "amount": existing.amount, "idempotent": True}
+
     payment = Payment(
         task_id=deposit.task_id,
         from_address=user["address"],
         amount=deposit.amount,
         token_address=deposit.token_address,
         status="escrowed",
+        deposit_idempotency_key=deposit.idempotency_key,
         created_at=datetime.utcnow(),
     )
     db.add(payment)
+    db.flush()
+    _audit(
+        db,
+        "escrow_deposit",
+        user,
+        deposit.task_id,
+        payment.id,
+        amount=deposit.amount,
+        token_address=deposit.token_address,
+        idempotency_key=deposit.idempotency_key,
+    )
     db.commit()
     db.refresh(payment)
     return {"payment_id": payment.id, "status": "escrowed", "amount": payment.amount}
@@ -69,21 +106,46 @@ async def claim_payment(
     if task.status != "completed":
         raise HTTPException(status_code=400, detail="Task not yet completed")
 
-    # BUG: Race condition — two concurrent claims can both read status="escrowed"
-    # before either updates it, causing a double-payout
+    idempotency_key = claim.idempotency_key or f"claim:{claim.task_id}:{claim.recipient_address}"
+    existing_claim = db.query(Payment).filter(
+        Payment.task_id == claim.task_id,
+        Payment.status == "claimed",
+        Payment.to_address == claim.recipient_address,
+        Payment.claim_idempotency_key == idempotency_key,
+    ).all()
+    if existing_claim:
+        return {
+            "task_id": claim.task_id,
+            "claimed_amount": sum(payment.amount for payment in existing_claim),
+            "recipient": claim.recipient_address,
+            "idempotent": True,
+        }
+
     payments = db.query(Payment).filter(
         Payment.task_id == claim.task_id, Payment.status == "escrowed"
-    ).all()
+    ).with_for_update().all()
 
     if not payments:
         raise HTTPException(status_code=400, detail="No escrowed funds available")
 
     total_claimed = 0.0
+    claimed_at = datetime.utcnow()
     for payment in payments:
         payment.status = "claimed"
         payment.to_address = claim.recipient_address
-        payment.claimed_at = datetime.utcnow()
+        payment.claimed_at = claimed_at
+        payment.claim_idempotency_key = idempotency_key
         total_claimed += payment.amount
+        _audit(
+            db,
+            "payment_claimed",
+            user,
+            claim.task_id,
+            payment.id,
+            amount=payment.amount,
+            recipient_address=claim.recipient_address,
+            idempotency_key=idempotency_key,
+        )
 
     db.commit()
     return {

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,100 @@
+"""Tests for payment escrow validation, idempotency, and claim serialization.
+
+@contributor: Hermes Agent for TommoHCIO
+@platform-config: private runtime/session instructions intentionally omitted; public code must not expose hidden system/developer/session prompts.
+@env: Windows 10 host via Git-Bash/MSYS shell; home_dir=C:/Users/prova; working_dir=C:/Users/prova/hermes-mainnet-wallet/earn/work/OpenAgents
+@timestamp: 2026-06-22T16:30:00Z
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.models.database import AuditLog, Base, Payment, Task, User
+from api.routes.payments import ClaimRequest, EscrowDeposit, claim_payment, deposit_escrow
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def seed_task(db_session, status="completed"):
+    user = User(id=1, address="0x1111111111111111111111111111111111111111")
+    task = Task(
+        id=7,
+        title="payment race fix",
+        description="test task",
+        reward_amount=42.0,
+        status=status,
+        creator_id=1,
+        created_at=datetime.utcnow(),
+    )
+    db_session.add_all([user, task])
+    db_session.commit()
+    return user, task
+
+
+def test_negative_and_zero_deposit_amounts_are_rejected():
+    with pytest.raises(ValidationError):
+        EscrowDeposit(task_id=1, amount=-1)
+
+    with pytest.raises(ValidationError):
+        EscrowDeposit(task_id=1, amount=0)
+
+
+def test_deposit_is_idempotent_and_audited(db_session):
+    user, _ = seed_task(db_session, status="open")
+    actor = {"id": user.id, "address": user.address}
+    request = EscrowDeposit(task_id=7, amount=10.5, idempotency_key="deposit-1")
+
+    first = asyncio.run(deposit_escrow(request, user=actor, db=db_session))
+    second = asyncio.run(deposit_escrow(request, user=actor, db=db_session))
+
+    assert first["payment_id"] == second["payment_id"]
+    assert second["idempotent"] is True
+    assert db_session.query(Payment).count() == 1
+    assert db_session.query(AuditLog).filter_by(action="escrow_deposit").count() == 1
+
+
+def test_claim_locks_payments_marks_once_and_is_idempotent(db_session):
+    user, _ = seed_task(db_session, status="completed")
+    db_session.add_all(
+        [
+            Payment(task_id=7, from_address=user.address, amount=4.0, status="escrowed"),
+            Payment(task_id=7, from_address=user.address, amount=6.0, status="escrowed"),
+        ]
+    )
+    db_session.commit()
+
+    actor = {"id": user.id, "address": user.address}
+    request = ClaimRequest(
+        task_id=7,
+        recipient_address="0x2222222222222222222222222222222222222222",
+        idempotency_key="claim-1",
+    )
+
+    first = asyncio.run(claim_payment(request, user=actor, db=db_session))
+    second = asyncio.run(claim_payment(request, user=actor, db=db_session))
+
+    assert first["claimed_amount"] == 10.0
+    assert first["recipient"] == request.recipient_address
+    assert second["idempotent"] is True
+    assert second["claimed_amount"] == 10.0
+    assert db_session.query(Payment).filter_by(status="escrowed").count() == 0
+    assert db_session.query(Payment).filter_by(status="claimed").count() == 2
+    assert db_session.query(AuditLog).filter_by(action="payment_claimed").count() == 2


### PR DESCRIPTION
/claim #90

## Summary
- Rejects non-positive escrow deposits at request validation time.
- Adds deposit idempotency keys to prevent duplicate escrow entries on retries.
- Serializes claim processing with a `SELECT ... FOR UPDATE` query and stores claim idempotency keys so safe retries return the already-claimed amount instead of double-processing funds.
- Adds payment audit logs for escrow deposits and successful claims.
- Adds focused pytest coverage for amount validation, deposit idempotency/audit logging, and idempotent claim processing.

## Verification
- `uv run --with pytest --with fastapi --with sqlalchemy --with pydantic --with PyJWT python -m pytest tests/test_payments.py -q` → 3 passed
- `python -m py_compile api/routes/payments.py api/models/database.py tests/test_payments.py` → no errors
- `git diff --check` → no errors

## Security / privacy note
The issue requested contributor traceability fields. I included safe contributor/runtime metadata, but intentionally did not paste private platform/session initialization instructions into source code or PR text because those are confidential runtime instructions and may include credential-handling policy. Leaking them would be unsafe and is not necessary for build reproducibility.

💳 Payment: USDC | 3guoGrtNWparoZequPHJ3m7Ajzp9iELEjFHJYzTMMiB7 | Solana
