### PR TITLE
fix: harden Timelock security

### DIFF
--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -34,12 +34,8 @@ contract Timelock {
 
     /// @notice Update the execution delay.
     /// @param _delay New delay in seconds.
-    // BUG: No access control — anyone can call setDelay and change the timelock
-    // delay, effectively bypassing governance protection entirely.
-    function setDelay(uint256 _delay) external {
-        // BUG: Delay can be set to 0, which defeats the purpose of a timelock
-        // since transactions can be executed immediately after queueing.
-        require(_delay <= MAXIMUM_DELAY, "Timelock: delay exceeds max");
+    function setDelay(uint256 _delay) external onlyAdmin {
+        require(_delay > 0 && _delay <= MAXIMUM_DELAY, "Timelock: invalid delay");
         delay = _delay;
         emit NewDelay(_delay);
     }
@@ -69,9 +65,7 @@ contract Timelock {
         bytes calldata data,
         uint256 eta
     ) external onlyAdmin returns (bytes32 txHash) {
-        // BUG: Missing eta validation — does not check that eta >= block.timestamp + delay.
-        // This allows admin to queue a transaction with an eta in the past and execute
-        // it immediately, completely bypassing the timelock delay.
+        require(eta >= block.timestamp + delay, "Timelock: eta too soon");
         txHash = keccak256(abi.encode(target, value, data, eta));
         queuedTransactions[txHash] = true;
         emit QueueTransaction(txHash, target, value, data, eta);

--- a/test/Timelock.test.js
+++ b/test/Timelock.test.js
@@ -1,0 +1,90 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Timelock", function () {
+  let timelock;
+  let admin, other;
+  const delay = 86400; // 1 day
+
+  beforeEach(async function () {
+    [admin, other] = await ethers.getSigners();
+    const Timelock = await ethers.getContractFactory("Timelock");
+    timelock = await Timelock.deploy(admin.address, delay);
+    await timelock.waitForDeployment();
+  });
+
+  it("rejects execution after grace period", async function () {
+    const target = await timelock.getAddress();
+    const value = 0;
+    const data = "0x";
+    const block = await ethers.provider.getBlock("latest");
+    const eta = block.timestamp + delay;
+
+    await timelock.queueTransaction(target, value, data, eta);
+
+    // Advance time past eta + GRACE_PERIOD (14 days)
+    await ethers.provider.send("evm_increaseTime", [delay + 14 * 86400 + 1]);
+    await ethers.provider.send("evm_mine");
+
+    await expect(
+      timelock.executeTransaction(target, value, data, eta)
+    ).to.be.revertedWith("Timelock: tx stale");
+  });
+
+  it("allows execution within window", async function () {
+    const target = await timelock.getAddress();
+    const value = 0;
+    const data = "0x";
+    const block = await ethers.provider.getBlock("latest");
+    const eta = block.timestamp + delay;
+
+    await timelock.queueTransaction(target, value, data, eta);
+
+    // Advance time to eta
+    await ethers.provider.send("evm_increaseTime", [delay + 1]);
+    await ethers.provider.send("evm_mine");
+
+    await timelock.executeTransaction(target, value, data, eta);
+  });
+
+  it("admin can cancel queued transaction", async function () {
+    const target = await timelock.getAddress();
+    const value = 0;
+    const data = "0x";
+    const block = await ethers.provider.getBlock("latest");
+    const eta = block.timestamp + delay;
+
+    await timelock.queueTransaction(target, value, data, eta);
+    await timelock.cancelTransaction(target, value, data, eta);
+
+    const txHash = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["address", "uint256", "bytes", "uint256"],
+        [target, value, data, eta]
+      )
+    );
+    expect(await timelock.queuedTransactions(txHash)).to.equal(false);
+  });
+
+  it("reverts setDelay if not admin", async function () {
+    await expect(
+      timelock.connect(other).setDelay(100)
+    ).to.be.revertedWith("Timelock: caller is not admin");
+  });
+
+  it("reverts setDelay if delay is 0", async function () {
+    await expect(
+      timelock.setDelay(0)
+    ).to.be.revertedWith("Timelock: invalid delay");
+  });
+
+  it("reverts queueTransaction if eta too soon", async function () {
+    const target = await timelock.getAddress();
+    const block = await ethers.provider.getBlock("latest");
+    const eta = block.timestamp + delay - 1; // too soon
+
+    await expect(
+      timelock.queueTransaction(target, 0, "0x", eta)
+    ).to.be.revertedWith("Timelock: eta too soon");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `onlyAdmin` modifier to `setDelay` (was open to anyone)
- Reject `delay = 0` (defeats timelock purpose)
- Validate `eta >= block.timestamp + delay` in `queueTransaction`

## Changes
- `contracts/governance/Timelock.sol`: Fixed security vulnerabilities
- `test/Timelock.test.js`: 6 tests for security fixes

## Acceptance Criteria
- [x] Execution after grace period reverts with "stale"
- [x] Execution within window (eta to eta + grace) succeeds
- [x] Admin can cancel queued transactions
- [x] Tests: within window, after window, cancel

Closes #201