### PR TITLE
fix: replace tx.origin with msg.sender in GovernorAlpha vote()

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -74,19 +74,19 @@ contract GovernorAlpha is ReentrancyGuard {
     function vote(uint256 proposalId, bool support) external {
         Proposal storage p = proposals[proposalId];
         require(block.number >= p.startBlock && block.number <= p.endBlock, "Governor: voting closed");
-        // BUG: Uses tx.origin instead of msg.sender — allows phishing attacks where
-        // a malicious contract can vote on behalf of the original caller.
-        require(!p.hasVoted[tx.origin], "Governor: already voted");
-        p.hasVoted[tx.origin] = true;
+        // FIX: Use msg.sender instead of tx.origin to prevent phishing attacks
+        // where a malicious contract could vote on behalf of the original caller.
+        require(!p.hasVoted[msg.sender], "Governor: already voted");
+        p.hasVoted[msg.sender] = true;
 
-        uint256 weight = token.getPastVotes(tx.origin, p.startBlock);
+        uint256 weight = token.getPastVotes(msg.sender, p.startBlock);
         if (support) {
             p.forVotes += weight;
         } else {
             p.againstVotes += weight;
         }
 
-        emit VoteCast(tx.origin, proposalId, support, weight);
+        emit VoteCast(msg.sender, proposalId, support, weight);
     }
 
     /// @notice Execute a succeeded proposal.


### PR DESCRIPTION
## Summary

Replaces all `tx.origin` usage with `msg.sender` in `GovernorAlpha.vote()`.

## Vulnerability

Using `tx.origin` for authorization allows phishing attacks where a malicious contract can trick a user into calling it, and the contract then votes on the user's behalf — because `tx.origin` is always the original EOA that initiated the transaction chain.

## Fix

Changed 4 occurrences of `tx.origin` to `msg.sender` in the `vote()` function:
- `hasVoted` check and storage
- `getPastVotes` query
- `VoteCast` event emission

## References

- SWC-115: https://swcregistry.io/docs/SWC-115
- Solidity docs: https://docs.soliditylang.org/en/latest/security-considerations.html#tx-origin