### PR TITLE
fix: SQL injection, input validation, auth on delete

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,7 +1,8 @@
 """Agent CRUD endpoints for the OpenAgents platform."""
 
+import re
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, validator
 from typing import Optional
 from datetime import datetime
 
@@ -10,18 +11,41 @@ from ..middleware.auth import get_current_user
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
+# Constants for input validation
+MAX_NAME_LENGTH = 64
+MAX_PAGINATION_LIMIT = 100
+NAME_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
+
 
 class AgentCreate(BaseModel):
-    name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    name: str = Field(..., min_length=1, max_length=MAX_NAME_LENGTH)
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
 
+    @validator('name')
+    def validate_name(cls, v):
+        if not NAME_PATTERN.match(v):
+            raise ValueError(
+                f'Name must be 1-{MAX_NAME_LENGTH} characters, '
+                'alphanumeric, underscores, or hyphens only'
+            )
+        return v
+
 
 class AgentUpdate(BaseModel):
-    name: Optional[str] = None
+    name: Optional[str] = Field(None, min_length=1, max_length=MAX_NAME_LENGTH)
     description: Optional[str] = None
     config: Optional[dict] = None
+
+    @validator('name')
+    def validate_name(cls, v):
+        if v is not None and not NAME_PATTERN.match(v):
+            raise ValueError(
+                f'Name must be 1-{MAX_NAME_LENGTH} characters, '
+                'alphanumeric, underscores, or hyphens only'
+            )
+        return v
 
 
 @router.post("/")
@@ -44,12 +68,12 @@ async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=De
 async def list_agents(
     owner: Optional[str] = None,
     skip: int = Query(0, ge=0),
-    limit: int = Query(50, ge=1),
+    limit: int = Query(50, ge=1, le=MAX_PAGINATION_LIMIT),
     db=Depends(get_db),
 ):
     query = db.query(Agent)
     if owner:
-        # BUG: String interpolation in query — vulnerable to SQL injection
+        # SQLAlchemy ORM uses parameterized queries — safe from SQL injection
         query = query.filter(Agent.owner_id == owner)
     return query.offset(skip).limit(limit).all()
 
@@ -77,12 +101,15 @@ async def update_agent(
     return agent
 
 
-# BUG: No authentication — anyone can delete any agent
 @router.delete("/{agent_id}")
-async def delete_agent(agent_id: int, db=Depends(get_db)):
+async def delete_agent(
+    agent_id: int, user=Depends(get_current_user), db=Depends(get_db)
+):
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.owner_id != user["id"]:
+        raise HTTPException(status_code=403, detail="Not the owner")
     db.delete(agent)
     db.commit()
     return {"deleted": True}


### PR DESCRIPTION
## Summary

This PR addresses all issues in #27:

### Changes

1. **Input Validation** (lines 14-43):
   - Agent name: 64 chars max, alphanumeric/underscores/hyphens only
   - Pydantic validators reject special characters and empty names
   - Prevents XSS and injection attacks via name field

2. **Pagination Cap** (line 68):
   - limit parameter capped at 100 max (was unlimited)
   - Prevents abuse via extremely large page requests

3. **Authentication on Delete** (lines 95-104):
   - Delete endpoint now requires authentication
   - Only the owner can delete their agents
   - Returns 403 for unauthorized attempts

4. **SQL Injection Clarification**:
   - SQLAlchemy ORM already uses parameterized queries
   - Removed misleading comment suggesting SQL injection vulnerability
   - Added clarification comment explaining ORM safety

### Acceptance Criteria Met

- ✅ No string interpolation in queries (SQLAlchemy ORM is safe)
- ✅ Special characters rejected via regex validation
- ✅ Pagination capped at 100
- ✅ Unauthenticated delete blocked

### Testing

All changes are backward-compatible with existing API consumers. The only breaking change is:
- Agent names must now match \^[a-zA-Z0-9_-]+$\
- Delete endpoint now requires authentication

Fixes #27