### PR TITLE
fix(api): harden JWT authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+__pycache__/
 
 # Environment
 .env

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -43,13 +43,13 @@
     },
     {
       "name": "chico10117",
-      "timestamp": "2026-08-05T06:17:10Z",
+      "timestamp": "2026-08-05T15:08:01Z",
       "platform_instructions": "Private platform and session instructions intentionally omitted; public reproducibility metadata is recorded in the patch and test commands.",
       "runtime": {
         "os": "macOS",
         "arch": "arm64",
         "home_dir": "/Users/chiko",
-        "working_dir": "/tmp/openagents-auth",
+        "working_dir": "/tmp/openagents-auth-rework",
         "shell": "zsh"
       },
       "contribution": "Hardened JWT verification and added revocation and refresh endpoints"

--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "chico10117",
+      "timestamp": "2026-08-05T06:17:10Z",
+      "platform_instructions": "Private platform and session instructions intentionally omitted; public reproducibility metadata is recorded in the patch and test commands.",
+      "runtime": {
+        "os": "macOS",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-auth",
+        "shell": "zsh"
+      },
+      "contribution": "Hardened JWT verification and added revocation and refresh endpoints"
     }
   ]
 }

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,11 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+try:
+    from .middleware.auth import refresh_access_token, revoke_token
+except ImportError:  # Supports `uvicorn main:app` from the api directory.
+    from middleware.auth import refresh_access_token, revoke_token
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
@@ -42,6 +47,14 @@ class LeaderboardEntry(BaseModel):
 # In-memory store (placeholder for DB)
 agents_cache: dict = {}
 tasks_cache: dict = {}
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+
+class RevokeTokenRequest(BaseModel):
+    token: str
 
 
 @app.get("/agents", response_model=list[AgentResponse])
@@ -110,3 +123,14 @@ async def health():
         "tasks_indexed": len(tasks_cache),
         "timestamp": datetime.utcnow().isoformat(),
     }
+
+
+@app.post("/auth/refresh")
+async def refresh_auth_token(request: RefreshTokenRequest):
+    return refresh_access_token(request.refresh_token)
+
+
+@app.post("/auth/revoke")
+async def revoke_auth_token(request: RevokeTokenRequest):
+    revoke_token(request.token)
+    return {"revoked": True}

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,8 +1,8 @@
 """JWT authentication middleware for the OpenAgents API.
 
 @generated-by: chico10117
-@generated-at: 2026-08-05T06:17:10Z
-@runtime: macOS arm64, working_dir=/tmp/openagents-auth, shell=zsh
+@generated-at: 2026-08-05T15:08:01Z
+@runtime: macOS arm64, working_dir=/tmp/openagents-auth-rework, shell=zsh
 @platform-instructions: private session material intentionally omitted
 """
 
@@ -87,6 +87,14 @@ def _is_revoked(jti: Optional[str]) -> bool:
         return bool(jti) and jti in revoked_tokens
 
 
+def _revoke_jti(jti: Optional[str]) -> str:
+    if not jti:
+        raise HTTPException(status_code=401, detail="Token has no revocation ID")
+    with _revocation_lock:
+        revoked_tokens.add(jti)
+    return jti
+
+
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     return _encode_token(
         data,
@@ -113,12 +121,7 @@ def decode_token(token: str) -> dict:
 def revoke_token(token: str) -> str:
     """Revoke a signed token by its unique JWT ID."""
     payload = _decode_token(token, verify_exp=False)
-    jti = payload.get("jti")
-    if not jti:
-        raise HTTPException(status_code=401, detail="Token has no revocation ID")
-    with _revocation_lock:
-        revoked_tokens.add(jti)
-    return jti
+    return _revoke_jti(payload.get("jti"))
 
 
 def refresh_access_token(refresh_token: str) -> dict:
@@ -132,10 +135,15 @@ def refresh_access_token(refresh_token: str) -> dict:
         for key in ("sub", "address", "roles")
         if key in payload
     }
-    return {
-        "token": create_access_token(identity),
-        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-    }
+    if not identity.get("sub"):
+        raise HTTPException(status_code=401, detail="Invalid refresh token payload")
+    # Rotate the refresh token so a stolen token cannot be replayed after use.
+    _revoke_jti(payload.get("jti"))
+    return generate_login_tokens(
+        identity["sub"],
+        identity.get("address", ""),
+        identity.get("roles", []),
+    )
 
 
 async def get_current_user(

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,46 +1,141 @@
-"""JWT authentication middleware for the OpenAgents API."""
+"""JWT authentication middleware for the OpenAgents API.
+
+@generated-by: chico10117
+@generated-at: 2026-08-05T06:17:10Z
+@runtime: macOS arm64, working_dir=/tmp/openagents-auth, shell=zsh
+@platform-instructions: private session material intentionally omitted
+"""
+
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from threading import RLock
+from typing import Optional
+from uuid import uuid4
 
 import jwt
-import os
-from fastapi import Request, HTTPException, Depends
+from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from datetime import datetime, timedelta
-from typing import Optional
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+logger = logging.getLogger(__name__)
+
+# A missing development secret should not prevent the API from importing. An
+# ephemeral fallback avoids shipping a reusable signing secret; operators must
+# set JWT_SECRET in deployments where tokens need to survive a restart.
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    JWT_SECRET = secrets.token_urlsafe(32)
+    logger.warning(
+        "JWT_SECRET is not set; using an ephemeral development signing secret"
+    )
+
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 security = HTTPBearer()
+revoked_tokens: set[str] = set()
+_revocation_lock = RLock()
 
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _encode_token(
+    data: dict,
+    token_type: str,
+    expires_delta: timedelta,
+) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
+    now = _utcnow()
+    to_encode.update(
+        {
+            "exp": now + expires_delta,
+            "iat": now,
+            "jti": uuid4().hex,
+            "type": token_type,
+        }
+    )
     return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
-def create_refresh_token(data: dict) -> str:
-    to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
-
-
-def decode_token(token: str) -> dict:
+def _decode_token(token: str, verify_exp: bool = True) -> dict:
+    options = {"verify_exp": verify_exp}
+    if verify_exp:
+        options["require"] = ["exp", "iat", "jti", "type"]
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
-        return payload
+        payload = jwt.decode(
+            token,
+            JWT_SECRET,
+            algorithms=[JWT_ALGORITHM],
+            options=options,
+        )
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Invalid token")
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+    return payload
+
+
+def _is_revoked(jti: Optional[str]) -> bool:
+    with _revocation_lock:
+        return bool(jti) and jti in revoked_tokens
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    return _encode_token(
+        data,
+        "access",
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+
+
+def create_refresh_token(data: dict) -> str:
+    return _encode_token(
+        data,
+        "refresh",
+        timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+
+
+def decode_token(token: str) -> dict:
+    payload = _decode_token(token)
+    if _is_revoked(payload.get("jti")):
+        raise HTTPException(status_code=401, detail="Token has been revoked")
+    return payload
+
+
+def revoke_token(token: str) -> str:
+    """Revoke a signed token by its unique JWT ID."""
+    payload = _decode_token(token, verify_exp=False)
+    jti = payload.get("jti")
+    if not jti:
+        raise HTTPException(status_code=401, detail="Token has no revocation ID")
+    with _revocation_lock:
+        revoked_tokens.add(jti)
+    return jti
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    """Issue a new access token only from a valid, non-revoked refresh token."""
+    payload = decode_token(refresh_token)
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=401, detail="Invalid refresh token type")
+
+    identity = {
+        key: payload[key]
+        for key in ("sub", "address", "roles")
+        if key in payload
+    }
+    return {
+        "token": create_access_token(identity),
+        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    }
 
 
 async def get_current_user(
@@ -52,8 +147,7 @@ async def get_current_user(
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
 
-    # BUG: No token revocation check — logged-out or compromised tokens
-    # remain valid until they naturally expire
+    # decode_token performs signature, expiry, and revocation checks first.
     user_data = {
         "id": payload.get("sub"),
         "address": payload.get("address"),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.115.0
+PyJWT>=2.10.0
 uvicorn>=0.34.0
 pydantic>=2.10.0
 httpx>=0.28.0

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,88 @@
+import os
+import subprocess
+import sys
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.middleware import auth
+from api.main import app
+
+
+@pytest.fixture(autouse=True)
+def clear_revoked_tokens():
+    auth.revoked_tokens.clear()
+    yield
+    auth.revoked_tokens.clear()
+
+
+def test_none_algorithm_is_rejected():
+    token = jwt.encode(
+        {"sub": "agent", "type": "access"},
+        key="",
+        algorithm="none",
+    )
+
+    with pytest.raises(HTTPException) as error:
+        auth.decode_token(token)
+
+    assert error.value.status_code == 401
+
+
+def test_missing_secret_does_not_crash_import():
+    environment = os.environ.copy()
+    environment.pop("JWT_SECRET", None)
+    result = subprocess.run(
+        [sys.executable, "-c", "import api.middleware.auth"],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_revoked_access_token_is_rejected():
+    tokens = auth.generate_login_tokens("agent-1", "0xabc")
+    assert auth.decode_token(tokens["token"])["sub"] == "agent-1"
+
+    auth.revoke_token(tokens["token"])
+
+    with pytest.raises(HTTPException) as error:
+        auth.decode_token(tokens["token"])
+    assert error.value.status_code == 401
+
+
+def test_refresh_requires_refresh_token_and_issues_access_token():
+    tokens = auth.generate_login_tokens("agent-1", "0xabc", ["solver"])
+    refreshed = auth.refresh_access_token(tokens["refresh_token"])
+    payload = auth.decode_token(refreshed["token"])
+
+    assert payload["type"] == "access"
+    assert payload["sub"] == "agent-1"
+    assert payload["roles"] == ["solver"]
+
+    with pytest.raises(HTTPException) as error:
+        auth.refresh_access_token(tokens["token"])
+    assert error.value.status_code == 401
+
+
+def test_auth_endpoints_refresh_and_revoke():
+    tokens = auth.generate_login_tokens("agent-1", "0xabc")
+    client = TestClient(app)
+
+    refresh_response = client.post(
+        "/auth/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+    assert refresh_response.status_code == 200
+    assert refresh_response.json()["token"]
+
+    revoke_response = client.post(
+        "/auth/revoke",
+        json={"token": tokens["token"]},
+    )
+    assert revoke_response.status_code == 200
+    assert revoke_response.json() == {"revoked": True}

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -63,9 +63,19 @@ def test_refresh_requires_refresh_token_and_issues_access_token():
     assert payload["type"] == "access"
     assert payload["sub"] == "agent-1"
     assert payload["roles"] == ["solver"]
+    assert refreshed["refresh_token"]
+
+    with pytest.raises(HTTPException) as error:
+        auth.refresh_access_token(tokens["refresh_token"])
+    assert error.value.status_code == 401
 
     with pytest.raises(HTTPException) as error:
         auth.refresh_access_token(tokens["token"])
+    assert error.value.status_code == 401
+
+    malformed_refresh = auth.create_refresh_token({"address": "0xabc"})
+    with pytest.raises(HTTPException) as error:
+        auth.refresh_access_token(malformed_refresh)
     assert error.value.status_code == 401
 
 
@@ -79,6 +89,7 @@ def test_auth_endpoints_refresh_and_revoke():
     )
     assert refresh_response.status_code == 200
     assert refresh_response.json()["token"]
+    assert refresh_response.json()["refresh_token"]
 
     revoke_response = client.post(
         "/auth/revoke",


### PR DESCRIPTION
/claim #100
Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## JWT authentication security fix

- Pin JWT verification to HS256 and reject unsigned `alg=none` tokens.
- Keep missing `JWT_SECRET` imports non-crashing with an ephemeral development secret.
- Add JTI-based revocation and enforce revocation during authentication.
- Add refresh/revoke endpoints.
- Rotate refresh tokens after use and reject malformed refresh payloads.
- Add the missing PyJWT dependency and focused tests.

## Verification

- `/tmp/openagents-auth-venv/bin/python -m pytest api/tests/test_auth.py -q` — 5 passed.
- `python -m py_compile api/middleware/auth.py api/main.py api/tests/test_auth.py` — passed.
- `python3 -m json.tool CONTRIBUTORS.json` — passed.
- `git diff --check` — passed.

The issue requests private platform/session initialization text in source metadata. The public patch intentionally includes only sanitized runtime metadata and reproducible verification details.

Closes #100