### PR TITLE
feat(sdk): add capped gas estimation

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "chico10117",
+      "timestamp": "2026-08-05T06:04:20Z",
+      "platform_instructions": "Private platform and session instructions intentionally omitted; public reproducibility metadata is recorded in the patch and test commands.",
+      "runtime": {
+        "os": "macOS",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-gas",
+        "shell": "zsh"
+      },
+      "contribution": "Added capped automatic gas estimation, manual gas-limit overrides, and EIP-1559 fee discovery to the SDK"
     }
   ]
 }

--- a/sdk/src/auth/wallet.ts
+++ b/sdk/src/auth/wallet.ts
@@ -1,6 +1,7 @@
 import { generateKeyPair, signMessage, keccak256 } from "../utils/crypto";
 import { encodeParams, AbiParam } from "../utils/encoding";
 import { RpcProvider } from "../providers/rpc";
+import { applyGasMargin, FeeData } from "../utils/gas";
 
 export interface WalletConfig {
   privateKey?: string;
@@ -11,8 +12,10 @@ export interface Transaction {
   to: string;
   value: bigint;
   data: string;
-  gasLimit: bigint;
+  gasLimit?: bigint;
   gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
   nonce?: number;
   chainId?: number;
 }
@@ -20,6 +23,10 @@ export interface Transaction {
 export interface SignedTransaction {
   raw: string;
   hash: string;
+  gasLimit: bigint;
+  gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
 }
 
 export class Wallet {
@@ -42,7 +49,7 @@ export class Wallet {
   }
 
   private deriveAddress(privateKey: string): string {
-    const { ec as EC } = require("elliptic");
+    const { ec: EC } = require("elliptic");
     const curve = new EC("secp256k1");
     const key = curve.keyFromPrivate(privateKey, "hex");
     const pubKey = key.getPublic(false, "hex").slice(2); // remove 04 prefix
@@ -50,16 +57,73 @@ export class Wallet {
     return "0x" + hash.slice(-40);
   }
 
+  async estimateGas(
+    tx: Omit<Transaction, "gasLimit" | "gasPrice" | "maxFeePerGas" | "maxPriorityFeePerGas">
+  ): Promise<bigint> {
+    const estimated = await this.provider.estimateGas({
+      from: this.address,
+      to: tx.to,
+      value: tx.value,
+      data: tx.data,
+    });
+    const blockGasLimit = await this.provider.getBlockGasLimit();
+    return applyGasMargin(estimated, blockGasLimit);
+  }
+
+  private async resolveFees(tx: Transaction): Promise<FeeData> {
+    const hasLegacyFee = tx.gasPrice !== undefined;
+    const hasEip1559Fee =
+      tx.maxFeePerGas !== undefined || tx.maxPriorityFeePerGas !== undefined;
+
+    if (hasLegacyFee && hasEip1559Fee) {
+      throw new Error("Use either gasPrice or EIP-1559 fee fields, not both");
+    }
+    if (hasLegacyFee) {
+      return { gasPrice: tx.gasPrice };
+    }
+
+    const feeData = await this.provider.getFeeData();
+    if (!hasEip1559Fee) {
+      return feeData;
+    }
+
+    if (
+      feeData.maxFeePerGas === undefined ||
+      feeData.maxPriorityFeePerGas === undefined
+    ) {
+      throw new Error("RPC provider does not expose EIP-1559 fee data");
+    }
+
+    return {
+      maxFeePerGas: tx.maxFeePerGas ?? feeData.maxFeePerGas,
+      maxPriorityFeePerGas:
+        tx.maxPriorityFeePerGas ?? feeData.maxPriorityFeePerGas,
+    };
+  }
+
   async signTransaction(tx: Transaction): Promise<SignedTransaction> {
     // BUG: No chain ID validation — transaction could be replayed on a different
     // chain if chainId is missing or mismatched with the provider
     const nonce = tx.nonce ?? await this.getNonce();
-    const gasPrice = tx.gasPrice ?? BigInt(await this.provider.call("eth_gasPrice") as string);
+    const gasLimit =
+      tx.gasLimit ??
+      (await this.estimateGas({
+        to: tx.to,
+        value: tx.value,
+        data: tx.data,
+        nonce: tx.nonce,
+        chainId: tx.chainId,
+      }));
+    const fees = await this.resolveFees(tx);
+    const gasPrice = fees.gasPrice ?? fees.maxFeePerGas;
+    if (gasPrice === undefined) {
+      throw new Error("RPC provider did not return a usable gas fee");
+    }
 
     const txData = encodeParams([
       { type: "uint256", value: nonce } as AbiParam,
       { type: "uint256", value: gasPrice } as AbiParam,
-      { type: "uint256", value: tx.gasLimit } as AbiParam,
+      { type: "uint256", value: gasLimit } as AbiParam,
       { type: "address", value: tx.to } as AbiParam,
       { type: "uint256", value: tx.value } as AbiParam,
     ]);
@@ -70,6 +134,8 @@ export class Wallet {
     return {
       raw: "0x" + txData.slice(2) + signature,
       hash: "0x" + txHash,
+      gasLimit,
+      ...fees,
     };
   }
 

--- a/sdk/src/providers/rpc.ts
+++ b/sdk/src/providers/rpc.ts
@@ -1,4 +1,10 @@
 import { withRetry, RetryOptions } from "../utils/retry";
+import {
+  FeeData,
+  GasEstimationTransaction,
+  parseRpcQuantity,
+  toRpcTransaction,
+} from "../utils/gas";
 
 export interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -85,6 +91,64 @@ export class RpcProvider {
     return responses
       .sort((a, b) => a.id - b.id)
       .map((r) => r.result);
+  }
+
+  async estimateGas(transaction: GasEstimationTransaction): Promise<bigint> {
+    const result = await this.call("eth_estimateGas", [
+      toRpcTransaction(transaction),
+    ]);
+    return parseRpcQuantity(result, "eth_estimateGas");
+  }
+
+  async getBlockGasLimit(): Promise<bigint> {
+    const block = await this.call("eth_getBlockByNumber", ["latest", false]);
+    if (!block || typeof block !== "object" || !("gasLimit" in block)) {
+      throw new Error("RPC latest block is missing gasLimit");
+    }
+
+    return parseRpcQuantity(
+      (block as { gasLimit: unknown }).gasLimit,
+      "latest.gasLimit"
+    );
+  }
+
+  async getFeeData(): Promise<FeeData> {
+    const block = await this.call("eth_getBlockByNumber", ["latest", false]);
+    const baseFeePerGas =
+      block && typeof block === "object" && "baseFeePerGas" in block
+        ? (block as { baseFeePerGas?: unknown }).baseFeePerGas
+        : undefined;
+
+    if (typeof baseFeePerGas !== "string") {
+      return {
+        gasPrice: parseRpcQuantity(
+          await this.call("eth_gasPrice"),
+          "eth_gasPrice"
+        ),
+      };
+    }
+
+    const baseFee = parseRpcQuantity(baseFeePerGas, "latest.baseFeePerGas");
+    let maxPriorityFeePerGas: bigint;
+
+    try {
+      maxPriorityFeePerGas = parseRpcQuantity(
+        await this.call("eth_maxPriorityFeePerGas"),
+        "eth_maxPriorityFeePerGas"
+      );
+    } catch {
+      const gasPrice = parseRpcQuantity(
+        await this.call("eth_gasPrice"),
+        "eth_gasPrice"
+      );
+      maxPriorityFeePerGas =
+        gasPrice > baseFee ? gasPrice - baseFee : 1_000_000_000n;
+    }
+
+    return {
+      maxPriorityFeePerGas,
+      maxFeePerGas: baseFee * 2n + maxPriorityFeePerGas,
+    };
   }
 
   async getBlockNumber(): Promise<number> {

--- a/sdk/src/utils/gas.ts
+++ b/sdk/src/utils/gas.ts
@@ -1,0 +1,67 @@
+export interface GasEstimationTransaction {
+  from?: string;
+  to: string;
+  value?: bigint;
+  data?: string;
+}
+
+export interface FeeData {
+  gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+}
+
+export function toRpcQuantity(value: bigint): string {
+  if (value < 0n) {
+    throw new Error("RPC quantities cannot be negative");
+  }
+
+  return `0x${value.toString(16)}`;
+}
+
+export function parseRpcQuantity(value: unknown, field: string): bigint {
+  if (typeof value !== "string" || !/^0x[0-9a-f]+$/i.test(value)) {
+    throw new Error(`RPC field ${field} must be a hexadecimal quantity`);
+  }
+
+  return BigInt(value);
+}
+
+export function applyGasMargin(
+  estimatedGas: bigint,
+  blockGasLimit: bigint,
+  marginPercent = 20
+): bigint {
+  if (estimatedGas < 0n) {
+    throw new Error("Estimated gas cannot be negative");
+  }
+  if (blockGasLimit <= 0n) {
+    throw new Error("Block gas limit must be positive");
+  }
+  if (!Number.isInteger(marginPercent) || marginPercent < 0) {
+    throw new Error("Gas margin must be a non-negative integer");
+  }
+
+  const denominator = 100n;
+  const numerator = denominator + BigInt(marginPercent);
+  const padded = (estimatedGas * numerator + denominator - 1n) / denominator;
+  return padded > blockGasLimit ? blockGasLimit : padded;
+}
+
+export function toRpcTransaction(
+  transaction: GasEstimationTransaction
+): Record<string, string> {
+  const rpcTransaction: Record<string, string> = {
+    to: transaction.to,
+    data: transaction.data ?? "0x",
+  };
+
+  if (transaction.from !== undefined) {
+    rpcTransaction.from = transaction.from;
+  }
+  if (transaction.value !== undefined) {
+    rpcTransaction.value = toRpcQuantity(transaction.value);
+  }
+
+  return rpcTransaction;
+}

--- a/sdk/test/gas-estimation.test.ts
+++ b/sdk/test/gas-estimation.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyGasMargin,
+  parseRpcQuantity,
+  toRpcQuantity,
+  toRpcTransaction,
+} from "../src/utils/gas.ts";
+
+test("applies a rounded-up 20% margin", () => {
+  assert.equal(applyGasMargin(100_000n, 200_000n), 120_000n);
+  assert.equal(applyGasMargin(101n, 200n), 122n);
+});
+
+test("caps the padded estimate at the latest block gas limit", () => {
+  assert.equal(applyGasMargin(90n, 100n), 100n);
+});
+
+test("supports explicit margin validation and RPC quantities", () => {
+  assert.equal(toRpcQuantity(0n), "0x0");
+  assert.equal(parseRpcQuantity("0x5208", "gas"), 21_000n);
+  assert.throws(() => parseRpcQuantity("21000", "gas"), /hexadecimal/);
+  assert.throws(() => applyGasMargin(1n, 100n, -1), /non-negative/);
+});
+
+test("serializes estimation input without losing zero values", () => {
+  assert.deepEqual(
+    toRpcTransaction({
+      from: "0xabc",
+      to: "0xdef",
+      value: 0n,
+      data: "0x1234",
+    }),
+    { from: "0xabc", to: "0xdef", value: "0x0", data: "0x1234" }
+  );
+});


### PR DESCRIPTION
/claim #101
Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Automatic gas estimation

- Call JSON-RPC `eth_estimateGas` when callers omit `gasLimit`.
- Apply a rounded 20% safety margin and cap at the latest block gas limit.
- Preserve explicit gas-limit overrides.
- Discover EIP-1559 fee data with a legacy gas-price fallback.
- Reject mixed legacy and EIP-1559 fee inputs.
- Add focused tests and sanitized contributor/runtime metadata.

## Verification

- `node --experimental-strip-types --test sdk/test/gas-estimation.test.ts` — 4 passed.
- Targeted TypeScript validation and `git diff --check` — passed.
- Root Hardhat tests remain blocked by the repository baseline: config Solidity 0.8.20 conflicts with installed OpenZeppelin imports requiring ^0.8.24.

The issue requests private platform/session initialization text in source metadata. The public patch intentionally includes only sanitized runtime metadata and reproducible verification details.

Closes #101