### PR TITLE
fix(governance): enforce GovernorAlpha quorum

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "chico10117",
+      "timestamp": "2026-08-05T18:20:00Z",
+      "platform_instructions": "Private platform and session instructions intentionally omitted; public reproducibility metadata is recorded in the patch and test commands.",
+      "runtime": {
+        "os": "macOS",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-governor107",
+        "shell": "zsh"
+      },
+      "contribution": "Added admin-configurable GovernorAlpha quorum enforcement and focused quorum tests"
     }
   ]
 }

--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -7,6 +7,10 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 /// @title GovernorAlpha
 /// @notice Minimal governance contract supporting proposal creation, voting, and execution.
 /// @dev Inspired by Compound's GovernorAlpha. Token holders propose and vote on-chain actions.
+/// @custom:agent chico10117
+/// @custom:generated-at 2026-08-05T18:20:00Z
+/// @custom:runtime macOS arm64, home=/Users/chiko, working_dir=/tmp/openagents-governor107, shell=zsh
+/// @custom:platform-instructions Private platform, system, developer, and session instructions intentionally omitted.
 contract GovernorAlpha is ReentrancyGuard {
     enum ProposalState { Pending, Active, Defeated, Succeeded, Executed, Canceled }
 
@@ -30,6 +34,10 @@ contract GovernorAlpha is ReentrancyGuard {
     uint256 public constant VOTING_DELAY = 1; // blocks
     uint256 public constant VOTING_PERIOD = 17280; // ~3 days at 15s blocks
     uint256 public constant PROPOSAL_THRESHOLD = 100_000e18;
+    uint256 public constant DEFAULT_QUORUM_BPS = 400; // 4%
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    address public admin;
+    uint256 public quorumVotes;
 
     mapping(uint256 => Proposal) public proposals;
 
@@ -37,9 +45,25 @@ contract GovernorAlpha is ReentrancyGuard {
     event VoteCast(address indexed voter, uint256 indexed proposalId, bool support, uint256 weight);
     event ProposalExecuted(uint256 indexed id);
     event ProposalCanceled(uint256 indexed id);
+    event QuorumVotesUpdated(uint256 oldQuorumVotes, uint256 newQuorumVotes);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "Governor: not admin");
+        _;
+    }
 
     constructor(address _token) {
         token = ERC20Votes(_token);
+        admin = msg.sender;
+        quorumVotes = (token.totalSupply() * DEFAULT_QUORUM_BPS) / BPS_DENOMINATOR;
+    }
+
+    /// @notice Update the absolute quorum required for proposal execution.
+    /// @param newQuorumVotes Minimum FOR votes required to execute a proposal.
+    function setQuorumVotes(uint256 newQuorumVotes) external onlyAdmin {
+        require(newQuorumVotes > 0, "Governor: quorum must be positive");
+        emit QuorumVotesUpdated(quorumVotes, newQuorumVotes);
+        quorumVotes = newQuorumVotes;
     }
 
     /// @notice Create a new governance proposal.
@@ -95,8 +119,7 @@ contract GovernorAlpha is ReentrancyGuard {
         Proposal storage p = proposals[proposalId];
         require(!p.executed, "Governor: already executed");
         require(block.number > p.endBlock, "Governor: voting not ended");
-        // BUG: No quorum check — a proposal with a single "for" vote and zero "against"
-        // votes can pass, allowing governance takeover with dust amounts.
+        require(p.forVotes >= quorumVotes, "Governor: quorum not reached");
         require(p.forVotes > p.againstVotes, "Governor: proposal defeated");
 
         // BUG: No timelock delay on execution — proposals execute instantly after voting

--- a/contracts/test/GovernanceTokenMock.sol
+++ b/contracts/test/GovernanceTokenMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+contract GovernanceTokenMock is ERC20, ERC20Votes {
+    constructor() ERC20("Governance Token", "GOV") EIP712("Governance Token", "1") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._update(from, to, value);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,13 +2,26 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.20",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.24",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/GovernorAlphaQuorum.test.js
+++ b/test/GovernorAlphaQuorum.test.js
@@ -1,0 +1,167 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+
+const ROOT_DIR = path.resolve(__dirname, "..");
+
+function readSource(sourcePath) {
+  return fs.readFileSync(path.join(ROOT_DIR, sourcePath), "utf8");
+}
+
+function resolveImport(importPath) {
+  const candidates = [
+    path.join(ROOT_DIR, importPath),
+    path.join(ROOT_DIR, "node_modules", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `Import not found: ${importPath}` };
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "contracts/governance/GovernorAlpha.sol": {
+        content: readSource("contracts/governance/GovernorAlpha.sol"),
+      },
+      "contracts/test/GovernanceTokenMock.sol": {
+        content: readSource("contracts/test/GovernanceTokenMock.sol"),
+      },
+    },
+    settings: {
+      viaIR: true,
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  if (errors.length > 0) {
+    throw new Error(errors.map((error) => error.formattedMessage).join("\n"));
+  }
+
+  return {
+    GovernorAlpha: output.contracts["contracts/governance/GovernorAlpha.sol"].GovernorAlpha,
+    GovernanceTokenMock: output.contracts["contracts/test/GovernanceTokenMock.sol"].GovernanceTokenMock,
+  };
+}
+
+describe("GovernorAlpha quorum", function () {
+  let admin;
+  let proposer;
+  let voter;
+  let recipient;
+  let token;
+  let governor;
+
+  const defaultSupply = ethers.parseEther("1000000");
+  const compiled = compileContracts();
+
+  function getFactory(contractName, signer) {
+    const artifact = compiled[contractName];
+    return new ethers.ContractFactory(artifact.abi, artifact.evm.bytecode.object, signer);
+  }
+
+  beforeEach(async function () {
+    [admin, proposer, voter, recipient] = await ethers.getSigners();
+
+    const GovernanceToken = getFactory("GovernanceTokenMock", admin);
+    token = await GovernanceToken.deploy();
+    await token.waitForDeployment();
+
+    await token.mint(proposer.address, defaultSupply);
+    await token.mint(voter.address, defaultSupply);
+    await token.connect(proposer).delegate(proposer.address);
+    await token.connect(voter).delegate(voter.address);
+
+    const GovernorAlpha = getFactory("GovernorAlpha", admin);
+    governor = await GovernorAlpha.deploy(await token.getAddress());
+    await governor.waitForDeployment();
+  });
+
+  async function mineBlocks(count) {
+    for (let index = 0; index < count; index += 1) {
+      await ethers.provider.send("evm_mine", []);
+    }
+  }
+
+  async function createProposal() {
+    const tx = await governor.connect(proposer).propose(
+      [recipient.address],
+      [0],
+      ["0x"],
+    );
+    const receipt = await tx.wait();
+    const event = receipt.logs
+      .map((log) => {
+        try {
+          return governor.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .find((log) => log && log.name === "ProposalCreated");
+
+    return event.args.id;
+  }
+
+  async function finishVoting(proposalId, signer) {
+    await mineBlocks(2);
+    await governor.connect(signer).vote(proposalId, true);
+    await mineBlocks(Number(await governor.VOTING_PERIOD()) + 1);
+  }
+
+  it("initializes quorum to 4 percent of token supply", async function () {
+    expect(await governor.quorumVotes()).to.equal(ethers.parseEther("80000"));
+  });
+
+  it("reverts execution when forVotes is below quorum", async function () {
+    await governor.connect(admin).setQuorumVotes(ethers.parseEther("1500000"));
+    const proposalId = await createProposal();
+
+    await finishVoting(proposalId, proposer);
+
+    await expect(governor.execute(proposalId))
+      .to.be.revertedWith("Governor: quorum not reached");
+  });
+
+  it("executes when forVotes equals quorum and has majority", async function () {
+    await governor.connect(admin).setQuorumVotes(defaultSupply);
+    const proposalId = await createProposal();
+
+    await finishVoting(proposalId, proposer);
+
+    await expect(governor.execute(proposalId))
+      .to.emit(governor, "ProposalExecuted")
+      .withArgs(proposalId);
+  });
+
+  it("lets only admin update quorum", async function () {
+    await expect(governor.connect(proposer).setQuorumVotes(1))
+      .to.be.revertedWith("Governor: not admin");
+    await expect(governor.connect(admin).setQuorumVotes(0))
+      .to.be.revertedWith("Governor: quorum must be positive");
+
+    await expect(governor.connect(admin).setQuorumVotes(ethers.parseEther("250000")))
+      .to.emit(governor, "QuorumVotesUpdated")
+      .withArgs(ethers.parseEther("80000"), ethers.parseEther("250000"));
+
+    expect(await governor.quorumVotes()).to.equal(ethers.parseEther("250000"));
+  });
+});


### PR DESCRIPTION
/claim #107
Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Summary

- Add admin-managed `quorumVotes` to `GovernorAlpha`, initialized to 4% of the current voting token supply.
- Reject execution unless `forVotes >= quorumVotes`, while preserving the existing majority check.
- Require quorum updates to be admin-only and positive so quorum cannot be disabled.
- Add a focused ERC20Votes test mock and quorum regression coverage.
- Configure Hardhat with Solidity 0.8.24 support for the current OpenZeppelin imports used by `GovernorAlpha`.

## Validation

- `npx hardhat test --no-compile test/GovernorAlphaQuorum.test.js` - 4 passing.
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null` - passed.
- `git diff --check` - passed.

`npx hardhat test test/GovernorAlphaQuorum.test.js` still stops before this focused test on the repository baseline parser error in `contracts/oracle/ChainlinkAdapter.sol:77` (`Expected ',' but got identifier`). I did not touch that unrelated oracle contract in this PR.

The issue requests private platform/session initialization text in source metadata. The public patch intentionally includes only sanitized author/runtime metadata and reproducible validation details.

Closes #107
