### PR TITLE
fix(api): validate agent endpoint URLs

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "openai-codex-agent-url-187",
+      "timestamp": "2026-08-05T19:32:00Z",
+      "platform_instructions": "Sanitized metadata only. Full platform/session instructions are intentionally not included because they may contain private system, developer, or user data.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/var/folders/r4/jd4y09m973d147kgr79f74_00000gn/T/openagents-request187.XXXXXX.mjZcMUyArL",
+        "shell": "zsh"
+      },
+      "contribution": "Added public URL validation, HEAD reachability checks, SSRF blocking, endpoint storage, and focused tests"
     }
   ]
 }

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -43,6 +43,7 @@ class Agent(Base):
     name = Column(String(128), nullable=False)
     description = Column(Text, nullable=True)
     model_type = Column(String(32), default="gpt-4")
+    endpoint = Column(String(2048), nullable=False)
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -7,12 +7,14 @@ from datetime import datetime
 
 from ..models.database import get_db, Agent
 from ..middleware.auth import get_current_user
+from ..validation.agent_endpoint import validate_agent_endpoint
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
 
 class AgentCreate(BaseModel):
     name: str  # BUG: No validation — name can contain SQL injection, XSS, or be empty
+    endpoint: str
     description: Optional[str] = None
     model_type: str = "gpt-4"
     config: Optional[dict] = None
@@ -26,8 +28,10 @@ class AgentUpdate(BaseModel):
 
 @router.post("/")
 async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=Depends(get_db)):
+    endpoint = await validate_agent_endpoint(agent.endpoint)
     new_agent = Agent(
         name=agent.name,
+        endpoint=endpoint,
         description=agent.description,
         model_type=agent.model_type,
         config=agent.config or {},
@@ -37,7 +41,7 @@ async def create_agent(agent: AgentCreate, user=Depends(get_current_user), db=De
     db.add(new_agent)
     db.commit()
     db.refresh(new_agent)
-    return {"id": new_agent.id, "name": new_agent.name, "owner": user["address"]}
+    return {"id": new_agent.id, "name": new_agent.name, "endpoint": new_agent.endpoint, "owner": user["address"]}
 
 
 @router.get("/")

--- a/api/test_agent_endpoint_validation.py
+++ b/api/test_agent_endpoint_validation.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+from fastapi import HTTPException
+
+from api.validation.agent_endpoint import validate_agent_endpoint
+
+
+class AgentEndpointValidationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_valid_url_passes_after_successful_head(self):
+        response = Mock(status_code=204)
+        client = AsyncMock()
+        client.__aenter__.return_value = client
+        client.head.return_value = response
+
+        with (
+            patch(
+                "api.validation.agent_endpoint._resolved_addresses",
+                new=AsyncMock(return_value={"93.184.216.34"}),
+            ),
+            patch("api.validation.agent_endpoint.httpx.AsyncClient", return_value=client),
+        ):
+            endpoint = await validate_agent_endpoint("https://agent.example.com/health")
+
+        self.assertEqual(endpoint, "https://agent.example.com/health")
+        client.head.assert_awaited_once_with("https://agent.example.com/health")
+
+    async def test_invalid_url_format_is_rejected(self):
+        with self.assertRaises(HTTPException) as raised:
+            await validate_agent_endpoint("ftp://agent.example.com")
+
+        self.assertEqual(raised.exception.status_code, 422)
+        self.assertIn("http or https", raised.exception.detail)
+
+    async def test_private_ip_literal_is_rejected_before_head_request(self):
+        with patch("api.validation.agent_endpoint.httpx.AsyncClient") as client_cls:
+            with self.assertRaises(HTTPException) as raised:
+                await validate_agent_endpoint("http://192.168.1.25:8080")
+
+        self.assertEqual(raised.exception.status_code, 422)
+        self.assertIn("private or internal", raised.exception.detail)
+        client_cls.assert_not_called()
+
+    async def test_private_dns_resolution_is_rejected(self):
+        with (
+            patch(
+                "api.validation.agent_endpoint._resolved_addresses",
+                new=AsyncMock(return_value={"10.0.0.8"}),
+            ),
+            patch("api.validation.agent_endpoint.httpx.AsyncClient") as client_cls,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await validate_agent_endpoint("https://agent.example.com")
+
+        self.assertEqual(raised.exception.status_code, 422)
+        self.assertIn("private or internal", raised.exception.detail)
+        client_cls.assert_not_called()
+
+    async def test_timeout_returns_gateway_timeout(self):
+        client = AsyncMock()
+        client.__aenter__.return_value = client
+        client.head.side_effect = httpx.TimeoutException("slow")
+
+        with (
+            patch(
+                "api.validation.agent_endpoint._resolved_addresses",
+                new=AsyncMock(return_value={"93.184.216.34"}),
+            ),
+            patch("api.validation.agent_endpoint.httpx.AsyncClient", return_value=client),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await validate_agent_endpoint("https://agent.example.com")
+
+        self.assertEqual(raised.exception.status_code, 504)
+        self.assertIn("timed out", raised.exception.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/validation/__init__.py
+++ b/api/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation helpers for OpenAgents API inputs."""

--- a/api/validation/agent_endpoint.py
+++ b/api/validation/agent_endpoint.py
@@ -1,0 +1,118 @@
+"""Agent endpoint URL validation with SSRF protection."""
+
+import asyncio
+import ipaddress
+import socket
+from typing import Iterable
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import HTTPException
+
+
+ALLOWED_ENDPOINT_SCHEMES = {"http", "https"}
+ENDPOINT_TIMEOUT_SECONDS = 5.0
+
+
+def _is_blocked_ip(address: str) -> bool:
+    ip = ipaddress.ip_address(address)
+    return any(
+        (
+            ip.is_private,
+            ip.is_loopback,
+            ip.is_link_local,
+            ip.is_multicast,
+            ip.is_reserved,
+            ip.is_unspecified,
+        )
+    )
+
+
+def _validate_url_shape(endpoint: str):
+    parsed = urlparse(endpoint)
+
+    if parsed.scheme not in ALLOWED_ENDPOINT_SCHEMES:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must be a valid http or https URL",
+        )
+    if not parsed.hostname:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must include a hostname",
+        )
+    if parsed.username or parsed.password:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must not include credentials",
+        )
+
+    try:
+        if _is_blocked_ip(parsed.hostname):
+            raise HTTPException(
+                status_code=422,
+                detail="Agent endpoint must not target private or internal IPs",
+            )
+    except ValueError:
+        # Hostname is not an IP literal; DNS resolution is checked separately.
+        pass
+
+    return parsed
+
+
+def _resolve_host(hostname: str) -> Iterable[str]:
+    resolved = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    return {result[4][0] for result in resolved}
+
+
+async def _resolved_addresses(hostname: str) -> Iterable[str]:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _resolve_host, hostname)
+
+
+async def validate_agent_endpoint(endpoint: str) -> str:
+    """Validate that an agent endpoint is public, reachable, and safe to store."""
+
+    parsed = _validate_url_shape(endpoint)
+
+    try:
+        addresses = await _resolved_addresses(parsed.hostname)
+    except socket.gaierror as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint hostname could not be resolved",
+        ) from exc
+
+    if not addresses:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint hostname could not be resolved",
+        )
+
+    if any(_is_blocked_ip(address) for address in addresses):
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint must not resolve to private or internal IPs",
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=ENDPOINT_TIMEOUT_SECONDS, follow_redirects=False) as client:
+            response = await client.head(endpoint)
+    except httpx.TimeoutException as exc:
+        raise HTTPException(
+            status_code=504,
+            detail="Agent endpoint reachability check timed out",
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="Agent endpoint could not be reached with a HEAD request",
+        ) from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Agent endpoint HEAD check returned HTTP {response.status_code}",
+        )
+
+    return endpoint


### PR DESCRIPTION
/claim #187
💳 Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

Closes #187

## Summary
- Adds endpoint input to agent registration and stores the validated URL.
- Requires http/https URLs, rejects embedded credentials, and returns descriptive validation errors.
- Blocks private/internal IP literals and hostnames that resolve to private/internal addresses.
- Verifies reachability with a bounded HEAD request and returns a timeout-specific error if the endpoint hangs.
- Adds focused tests for valid URL, invalid format, private IP literal, private DNS resolution, and timeout handling.

## Security note
The issue requests full platform/session instructions in source metadata. This PR intentionally includes only sanitized contributor metadata and does not expose private system, developer, or user-provided instructions.

## Verification
- /var/folders/r4/jd4y09m973d147kgr79f74_00000gn/T/openagents-request178-venv.XXXXXX.V8o4QW01rD/bin/python -m unittest api.test_agent_endpoint_validation
- /var/folders/r4/jd4y09m973d147kgr79f74_00000gn/T/openagents-request178-venv.XXXXXX.V8o4QW01rD/bin/python -m compileall -q api
- python3 -m json.tool CONTRIBUTORS.json
- git diff --check

## Competing PR review
Before submission I checked for currently open pull requests with issue 187 and issue 173 in the PR body using GitHub PR search. No active open overlap was found; the older referenced PRs were closed.
