### PR TITLE
fix(dex): enforce swap deadline and fees

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-chico10117-issue5",
+      "timestamp": "2026-08-05T20:20:58Z",
+      "platform_instructions": "Public task context only: OpenAgents issue #5 requested swap slippage protection, deadline enforcement, a minimum 1 wei fee for swaps, tests, and contributor metadata. Private system/developer/session initialization text was intentionally omitted.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-issue5.C214b6/repo",
+        "shell": "zsh"
+      },
+      "contribution": "Added AMMPool deadline enforcement, minimum nonzero swap fees, and focused swap protection tests"
     }
   ]
 }

--- a/contracts/dex/AMMPool.sol
+++ b/contracts/dex/AMMPool.sol
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/// @custom:contributor-info
+///   agent: Codex
+///   public_task: OpenAgents issue #5, add swap deadline protection and nonzero swap fees
+///   runtime: macOS Darwin arm64, zsh, /tmp/openagents-issue5.C214b6/repo
+///   privacy: private system/developer/session initialization text intentionally omitted
+
 interface IERC20 {
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
     function transfer(address to, uint256 amount) external returns (bool);
@@ -23,7 +29,7 @@ contract AMMPool {
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB);
-    event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut, uint256 fee);
 
     constructor(address _tokenA, address _tokenB) {
         tokenA = IERC20(_tokenA);
@@ -72,19 +78,22 @@ contract AMMPool {
         emit LiquidityRemoved(msg.sender, amountA, amountB);
     }
 
-    // BUG: Swap has no deadline parameter — transaction can sit in mempool and execute
-    // at a much later time when price has moved unfavorably (stale transaction attack)
-    // BUG: Fee truncates to zero for small swaps — (amountIn * 30) / 10000 rounds to 0
-    // when amountIn < 334, meaning tiny swaps pay no fee and can drain value over time
-    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Zero input");
+        require(block.timestamp <= deadline, "Swap expired");
 
         bool isA = tokenIn == address(tokenA);
         (uint256 resIn, uint256 resOut) = isA ? (reserveA, reserveB) : (reserveB, reserveA);
 
-        uint256 amountInWithFee = amountIn * (10000 - FEE_BPS);
-        amountOut = (amountInWithFee * resOut) / (resIn * 10000 + amountInWithFee);
+        uint256 fee = _calculateFee(amountIn);
+        uint256 amountInAfterFee = amountIn - fee;
+        amountOut = (amountInAfterFee * resOut) / (resIn + amountInAfterFee);
 
         require(amountOut >= minAmountOut, "Slippage exceeded");
 
@@ -102,7 +111,29 @@ contract AMMPool {
             reserveA -= amountOut;
         }
 
-        emit Swap(msg.sender, tokenIn, amountIn, amountOut);
+        emit Swap(msg.sender, tokenIn, amountIn, amountOut, fee);
+    }
+
+    function getAmountOut(
+        address tokenIn,
+        uint256 amountIn
+    ) external view returns (uint256 amountOut, uint256 fee) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+        require(amountIn > 0, "Zero input");
+
+        bool isA = tokenIn == address(tokenA);
+        (uint256 resIn, uint256 resOut) = isA ? (reserveA, reserveB) : (reserveB, reserveA);
+
+        fee = _calculateFee(amountIn);
+        uint256 amountInAfterFee = amountIn - fee;
+        amountOut = (amountInAfterFee * resOut) / (resIn + amountInAfterFee);
+    }
+
+    function _calculateFee(uint256 amountIn) internal pure returns (uint256 fee) {
+        fee = (amountIn * FEE_BPS) / 10000;
+        if (fee == 0) {
+            return 1;
+        }
     }
 
     function _sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/contracts/dex/AMMPoolTestToken.sol
+++ b/contracts/dex/AMMPoolTestToken.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract AMMPoolTestToken {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        require(currentAllowance >= amount, "ERC20: insufficient allowance");
+        allowance[from][msg.sender] = currentAllowance - amount;
+
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/contracts/dex/Router.sol
+++ b/contracts/dex/Router.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 interface IAMMPool {
-    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut) external returns (uint256);
+    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut, uint256 deadline) external returns (uint256);
     function getReserves() external view returns (uint256, uint256);
+    function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256, uint256);
     function tokenA() external view returns (address);
     function tokenB() external view returns (address);
 }
@@ -47,9 +48,11 @@ contract Router {
     function swapMultiHop(
         address[] calldata path,
         uint256 amountIn,
-        uint256 /* minAmountOut */
+        uint256 minAmountOut,
+        uint256 deadline
     ) external returns (uint256 amountOut) {
         require(path.length >= 2, "Path too short");
+        require(block.timestamp <= deadline, "Swap expired");
 
         IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
 
@@ -64,11 +67,11 @@ contract Router {
 
             IERC20(tokenIn).approve(pool, currentAmount);
 
-            // Passes 0 as minAmountOut — no slippage protection on intermediate hops
-            currentAmount = IAMMPool(pool).swap(tokenIn, currentAmount, 0);
+            currentAmount = IAMMPool(pool).swap(tokenIn, currentAmount, 0, deadline);
         }
 
         amountOut = currentAmount;
+        require(amountOut >= minAmountOut, "Slippage exceeded");
 
         // Transfer final tokens to user
         IERC20(path[path.length - 1]).transfer(msg.sender, amountOut);
@@ -86,12 +89,8 @@ contract Router {
             address pool = pools[path[i]][path[i + 1]];
             require(pool != address(0), "No pool");
 
-            (uint256 resA, uint256 resB) = IAMMPool(pool).getReserves();
-            address tA = IAMMPool(pool).tokenA();
-
-            (uint256 resIn, uint256 resOut) = (path[i] == tA) ? (resA, resB) : (resB, resA);
-            uint256 amountInWithFee = currentAmount * 9970;
-            currentAmount = (amountInWithFee * resOut) / (resIn * 10000 + amountInWithFee);
+            (uint256 quotedOut, ) = IAMMPool(pool).getAmountOut(path[i], currentAmount);
+            currentAmount = quotedOut;
         }
 
         return currentAmount;

--- a/test/AMMPool.test.js
+++ b/test/AMMPool.test.js
@@ -1,0 +1,104 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("AMMPool swap protections", function () {
+  let pool;
+  let tokenA;
+  let tokenB;
+  let owner;
+  let trader;
+
+  const INITIAL_LIQUIDITY = ethers.parseEther("1000");
+  const SWAP_AMOUNT = ethers.parseEther("10");
+
+  beforeEach(async function () {
+    [owner, trader] = await ethers.getSigners();
+
+    const AMMPoolTestToken = await ethers.getContractFactory("AMMPoolTestToken");
+    tokenA = await AMMPoolTestToken.deploy("Token A", "TKNA");
+    tokenB = await AMMPoolTestToken.deploy("Token B", "TKNB");
+    await tokenA.waitForDeployment();
+    await tokenB.waitForDeployment();
+
+    const AMMPool = await ethers.getContractFactory("AMMPool");
+    pool = await AMMPool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    await pool.waitForDeployment();
+
+    await tokenA.mint(owner.address, INITIAL_LIQUIDITY);
+    await tokenB.mint(owner.address, INITIAL_LIQUIDITY);
+    await tokenA.mint(trader.address, ethers.parseEther("100"));
+    await tokenB.mint(trader.address, ethers.parseEther("100"));
+
+    await tokenA.approve(await pool.getAddress(), INITIAL_LIQUIDITY);
+    await tokenB.approve(await pool.getAddress(), INITIAL_LIQUIDITY);
+    await pool.addLiquidity(INITIAL_LIQUIDITY, INITIAL_LIQUIDITY);
+  });
+
+  async function futureDeadline() {
+    const latest = await ethers.provider.getBlock("latest");
+    return BigInt(latest.timestamp + 3600);
+  }
+
+  it("reverts when output is below minAmountOut", async function () {
+    await tokenA.connect(trader).approve(await pool.getAddress(), SWAP_AMOUNT);
+    const [quotedOut] = await pool.getAmountOut(await tokenA.getAddress(), SWAP_AMOUNT);
+
+    await expect(
+      pool.connect(trader).swap(
+        await tokenA.getAddress(),
+        SWAP_AMOUNT,
+        quotedOut + 1n,
+        await futureDeadline()
+      )
+    ).to.be.revertedWith("Slippage exceeded");
+  });
+
+  it("reverts when the deadline has passed", async function () {
+    await tokenA.connect(trader).approve(await pool.getAddress(), SWAP_AMOUNT);
+    const [quotedOut] = await pool.getAmountOut(await tokenA.getAddress(), SWAP_AMOUNT);
+    const latest = await ethers.provider.getBlock("latest");
+
+    await expect(
+      pool.connect(trader).swap(
+        await tokenA.getAddress(),
+        SWAP_AMOUNT,
+        quotedOut,
+        latest.timestamp - 1
+      )
+    ).to.be.revertedWith("Swap expired");
+  });
+
+  it("charges at least a 1 wei fee for tiny swaps", async function () {
+    const tinyAmount = 100n;
+    await tokenA.connect(trader).approve(await pool.getAddress(), tinyAmount);
+    const [quotedOut, fee] = await pool.getAmountOut(await tokenA.getAddress(), tinyAmount);
+
+    expect(fee).to.equal(1n);
+
+    await expect(
+      pool.connect(trader).swap(
+        await tokenA.getAddress(),
+        tinyAmount,
+        quotedOut,
+        await futureDeadline()
+      )
+    )
+      .to.emit(pool, "Swap")
+      .withArgs(trader.address, await tokenA.getAddress(), tinyAmount, quotedOut, 1n);
+  });
+
+  it("executes when minAmountOut and deadline are satisfied", async function () {
+    await tokenA.connect(trader).approve(await pool.getAddress(), SWAP_AMOUNT);
+    const [quotedOut] = await pool.getAmountOut(await tokenA.getAddress(), SWAP_AMOUNT);
+    const traderTokenBBefore = await tokenB.balanceOf(trader.address);
+
+    await pool.connect(trader).swap(
+      await tokenA.getAddress(),
+      SWAP_AMOUNT,
+      quotedOut,
+      await futureDeadline()
+    );
+
+    expect(await tokenB.balanceOf(trader.address)).to.equal(traderTokenBBefore + quotedOut);
+  });
+});


### PR DESCRIPTION
/claim #5
💳 Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Summary
- Adds a `deadline` parameter to AMMPool swaps and rejects expired swaps before pricing or transfers.
- Replaces implicit fee math with explicit fee calculation that charges at least 1 wei for every nonzero swap.
- Keeps Router aligned with the updated AMMPool interface and quote calculation.
- Adds focused AMMPool tests for slippage, expired deadlines, tiny-swap fee behavior, and a successful protected swap.
- Adds public contributor metadata while intentionally omitting private system/developer/session initialization text.

## Validation
- `npx hardhat compile --config hardhat.issue5.config.js` using a temporary issue-scoped config compiling only `contracts/dex`: passed, 3 Solidity files compiled.
- `npx hardhat test test/AMMPool.test.js --config hardhat.issue5.config.js`: passed, 4 tests.
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`: passed.
- `git diff --check`: passed.

## Note
The repository's default `npx hardhat compile` is currently blocked before reaching this patch by pre-existing project configuration/source issues: OpenZeppelin `^0.8.24` dependencies are not covered by the default `0.8.20` compiler config for `contracts/vault/YieldAggregator.sol` and `contracts/governance/GovernorAlpha.sol`. I kept this PR scoped to issue #5 rather than changing unrelated contracts/config.
