### PR TITLE
fix(staking): cap reward accrual period

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-chico10117-issue7",
+      "timestamp": "2026-08-05T20:32:49Z",
+      "platform_instructions": "Public task context only: OpenAgents issue #7 requested capping reward accrual at period finish, distributor-only reward notification, low precision loss, tests, and contributor metadata. Private system/developer/session initialization text was intentionally omitted.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-issue7.ZO0M1e/repo",
+        "shell": "zsh"
+      },
+      "contribution": "Capped StakingRewards accrual at periodFinish, restricted reward notification, and scaled reward-rate precision"
     }
   ]
 }

--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -5,17 +5,28 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/// @custom:contributor-info
+///   agent: Codex
+///   public_task: OpenAgents issue #7, cap reward accrual and restrict reward notification
+///   runtime: macOS Darwin arm64, zsh, /tmp/openagents-issue7.ZO0M1e/repo
+///   privacy: private system/developer/session initialization text intentionally omitted
+
 /// @title StakingRewards
 /// @notice Synthetix-style staking rewards distribution contract.
 /// @dev Users stake an ERC20 token and earn rewards over a fixed duration.
 contract StakingRewards is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
+    uint256 private constant RATE_PRECISION = 1e18;
+    uint256 private constant REWARD_PER_TOKEN_PRECISION = 1e27;
+
     IERC20 public immutable stakingToken;
     IERC20 public immutable rewardsToken;
     address public owner;
+    address public rewardsDistributor;
 
     uint256 public periodFinish;
+    // Scaled by RATE_PRECISION to preserve sub-wei-per-second reward rates.
     uint256 public rewardRate;
     uint256 public rewardsDuration = 7 days;
     uint256 public lastUpdateTime;
@@ -31,6 +42,7 @@ contract StakingRewards is ReentrancyGuard {
     event Withdrawn(address indexed user, uint256 amount);
     event RewardPaid(address indexed user, uint256 reward);
     event RewardAdded(uint256 reward);
+    event RewardsDistributorUpdated(address indexed distributor);
 
     modifier updateReward(address account) {
         rewardPerTokenStored = rewardPerToken();
@@ -42,10 +54,21 @@ contract StakingRewards is ReentrancyGuard {
         _;
     }
 
+    modifier onlyOwner() {
+        require(msg.sender == owner, "StakingRewards: not owner");
+        _;
+    }
+
+    modifier onlyRewardsDistributor() {
+        require(msg.sender == rewardsDistributor, "StakingRewards: not distributor");
+        _;
+    }
+
     constructor(address _stakingToken, address _rewardsToken) {
         stakingToken = IERC20(_stakingToken);
         rewardsToken = IERC20(_rewardsToken);
         owner = msg.sender;
+        rewardsDistributor = msg.sender;
     }
 
     function totalSupply() external view returns (uint256) {
@@ -66,17 +89,18 @@ contract StakingRewards is ReentrancyGuard {
         if (_totalSupply == 0) {
             return rewardPerTokenStored;
         }
-        // BUG: Uses block.timestamp directly instead of lastTimeRewardApplicable().
-        // After periodFinish, this keeps accruing phantom rewards indefinitely,
-        // allowing stakers to drain more rewards than were actually deposited.
+        uint256 applicableTime = lastTimeRewardApplicable();
+        if (applicableTime <= lastUpdateTime) {
+            return rewardPerTokenStored;
+        }
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
+            (applicableTime - lastUpdateTime) * rewardRate * REWARD_PER_TOKEN_PRECISION / RATE_PRECISION / _totalSupply
         );
     }
 
     /// @notice Calculate total earned rewards for an account.
     function earned(address account) public view returns (uint256) {
-        return (_balances[account] * (rewardPerToken() - userRewardPerTokenPaid[account])) / 1e18
+        return (_balances[account] * (rewardPerToken() - userRewardPerTokenPaid[account])) / REWARD_PER_TOKEN_PRECISION
             + rewards[account];
     }
 
@@ -112,22 +136,26 @@ contract StakingRewards is ReentrancyGuard {
 
     /// @notice Notify the contract of a new reward amount to distribute.
     /// @param reward Total reward tokens to distribute over the duration.
-    // BUG: No access control — anyone can call notifyRewardAmount. An attacker can
-    // call this with 0 to reset the rewardRate to near-zero, stealing future rewards.
-    function notifyRewardAmount(uint256 reward) external updateReward(address(0)) {
+    function notifyRewardAmount(uint256 reward) external onlyRewardsDistributor updateReward(address(0)) {
+        uint256 totalReward = reward;
+
         if (block.timestamp >= periodFinish) {
-            // BUG: Precision loss — integer division truncates rewardRate for small
-            // reward amounts relative to rewardsDuration (7 days = 604800 seconds).
-            // E.g., 500000 wei / 604800 = 0, meaning all rewards are lost.
-            rewardRate = reward / rewardsDuration;
+            rewardRate = (totalReward * RATE_PRECISION) / rewardsDuration;
         } else {
             uint256 remaining = periodFinish - block.timestamp;
-            uint256 leftover = remaining * rewardRate;
-            rewardRate = (reward + leftover) / rewardsDuration;
+            uint256 leftover = (remaining * rewardRate) / RATE_PRECISION;
+            totalReward += leftover;
+            rewardRate = (totalReward * RATE_PRECISION) / rewardsDuration;
         }
 
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + rewardsDuration;
         emit RewardAdded(reward);
+    }
+
+    function setRewardsDistributor(address distributor) external onlyOwner {
+        require(distributor != address(0), "StakingRewards: zero distributor");
+        rewardsDistributor = distributor;
+        emit RewardsDistributorUpdated(distributor);
     }
 }

--- a/contracts/staking/StakingRewardsTestToken.sol
+++ b/contracts/staking/StakingRewardsTestToken.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract StakingRewardsTestToken {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        require(currentAllowance >= amount, "ERC20: insufficient allowance");
+        allowance[from][msg.sender] = currentAllowance - amount;
+
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/test/StakingRewardsIssue7.test.js
+++ b/test/StakingRewardsIssue7.test.js
@@ -1,0 +1,76 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("StakingRewards issue #7", function () {
+  let stakingRewards;
+  let stakingToken;
+  let rewardToken;
+  let owner;
+  let distributor;
+  let staker;
+  let attacker;
+
+  const STAKE_AMOUNT = ethers.parseEther("100");
+
+  beforeEach(async function () {
+    [owner, distributor, staker, attacker] = await ethers.getSigners();
+
+    const TestToken = await ethers.getContractFactory("StakingRewardsTestToken");
+    stakingToken = await TestToken.deploy("Stake Token", "STK");
+    rewardToken = await TestToken.deploy("Reward Token", "RWD");
+    await stakingToken.waitForDeployment();
+    await rewardToken.waitForDeployment();
+
+    const StakingRewards = await ethers.getContractFactory("StakingRewards");
+    stakingRewards = await StakingRewards.deploy(
+      await stakingToken.getAddress(),
+      await rewardToken.getAddress()
+    );
+    await stakingRewards.waitForDeployment();
+
+    await stakingRewards.setRewardsDistributor(distributor.address);
+    await stakingToken.mint(staker.address, STAKE_AMOUNT);
+    await rewardToken.mint(await stakingRewards.getAddress(), ethers.parseEther("1000000"));
+    await stakingToken.connect(staker).approve(await stakingRewards.getAddress(), STAKE_AMOUNT);
+    await stakingRewards.connect(staker).stake(STAKE_AMOUNT);
+  });
+
+  it("does not accrue additional rewards after periodFinish", async function () {
+    const reward = ethers.parseEther("700");
+    await stakingRewards.connect(distributor).notifyRewardAmount(reward);
+
+    const duration = await stakingRewards.rewardsDuration();
+    await time.increase(Number(duration) + 1);
+    const earnedAtFinish = await stakingRewards.earned(staker.address);
+
+    await time.increase(3 * 24 * 60 * 60);
+    const earnedAfterFinish = await stakingRewards.earned(staker.address);
+
+    expect(earnedAfterFinish).to.equal(earnedAtFinish);
+  });
+
+  it("only allows the configured rewards distributor to notify rewards", async function () {
+    await expect(
+      stakingRewards.connect(attacker).notifyRewardAmount(ethers.parseEther("1"))
+    ).to.be.revertedWith("StakingRewards: not distributor");
+
+    await expect(
+      stakingRewards.connect(distributor).notifyRewardAmount(ethers.parseEther("1"))
+    ).to.emit(stakingRewards, "RewardAdded");
+  });
+
+  it("keeps precision loss below 0.01 percent for small rewards", async function () {
+    const reward = 500000n;
+    await stakingRewards.connect(distributor).notifyRewardAmount(reward);
+
+    const duration = await stakingRewards.rewardsDuration();
+    await time.increase(Number(duration) + 1);
+
+    const earned = await stakingRewards.earned(staker.address);
+    const loss = reward - earned;
+    const maxLoss = reward / 10000n;
+
+    expect(loss).to.be.lte(maxLoss);
+  });
+});


### PR DESCRIPTION
/claim #7
💳 Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Summary
- Caps reward accrual with `lastTimeRewardApplicable()` so `rewardPerToken()` stops increasing after `periodFinish`.
- Restricts `notifyRewardAmount()` to a configured rewards distributor, with owner-controlled distributor updates.
- Uses scaled reward-rate and reward-per-token accounting to keep small-reward precision loss below the requested threshold.
- Adds focused tests covering no post-period phantom rewards, distributor-only notification, and `<0.01%` precision loss.
- Adds public contributor metadata while intentionally omitting private system/developer/session initialization text.

## Validation
- `npx hardhat compile --config hardhat.issue7.config.js` using a temporary issue-scoped config compiling `contracts/staking`: passed, 13 Solidity files compiled.
- `npx hardhat test test/StakingRewardsIssue7.test.js --config hardhat.issue7.config.js`: passed, 3 tests.
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`: passed.
- `git diff --check`: passed.

## Note
The issue text names `contracts/vault/YieldVault.sol`, but that file does not exist in the current repository. The live implementation containing the exact described phantom-accrual, notify-access-control, and precision-loss bugs is `contracts/staking/StakingRewards.sol`, so this PR patches that current target.

The repository's default `npx hardhat compile` is currently blocked before reaching this patch by pre-existing project configuration/source issues: OpenZeppelin `^0.8.24` dependencies are not covered by the default `0.8.20` compiler config for `contracts/vault/YieldAggregator.sol` and `contracts/governance/GovernorAlpha.sol`. I kept this PR scoped to issue #7 rather than changing unrelated contracts/config.
