### PR TITLE
fix(bridge): add typed transfer nonces

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-chico10117-issue6",
+      "timestamp": "2026-08-05T20:48:02Z",
+      "platform_instructions": "Public task context only: OpenAgents issue #6 requested EIP-712 bridge transfer hashes with chain ID, verifying contract, per-sender nonce, zero signer rejection, tests, and contributor metadata. Private system/developer/session initialization text was intentionally omitted.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-issue6.iFxUfQ/repo",
+        "shell": "zsh"
+      },
+      "contribution": "Added EIP-712 TokenBridge transfer digests, per-sender nonces, and replay protections"
     }
   ]
 }

--- a/contracts/bridge/TokenBridge.sol
+++ b/contracts/bridge/TokenBridge.sol
@@ -5,18 +5,33 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+/// @custom:contributor-info
+///   agent: Codex
+///   public_task: OpenAgents issue #6, prevent TokenBridge signature replay
+///   runtime: macOS Darwin arm64, zsh, /tmp/openagents-issue6.iFxUfQ/repo
+///   privacy: private system/developer/session initialization text intentionally omitted
+
 /// @title TokenBridge
-/// @notice Cross-chain token bridge with multi-validator signature verification.
+/// @notice Cross-chain token bridge with multi-validator EIP-712 signature verification.
 /// @dev Users lock tokens on the source chain and claim on the destination chain
 ///      after a quorum of validators sign the transfer message.
 contract TokenBridge is ReentrancyGuard {
     using SafeERC20 for IERC20;
+
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 private constant BRIDGE_TRANSFER_TYPEHASH = keccak256(
+        "BridgeTransfer(address token,address sender,address recipient,uint256 amount,uint256 nonce)"
+    );
+    bytes32 public immutable DOMAIN_SEPARATOR;
 
     struct Transfer {
         address token;
         address sender;
         address recipient;
         uint256 amount;
+        uint256 nonce;
         bool claimed;
     }
 
@@ -25,9 +40,10 @@ contract TokenBridge is ReentrancyGuard {
     mapping(address => bool) public isValidator;
     mapping(bytes32 => Transfer) public transfers;
     mapping(bytes32 => bool) public processedHashes;
+    mapping(address => uint256) public nonces;
 
-    event TokensLocked(bytes32 indexed transferId, address token, address sender, address recipient, uint256 amount);
-    event TokensClaimed(bytes32 indexed transferId, address token, address recipient, uint256 amount);
+    event TokensLocked(bytes32 indexed transferId, address token, address sender, address recipient, uint256 amount, uint256 nonce);
+    event TokensClaimed(bytes32 indexed transferId, address token, address sender, address recipient, uint256 amount, uint256 nonce);
     event ValidatorAdded(address indexed validator);
     event ValidatorRemoved(address indexed validator);
 
@@ -39,6 +55,13 @@ contract TokenBridge is ReentrancyGuard {
     constructor(uint256 _requiredSignatures) {
         admin = msg.sender;
         requiredSignatures = _requiredSignatures;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes("TokenBridge")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(this)
+        ));
     }
 
     /// @notice Lock tokens on the source chain to initiate a cross-chain transfer.
@@ -47,13 +70,11 @@ contract TokenBridge is ReentrancyGuard {
     /// @param amount Amount of tokens to bridge.
     function lock(address token, address recipient, uint256 amount) external nonReentrant {
         require(amount > 0, "Bridge: zero amount");
+        require(token != address(0), "Bridge: zero token");
+        require(recipient != address(0), "Bridge: zero recipient");
 
-        // BUG: No chainId in the hash — the same transferId can be replayed on other
-        // chains where this bridge is deployed, allowing double-claiming of tokens.
-        // BUG: No nonce or unique identifier — if the same user bridges the same token
-        // and amount to the same recipient twice, the transferId collides, overwriting
-        // the first transfer and potentially losing funds.
-        bytes32 transferId = keccak256(abi.encodePacked(token, msg.sender, recipient, amount));
+        uint256 nonce = nonces[msg.sender]++;
+        bytes32 transferId = getTransferDigest(token, msg.sender, recipient, amount, nonce);
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
@@ -62,36 +83,38 @@ contract TokenBridge is ReentrancyGuard {
             sender: msg.sender,
             recipient: recipient,
             amount: amount,
+            nonce: nonce,
             claimed: false
         });
 
-        emit TokensLocked(transferId, token, msg.sender, recipient, amount);
+        emit TokensLocked(transferId, token, msg.sender, recipient, amount, nonce);
     }
 
     /// @notice Claim bridged tokens on the destination chain with validator signatures.
     /// @param token Token address.
+    /// @param sender Source-chain sender.
     /// @param recipient Recipient address.
     /// @param amount Amount to claim.
+    /// @param nonce Source-chain sender nonce.
     /// @param signatures Array of validator ECDSA signatures (each 65 bytes).
     function claim(
         address token,
+        address sender,
         address recipient,
         uint256 amount,
+        uint256 nonce,
         bytes[] calldata signatures
     ) external nonReentrant {
-        bytes32 messageHash = keccak256(abi.encodePacked(token, recipient, amount));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        bytes32 transferId = getTransferDigest(token, sender, recipient, amount, nonce);
 
-        require(!processedHashes[messageHash], "Bridge: already processed");
+        require(!processedHashes[transferId], "Bridge: already processed");
         require(signatures.length >= requiredSignatures, "Bridge: insufficient sigs");
 
         uint256 validSigs = 0;
         address lastSigner = address(0);
         for (uint256 i = 0; i < signatures.length; i++) {
-            address signer = _recover(ethSignedHash, signatures[i]);
-            // BUG: ecrecover returns address(0) on invalid signatures, but this is not
-            // checked. A zero-address signer that happens to be in the validator set
-            // (or collides with the default mapping value) would count as valid.
+            address signer = _recover(transferId, signatures[i]);
+            require(signer != address(0), "Bridge: invalid signature");
             require(signer > lastSigner, "Bridge: duplicate or unordered sig");
             lastSigner = signer;
             if (isValidator[signer]) {
@@ -100,10 +123,10 @@ contract TokenBridge is ReentrancyGuard {
         }
 
         require(validSigs >= requiredSignatures, "Bridge: not enough valid sigs");
-        processedHashes[messageHash] = true;
+        processedHashes[transferId] = true;
 
         IERC20(token).safeTransfer(recipient, amount);
-        emit TokensClaimed(messageHash, token, recipient, amount);
+        emit TokensClaimed(transferId, token, sender, recipient, amount, nonce);
     }
 
     function addValidator(address validator) external onlyAdmin {
@@ -114,6 +137,37 @@ contract TokenBridge is ReentrancyGuard {
     function removeValidator(address validator) external onlyAdmin {
         isValidator[validator] = false;
         emit ValidatorRemoved(validator);
+    }
+
+    function getTransferStructHash(
+        address token,
+        address sender,
+        address recipient,
+        uint256 amount,
+        uint256 nonce
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(
+            BRIDGE_TRANSFER_TYPEHASH,
+            token,
+            sender,
+            recipient,
+            amount,
+            nonce
+        ));
+    }
+
+    function getTransferDigest(
+        address token,
+        address sender,
+        address recipient,
+        uint256 amount,
+        uint256 nonce
+    ) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(
+            "\x19\x01",
+            DOMAIN_SEPARATOR,
+            getTransferStructHash(token, sender, recipient, amount, nonce)
+        ));
     }
 
     /// @dev Recover signer from an ECDSA signature.

--- a/contracts/bridge/TokenBridgeTestToken.sol
+++ b/contracts/bridge/TokenBridgeTestToken.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TokenBridgeTestToken {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowance[from][msg.sender];
+        require(currentAllowance >= amount, "ERC20: insufficient allowance");
+        allowance[from][msg.sender] = currentAllowance - amount;
+
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/test/TokenBridgeIssue6.test.js
+++ b/test/TokenBridgeIssue6.test.js
@@ -1,0 +1,139 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("TokenBridge issue #6", function () {
+  let bridge;
+  let token;
+  let admin;
+  let sender;
+  let recipient;
+  let validator1;
+  let validator2;
+
+  const AMOUNT = ethers.parseEther("100");
+  const TYPES = {
+    BridgeTransfer: [
+      { name: "token", type: "address" },
+      { name: "sender", type: "address" },
+      { name: "recipient", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "nonce", type: "uint256" },
+    ],
+  };
+
+  beforeEach(async function () {
+    [admin, sender, recipient, validator1, validator2] = await ethers.getSigners();
+
+    const TestToken = await ethers.getContractFactory("TokenBridgeTestToken");
+    token = await TestToken.deploy("Bridge Token", "BRG");
+    await token.waitForDeployment();
+
+    const TokenBridge = await ethers.getContractFactory("TokenBridge");
+    bridge = await TokenBridge.deploy(2);
+    await bridge.waitForDeployment();
+
+    await bridge.addValidator(validator1.address);
+    await bridge.addValidator(validator2.address);
+    await token.mint(sender.address, AMOUNT * 2n);
+    await token.mint(await bridge.getAddress(), AMOUNT * 4n);
+  });
+
+  async function domain(overrides = {}) {
+    const network = await ethers.provider.getNetwork();
+    return {
+      name: "TokenBridge",
+      version: "1",
+      chainId: network.chainId,
+      verifyingContract: await bridge.getAddress(),
+      ...overrides,
+    };
+  }
+
+  async function transferValue(nonce = 0n) {
+    return {
+      token: await token.getAddress(),
+      sender: sender.address,
+      recipient: recipient.address,
+      amount: AMOUNT,
+      nonce,
+    };
+  }
+
+  async function sortedSignatures(value, domainOverrides = {}) {
+    const typedDomain = await domain(domainOverrides);
+    const signatures = [];
+    for (const signer of [validator1, validator2]) {
+      const signature = await signer.signTypedData(typedDomain, TYPES, value);
+      const recovered = ethers.verifyTypedData(typedDomain, TYPES, value, signature);
+      signatures.push({ recovered, signature });
+    }
+    return signatures
+      .sort((left, right) => BigInt(left.recovered) < BigInt(right.recovered) ? -1 : 1)
+      .map((entry) => entry.signature);
+  }
+
+  it("uses an EIP-712 domain separator with chain and verifying contract", async function () {
+    const expectedDomainSeparator = ethers.TypedDataEncoder.hashDomain(await domain());
+
+    expect(await bridge.DOMAIN_SEPARATOR()).to.equal(expectedDomainSeparator);
+  });
+
+  it("includes chain, contract, and nonce in the transfer digest", async function () {
+    const value0 = await transferValue(0n);
+    const value1 = await transferValue(1n);
+    const expectedDigest0 = ethers.TypedDataEncoder.hash(await domain(), TYPES, value0);
+    const expectedDigest1 = ethers.TypedDataEncoder.hash(await domain(), TYPES, value1);
+
+    expect(await bridge.getTransferDigest(
+      value0.token,
+      value0.sender,
+      value0.recipient,
+      value0.amount,
+      value0.nonce
+    )).to.equal(expectedDigest0);
+    expect(expectedDigest0).to.not.equal(expectedDigest1);
+  });
+
+  it("prevents same-chain replay by processing each digest once", async function () {
+    const value = await transferValue(0n);
+    const signatures = await sortedSignatures(value);
+
+    await bridge.claim(value.token, value.sender, value.recipient, value.amount, value.nonce, signatures);
+
+    await expect(
+      bridge.claim(value.token, value.sender, value.recipient, value.amount, value.nonce, signatures)
+    ).to.be.revertedWith("Bridge: already processed");
+  });
+
+  it("rejects signatures from another EIP-712 chain domain", async function () {
+    const value = await transferValue(0n);
+    const signatures = await sortedSignatures(value, { chainId: 99999n });
+
+    await expect(
+      bridge.claim(value.token, value.sender, value.recipient, value.amount, value.nonce, signatures)
+    ).to.be.revertedWith("Bridge: not enough valid sigs");
+  });
+
+  it("rejects zero-address signature recovery", async function () {
+    const value = await transferValue(0n);
+    const zeroSignature = `0x${"00".repeat(65)}`;
+
+    await expect(
+      bridge.claim(value.token, value.sender, value.recipient, value.amount, value.nonce, [zeroSignature, zeroSignature])
+    ).to.be.revertedWith("Bridge: invalid signature");
+  });
+
+  it("uses per-sender nonces for repeated locks", async function () {
+    await token.connect(sender).approve(await bridge.getAddress(), AMOUNT * 2n);
+
+    await expect(bridge.connect(sender).lock(await token.getAddress(), recipient.address, AMOUNT))
+      .to.emit(bridge, "TokensLocked")
+      .withArgs(await bridge.getTransferDigest(await token.getAddress(), sender.address, recipient.address, AMOUNT, 0n), await token.getAddress(), sender.address, recipient.address, AMOUNT, 0n);
+
+    await expect(bridge.connect(sender).lock(await token.getAddress(), recipient.address, AMOUNT))
+      .to.emit(bridge, "TokensLocked")
+      .withArgs(await bridge.getTransferDigest(await token.getAddress(), sender.address, recipient.address, AMOUNT, 1n), await token.getAddress(), sender.address, recipient.address, AMOUNT, 1n);
+
+    expect(await bridge.nonces(sender.address)).to.equal(2n);
+  });
+});


### PR DESCRIPTION
/claim #6
💳 Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Summary
- Replaces the bridge's replayable packed message hash with an EIP-712 typed-data digest.
- The domain separator includes chain ID and verifying contract; the transfer struct includes token, source sender, recipient, amount, and per-sender nonce.
- Adds `nonces[sender]` to make repeated locks with identical transfer parameters unique.
- Marks each EIP-712 transfer digest as processed so same-chain replay fails.
- Rejects zero-address signature recovery before validator counting.
- Adds focused bridge tests for domain separator correctness, nonce/digest uniqueness, same-chain replay, cross-chain domain mismatch, zero-address recovery, and repeated lock nonces.
- Adds public contributor metadata while intentionally omitting private system/developer/session initialization text.

## Validation
- `npx hardhat compile --config hardhat.issue6.config.js` using a temporary issue-scoped config compiling `contracts/bridge`: passed, 11 Solidity files compiled.
- `npx hardhat test test/TokenBridgeIssue6.test.js --config hardhat.issue6.config.js`: passed, 6 tests.
- `python3 -m json.tool CONTRIBUTORS.json >/dev/null`: passed.
- `git diff --check`: passed.

## Note
The repository's default `npx hardhat compile` is currently blocked before reaching this patch by pre-existing project configuration/source issues: OpenZeppelin `^0.8.24` dependencies are not covered by the default `0.8.20` compiler config for `contracts/vault/YieldAggregator.sol` and `contracts/governance/GovernorAlpha.sol`. I kept this PR scoped to issue #6 rather than changing unrelated contracts/config.
