### PR TITLE
security(vesting): harden VestingWallet accounting

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-base-usdc-hunter-vesting-12",
+      "timestamp": "2026-08-05T21:25:39Z",
+      "platform_instructions": "Public bounty implementation metadata; private session initialization text intentionally omitted.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-issue12.Codex",
+        "shell": "/bin/zsh"
+      },
+      "contribution": "Hardened VestingWallet arithmetic, constructor validation, and revoke accounting."
     }
   ]
 }

--- a/contracts/token/VestingWallet.sol
+++ b/contracts/token/VestingWallet.sol
@@ -3,11 +3,18 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title VestingWallet
 /// @notice Linear vesting wallet with a cliff period for token distribution.
 /// @dev Tokens vest linearly from cliff end to vesting end. The contract owner
 ///      can revoke unvested tokens and redirect them to a specified address.
+/**
+ * @custom:contributor CodexBaseUSDCHunter
+ * @custom:date 2026-08-05
+ * @custom:runtime darwin/arm64; shell /bin/zsh
+ * @custom:note Private session initialization text is intentionally omitted.
+ */
 contract VestingWallet {
     using SafeERC20 for IERC20;
 
@@ -26,8 +33,6 @@ contract VestingWallet {
     event TokensReleased(address indexed beneficiary, uint256 amount);
     event VestingRevoked(address indexed token, uint256 refund);
 
-    // BUG: No zero-address validation on beneficiary — if beneficiary is set to
-    // address(0), all vested tokens are sent to the zero address (burned) on release.
     constructor(
         address _beneficiary,
         address _token,
@@ -37,6 +42,8 @@ contract VestingWallet {
         uint256 _totalAllocation,
         bool _revocable
     ) {
+        require(_beneficiary != address(0), "Vesting: zero beneficiary");
+        require(_token != address(0), "Vesting: zero token");
         require(_vestingDuration > _cliffDuration, "Vesting: cliff exceeds duration");
         require(_totalAllocation > 0, "Vesting: zero allocation");
 
@@ -53,6 +60,7 @@ contract VestingWallet {
     /// @notice Release vested tokens to the beneficiary.
     function release() external {
         require(msg.sender == beneficiary, "Vesting: not beneficiary");
+        require(!revoked, "Vesting: revoked");
         uint256 vested = vestedAmount();
         uint256 unreleased = vested - released;
         require(unreleased > 0, "Vesting: nothing to release");
@@ -65,17 +73,23 @@ contract VestingWallet {
     /// @notice Calculate the total vested amount at the current timestamp.
     /// @return The total amount of tokens that have vested.
     function vestedAmount() public view returns (uint256) {
-        if (block.timestamp < start + cliffDuration) {
+        if (block.timestamp < start) {
             return 0;
         }
-        if (block.timestamp >= start + vestingDuration) {
+
+        uint256 elapsed = block.timestamp - start;
+        if (elapsed < cliffDuration) {
+            return 0;
+        }
+        if (elapsed >= vestingDuration) {
             return totalAllocation;
         }
-        // BUG: Overflow risk — (totalAllocation * elapsed) can overflow for large
-        // allocations. E.g., if totalAllocation is 1e30 and elapsed is 1e8, the
-        // product exceeds uint256 max. Should use mulDiv or restructure the math.
-        uint256 elapsed = block.timestamp - start;
-        return (totalAllocation * elapsed) / vestingDuration;
+
+        // Split the quotient before multiplying. Math.mulDiv keeps the remainder
+        // product in full precision when allocations and timestamps are large.
+        uint256 whole = totalAllocation / vestingDuration;
+        uint256 remainder = totalAllocation % vestingDuration;
+        return (whole * elapsed) + Math.mulDiv(remainder, elapsed, vestingDuration);
     }
 
     /// @notice Revoke unvested tokens and return them to the owner.
@@ -85,13 +99,9 @@ contract VestingWallet {
         require(!revoked, "Vesting: already revoked");
 
         revoked = true;
-        uint256 vested = vestedAmount();
-        // BUG: During the cliff period, vestedAmount() returns 0, so refund is
-        // calculated as totalAllocation - 0 = totalAllocation. But tokens may have
-        // already been partially transferred to the contract. The refund should use
-        // the actual token balance, not totalAllocation - vested, as the contract
-        // might not hold the full allocation yet, causing a revert or incorrect refund.
-        uint256 refund = totalAllocation - vested;
+        uint256 refundable = totalAllocation - released;
+        uint256 balance = token.balanceOf(address(this));
+        uint256 refund = balance < refundable ? balance : refundable;
 
         token.safeTransfer(owner, refund);
         emit VestingRevoked(address(token), refund);
@@ -99,11 +109,14 @@ contract VestingWallet {
 
     /// @notice Get the releasable (vested but not yet released) token amount.
     function releasable() external view returns (uint256) {
+        if (revoked) {
+            return 0;
+        }
         return vestedAmount() - released;
     }
 
     /// @notice Check if the cliff period has passed.
     function cliffReached() external view returns (bool) {
-        return block.timestamp >= start + cliffDuration;
+        return block.timestamp >= start && block.timestamp - start >= cliffDuration;
     }
 }

--- a/test/VestingWalletIssue12.test.js
+++ b/test/VestingWalletIssue12.test.js
@@ -1,0 +1,118 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("VestingWallet safety hardening", function () {
+  const MAX_UINT256 = (1n << 256n) - 1n;
+
+  async function deployToken(initialSupply = 1_000_000n) {
+    const AgentToken = await ethers.getContractFactory("AgentToken");
+    const token = await AgentToken.deploy("Test Token", "TST", initialSupply);
+    await token.waitForDeployment();
+    return token;
+  }
+
+  async function deployWallet({ beneficiary, token, start, cliff, duration, allocation, revocable = true }) {
+    const VestingWallet = await ethers.getContractFactory("VestingWallet");
+    const wallet = await VestingWallet.deploy(
+      beneficiary,
+      await token.getAddress(),
+      start,
+      cliff,
+      duration,
+      allocation,
+      revocable
+    );
+    await wallet.waitForDeployment();
+    return wallet;
+  }
+
+  it("rejects zero-address beneficiaries and tokens", async function () {
+    const [, beneficiary] = await ethers.getSigners();
+    const token = await deployToken(1n);
+    const VestingWallet = await ethers.getContractFactory("VestingWallet");
+    const latest = await ethers.provider.getBlock("latest");
+    const start = BigInt(latest.timestamp) + 1n;
+
+    await expect(
+      VestingWallet.deploy(
+        ethers.ZeroAddress,
+        await token.getAddress(),
+        start,
+        10n,
+        20n,
+        1n,
+        true
+      )
+    ).to.be.revertedWith("Vesting: zero beneficiary");
+    await expect(
+      VestingWallet.deploy(beneficiary.address, ethers.ZeroAddress, start, 10n, 20n, 1n, true)
+    ).to.be.revertedWith("Vesting: zero token");
+  });
+
+  it("calculates large allocations without multiplication overflow", async function () {
+    const [, beneficiary] = await ethers.getSigners();
+    const token = await deployToken(1n);
+    const duration = 1n << 128n;
+    const wallet = await deployWallet({
+      beneficiary: beneficiary.address,
+      token,
+      start: 0n,
+      cliff: 0n,
+      duration,
+      allocation: MAX_UINT256,
+    });
+    const latest = await ethers.provider.getBlock("latest");
+    const elapsed = BigInt(latest.timestamp);
+
+    expect(elapsed).to.be.lt(duration);
+    expect(await wallet.vestedAmount()).to.equal((MAX_UINT256 * elapsed) / duration);
+  });
+
+  it("caps a cliff revoke refund at the wallet's actual balance", async function () {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const allocation = 1_000n;
+    const token = await deployToken(allocation);
+    const latest = await ethers.provider.getBlock("latest");
+    const wallet = await deployWallet({
+      beneficiary: beneficiary.address,
+      token,
+      start: BigInt(latest.timestamp) + 1_000n,
+      cliff: 1_000n,
+      duration: 2_000n,
+      allocation,
+    });
+    await token.transfer(await wallet.getAddress(), 600n);
+
+    await wallet.connect(owner).revoke();
+
+    expect(await token.balanceOf(owner.address)).to.equal(allocation);
+    expect(await token.balanceOf(await wallet.getAddress())).to.equal(0n);
+    expect(await wallet.releasable()).to.equal(0n);
+    await expect(wallet.connect(beneficiary).release()).to.be.revertedWith("Vesting: revoked");
+  });
+
+  it("refunds all unreleased tokens after a partial release", async function () {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const allocation = 1_000n;
+    const token = await deployToken(allocation);
+    const latest = await ethers.provider.getBlock("latest");
+    const start = BigInt(latest.timestamp) + 10n;
+    const wallet = await deployWallet({
+      beneficiary: beneficiary.address,
+      token,
+      start,
+      cliff: 0n,
+      duration: 1_000n,
+      allocation,
+    });
+    await token.transfer(await wallet.getAddress(), allocation);
+
+    await ethers.provider.send("evm_setNextBlockTimestamp", [Number(start + 500n)]);
+    await wallet.connect(beneficiary).release();
+    expect(await wallet.released()).to.equal(500n);
+
+    await wallet.connect(owner).revoke();
+    expect(await token.balanceOf(owner.address)).to.equal(500n);
+    expect(await token.balanceOf(await wallet.getAddress())).to.equal(0n);
+  });
+});


### PR DESCRIPTION
/claim #12

💳 Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Summary

- Makes `vestedAmount()` safe for large allocations using quotient/remainder math plus full-precision `Math.mulDiv`.
- Avoids timestamp addition overflow in cliff and vesting-end checks.
- Rejects zero-address beneficiaries and token contracts.
- Computes revoke refunds as `totalAllocation - released`, capped by the wallet's actual token balance.
- Blocks release and reports zero releasable tokens after revocation.
- Adds focused regression coverage and sanitized public contributor/runtime metadata.

## Root cause

The old vesting formula multiplied the full allocation by elapsed time before dividing, which could overflow. Revoke used `totalAllocation - vestedAmount()` instead of the unreleased allocation, and could attempt to transfer more tokens than the wallet held during a cliff or after partial release.

## Validation

- `hardhat compile --config hardhat.issue12.config.js` — passed (16 Solidity files).
- `hardhat test test/VestingWalletIssue12.test.js --config hardhat.issue12.config.js` — 4 passing.
- `python3 -m json.tool CONTRIBUTORS.json` — passed.
- `node --check test/VestingWalletIssue12.test.js` — passed.
- `git diff --check` — passed.

The repository-wide compile still hits the pre-existing `HH606` OpenZeppelin/compiler mismatch in unrelated `YieldAggregator` and `GovernorAlpha` dependencies; the issue-scoped compile isolates and validates the VestingWallet lane.

Private session initialization text requested by the issue is intentionally not included. The commit contains public contributor/runtime metadata only.

Fixes #12
