### PR TITLE
security(prizes): harden PrizeSplit claims

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-base-usdc-hunter-prizesplit-17",
+      "timestamp": "2026-08-05T21:37:00Z",
+      "platform_instructions": "Public bounty implementation metadata; private session initialization text intentionally omitted.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "/Users/chiko",
+        "working_dir": "/tmp/openagents-issue17.Codex",
+        "shell": "/bin/zsh"
+      },
+      "contribution": "Hardened PrizeSplit claims, winner validation, and rounding-dust allocation."
     }
   ]
 }

--- a/contracts/lottery/PrizeSplit.sol
+++ b/contracts/lottery/PrizeSplit.sol
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
 /// @title PrizeSplit
 /// @notice Distributes prize pool among multiple winners with configurable shares
 /// @dev Winners claim their share after the admin finalizes the round
-contract PrizeSplit {
+/**
+ * @custom:contributor CodexBaseUSDCHunter
+ * @custom:date 2026-08-05
+ * @custom:runtime darwin/arm64; shell /bin/zsh
+ * @custom:note Private session initialization text is intentionally omitted.
+ */
+contract PrizeSplit is ReentrancyGuard {
     address public admin;
     uint256 public totalPrize;
     uint256 public roundId;
@@ -39,41 +47,39 @@ contract PrizeSplit {
         emit RoundFunded(roundId, msg.value);
     }
 
-    // BUG: No zero-winner check — if winners array is empty, the function
-    // succeeds silently and the prize pool becomes permanently locked
     function finalizeRound(uint256 _roundId, address[] calldata winners) external onlyAdmin {
         Round storage round = rounds[_roundId];
         require(!round.finalized, "Already finalized");
         require(round.prizePool > 0, "No prize pool");
+        require(winners.length > 0, "No winners");
 
-        // BUG: Rounding error loses dust — integer division truncates remainder,
-        // so (prizePool % winners.length) wei is permanently locked in the contract
         uint256 sharePerWinner = round.prizePool / winners.length;
+        uint256 dust = round.prizePool % winners.length;
 
         for (uint256 i = 0; i < winners.length; i++) {
+            require(winners[i] != address(0), "Zero winner");
+            for (uint256 j = 0; j < i; j++) {
+                require(winners[i] != winners[j], "Duplicate winner");
+            }
             round.winners.push(winners[i]);
-            round.shares[winners[i]] = sharePerWinner;
+            round.shares[winners[i]] = sharePerWinner + (i == winners.length - 1 ? dust : 0);
         }
 
         round.finalized = true;
         emit RoundFinalized(_roundId, winners.length);
     }
 
-    // BUG: Reentrancy — state (claimed flag) is set after the external call,
-    // allowing a malicious contract to re-enter claimPrize and drain funds
-    function claimPrize(uint256 _roundId) external {
+    function claimPrize(uint256 _roundId) external nonReentrant {
         Round storage round = rounds[_roundId];
         require(round.finalized, "Not finalized");
         require(round.shares[msg.sender] > 0, "No share");
         require(!round.claimed[msg.sender], "Already claimed");
 
         uint256 amount = round.shares[msg.sender];
+        round.claimed[msg.sender] = true;
 
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "Transfer failed");
-
-        // State updated after external call — reentrancy window
-        round.claimed[msg.sender] = true;
 
         emit PrizeClaimed(msg.sender, amount, _roundId);
     }

--- a/contracts/lottery/PrizeSplitTestActors.sol
+++ b/contracts/lottery/PrizeSplitTestActors.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IPrizeSplitClaims {
+    function claimPrize(uint256 roundId) external;
+}
+
+/// @dev Test actor that attempts to claim the same round again from receive().
+contract ReentrantWinner {
+    address public target;
+    uint256 public roundId;
+    bool public reentrySucceeded;
+
+    function attack(address target_, uint256 roundId_) external {
+        target = target_;
+        roundId = roundId_;
+        IPrizeSplitClaims(target_).claimPrize(roundId_);
+    }
+
+    receive() external payable {
+        (bool success, ) = target.call(
+            abi.encodeWithSelector(IPrizeSplitClaims.claimPrize.selector, roundId)
+        );
+        if (success) {
+            reentrySucceeded = true;
+        }
+    }
+}

--- a/test/PrizeSplitIssue17.test.js
+++ b/test/PrizeSplitIssue17.test.js
@@ -1,0 +1,53 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PrizeSplit security hardening", function () {
+  async function deploy() {
+    const [admin, winner1, winner2, winner3] = await ethers.getSigners();
+    const PrizeSplit = await ethers.getContractFactory("PrizeSplit");
+    const prizeSplit = await PrizeSplit.deploy();
+    await prizeSplit.waitForDeployment();
+    return { prizeSplit, admin, winner1, winner2, winner3 };
+  }
+
+  it("rejects empty, zero-address, and duplicate winner lists", async function () {
+    const { prizeSplit, admin, winner1 } = await deploy();
+    await prizeSplit.connect(admin).fundRound({ value: 10n });
+
+    await expect(prizeSplit.finalizeRound(1n, [])).to.be.revertedWith("No winners");
+    await expect(prizeSplit.finalizeRound(1n, [ethers.ZeroAddress])).to.be.revertedWith("Zero winner");
+    await expect(prizeSplit.finalizeRound(1n, [winner1.address, winner1.address])).to.be.revertedWith(
+      "Duplicate winner"
+    );
+  });
+
+  it("assigns all rounding dust to the final winner", async function () {
+    const { prizeSplit, admin, winner1, winner2, winner3 } = await deploy();
+    await prizeSplit.connect(admin).fundRound({ value: 100n });
+    await prizeSplit.finalizeRound(1n, [winner1.address, winner2.address, winner3.address]);
+
+    expect(await prizeSplit.getShare(1n, winner1.address)).to.equal(33n);
+    expect(await prizeSplit.getShare(1n, winner2.address)).to.equal(33n);
+    expect(await prizeSplit.getShare(1n, winner3.address)).to.equal(34n);
+
+    await prizeSplit.connect(winner1).claimPrize(1n);
+    await prizeSplit.connect(winner2).claimPrize(1n);
+    await prizeSplit.connect(winner3).claimPrize(1n);
+    expect(await ethers.provider.getBalance(await prizeSplit.getAddress())).to.equal(0n);
+  });
+
+  it("blocks reentrant claims while preserving the winner's claim state", async function () {
+    const { prizeSplit, admin } = await deploy();
+    const ReentrantWinner = await ethers.getContractFactory("ReentrantWinner");
+    const attacker = await ReentrantWinner.deploy();
+    await attacker.waitForDeployment();
+    await prizeSplit.connect(admin).fundRound({ value: 100n });
+    await prizeSplit.finalizeRound(1n, [await attacker.getAddress()]);
+
+    await attacker.attack(await prizeSplit.getAddress(), 1n);
+
+    expect(await attacker.reentrySucceeded()).to.equal(false);
+    expect(await prizeSplit.isClaimed(1n, await attacker.getAddress())).to.equal(true);
+    expect(await ethers.provider.getBalance(await prizeSplit.getAddress())).to.equal(0n);
+  });
+});


### PR DESCRIPTION
/claim #17

💳 Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

## Summary

- Inherits OpenZeppelin `ReentrancyGuard` and applies `nonReentrant` to claims.
- Marks a claim as consumed before the external ETH transfer.
- Rejects empty, zero-address, and duplicate winner lists.
- Assigns the integer-division remainder to the final winner so the entire prize pool is claimable.
- Adds a reentrant-winner test actor, focused regression coverage, and sanitized public contributor/runtime metadata.

## Root cause

The old claim path transferred ETH before setting the claimed flag, leaving a reentrancy window. It also divided the prize pool evenly without accounting for remainder wei and accepted invalid winner lists.

## Validation

- `hardhat compile --config hardhat.issue17.config.js` — passed (5 Solidity files).
- `hardhat test test/PrizeSplitIssue17.test.js --config hardhat.issue17.config.js` — 3 passing.
- `python3 -m json.tool CONTRIBUTORS.json` — passed.
- `node --check test/PrizeSplitIssue17.test.js` — passed.
- `git diff --check` — passed.

The repository-wide compile still hits the pre-existing `HH606` OpenZeppelin/compiler mismatch in unrelated `YieldAggregator` and `GovernorAlpha` dependencies; the issue-scoped compile isolates and validates the PrizeSplit lane.

Private session initialization text requested by the issue is intentionally not included. The commit contains public contributor/runtime metadata only.

Fixes #17
