### PR TITLE
feat(sdk): add event subscriptions

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-base-usdc-hunter-events-196",
+      "timestamp": "2026-08-06T02:09:03Z",
+      "platform_instructions": "Private platform/session initialization text intentionally omitted; public validation commands are documented in the pull request.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "[redacted]",
+        "working_dir": "[redacted]",
+        "shell": "zsh"
+      },
+      "contribution": "Added SDK event subscriptions with ABI decoding, indexed filters, reconnect resubscription, and focused tests."
     }
   ]
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,18 +1,99 @@
 import { ethers } from "ethers";
+import { WebSocketProvider } from "./providers/websocket";
 
 export interface AgentConfig {
   name: string;
   endpoint: string;
   privateKey: string;
   rpcUrl: string;
+  websocketUrl?: string;
   registryAddress: string;
   routerAddress: string;
+}
+
+export interface EventContractDefinition {
+  address: string;
+  abi: ethers.InterfaceAbi;
+}
+
+export type EventContract = ethers.Contract | EventContractDefinition;
+
+export interface EventSubscriptionProvider {
+  subscribe(
+    event: string,
+    callback: (data: unknown) => void,
+    params?: unknown[]
+  ): Promise<string>;
+  unsubscribe(subscriptionId: string): Promise<boolean>;
+}
+
+export interface EventSubscriptionOptions {
+  indexedFilters?: Record<string, unknown>;
+  provider?: EventSubscriptionProvider;
+  websocketUrl?: string;
+  reconnectIntervalMs?: number;
+  maxReconnectAttempts?: number;
+}
+
+export interface DecodedContractEvent {
+  name: string;
+  signature: string;
+  args: Record<string, unknown>;
+  values: unknown[];
+  log: unknown;
+}
+
+export interface EventSubscription {
+  id: string;
+  unsubscribe(): Promise<boolean>;
+}
+
+function contractInterface(contract: EventContract): ethers.Interface {
+  if (contract instanceof ethers.Contract) return contract.interface;
+  return new ethers.Interface(contract.abi);
+}
+
+function contractAddress(contract: EventContract): string {
+  if (contract instanceof ethers.Contract) {
+    if (typeof contract.target !== "string") {
+      throw new Error("Event contract must expose a concrete address");
+    }
+    return contract.target;
+  }
+  return contract.address;
+}
+
+function eventFilter(
+  iface: ethers.Interface,
+  fragment: ethers.EventFragment,
+  address: string,
+  indexedFilters: Record<string, unknown> = {}
+): { address: string; topics: Array<null | string | string[]> } {
+  const indexedInputs = fragment.inputs.filter((input) => input.indexed);
+  const acceptedKeys = new Set(
+    indexedInputs.map((input, index) => input.name || String(index)),
+  );
+  for (const key of Object.keys(indexedFilters)) {
+    if (!acceptedKeys.has(key)) {
+      throw new Error(`Unknown indexed event filter: ${key}`);
+    }
+  }
+
+  const values = indexedInputs.map((input, index) => {
+    const key = input.name || String(index);
+    return Object.prototype.hasOwnProperty.call(indexedFilters, key)
+      ? indexedFilters[key]
+      : null;
+  });
+  const topics = iface.encodeFilterTopics(fragment, values);
+  return { address, topics };
 }
 
 export class OpenAgentsSDK {
   private provider: ethers.JsonRpcProvider;
   private signer: ethers.Wallet;
   private config: AgentConfig;
+  private eventProvider: EventSubscriptionProvider | null = null;
 
   constructor(config: AgentConfig) {
     this.config = config;
@@ -58,6 +139,78 @@ export class OpenAgentsSDK {
       ethers.toUtf8Bytes(result)
     );
     await tx.wait();
+  }
+
+  async subscribeToEvents(
+    contract: EventContract,
+    eventName: string,
+    callback: (event: DecodedContractEvent) => void | Promise<void>,
+    options: EventSubscriptionOptions = {},
+  ): Promise<EventSubscription> {
+    const iface = contractInterface(contract);
+    let fragment: ethers.EventFragment | null;
+    try {
+      fragment = iface.getEvent(eventName);
+    } catch (error) {
+      throw new Error(`Unknown or ambiguous event: ${eventName}`, { cause: error });
+    }
+    if (!fragment) throw new Error(`Unknown event: ${eventName}`);
+
+    const filter = eventFilter(iface, fragment, contractAddress(contract), options.indexedFilters);
+    const provider = options.provider ?? this.getEventProvider(options);
+    let active = true;
+    const subscriptionId = await provider.subscribe(
+      "logs",
+      async (rawLog: unknown) => {
+        if (!active) return;
+        const log = rawLog as { topics?: unknown; data?: unknown };
+        if (!Array.isArray(log.topics) || typeof log.data !== "string") {
+          throw new Error(`Invalid ${eventName} log payload`);
+        }
+        const parsed = iface.parseLog({
+          topics: log.topics as string[],
+          data: log.data,
+        });
+        if (!parsed) return;
+
+        const values = Array.from(parsed.args);
+        const args: Record<string, unknown> = {};
+        fragment.inputs.forEach((input, index) => {
+          args[input.name || String(index)] = values[index];
+        });
+        await callback({
+          name: parsed.name,
+          signature: parsed.signature,
+          args,
+          values,
+          log: rawLog,
+        });
+      },
+      [filter],
+    );
+
+    return {
+      id: subscriptionId,
+      async unsubscribe(): Promise<boolean> {
+        if (!active) return false;
+        active = false;
+        return provider.unsubscribe(subscriptionId);
+      },
+    };
+  }
+
+  private getEventProvider(options: EventSubscriptionOptions): EventSubscriptionProvider {
+    if (this.eventProvider) return this.eventProvider;
+    const url = options.websocketUrl ?? this.config.websocketUrl;
+    if (!url) {
+      throw new Error("subscribeToEvents requires AgentConfig.websocketUrl or options.websocketUrl");
+    }
+    this.eventProvider = new WebSocketProvider({
+      url,
+      reconnectIntervalMs: options.reconnectIntervalMs,
+      maxReconnectAttempts: options.maxReconnectAttempts,
+    });
+    return this.eventProvider;
   }
 
   async getOpenTasks(): Promise<any[]> {

--- a/sdk/src/providers/websocket.ts
+++ b/sdk/src/providers/websocket.ts
@@ -11,16 +11,26 @@ interface PendingRequest {
   reject: (reason: Error) => void;
 }
 
+interface Subscription {
+  event: string;
+  params: unknown[];
+  callback: (data: unknown) => void;
+  remoteId: string;
+}
+
 export class WebSocketProvider extends EventEmitter {
   private url: string;
   private ws: WebSocket | null = null;
   private requestId = 0;
   private pendingRequests = new Map<number, PendingRequest>();
-  private subscriptions = new Map<string, (data: unknown) => void>();
+  private subscriptions = new Map<string, Subscription>();
+  private subscriptionIdsByRemote = new Map<string, string>();
   private reconnectInterval: number;
   private maxReconnectAttempts: number;
   private reconnectCount = 0;
   private isConnected = false;
+  private manuallyDisconnected = false;
+  private connectPromise: Promise<void> | null = null;
 
   constructor(config: WsProviderConfig) {
     super();
@@ -30,56 +40,99 @@ export class WebSocketProvider extends EventEmitter {
   }
 
   async connect(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url);
+    if (this.isConnected) return;
+    if (this.connectPromise) return this.connectPromise;
 
-      this.ws.onopen = () => {
+    this.manuallyDisconnected = false;
+    this.connectPromise = new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url);
+      this.ws = ws;
+      let settled = false;
+
+      ws.onopen = () => {
         this.isConnected = true;
         this.reconnectCount = 0;
-        // BUG: No heartbeat/ping mechanism — connection can silently die
-        // without the client knowing, leading to stale state
         this.emit("connected");
-        resolve();
-      };
-
-      this.ws.onmessage = (event) => {
-        const data = JSON.parse(event.data as string);
-        if (data.id && this.pendingRequests.has(data.id)) {
-          const pending = this.pendingRequests.get(data.id)!;
-          this.pendingRequests.delete(data.id);
-          data.error ? pending.reject(new Error(data.error.message)) : pending.resolve(data.result);
-        } else if (data.method === "eth_subscription") {
-          const subId = data.params?.subscription;
-          this.subscriptions.get(subId)?.(data.params.result);
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+        if (this.subscriptions.size > 0) {
+          void this.resubscribeAll().catch((error: unknown) => {
+            this.emit("error", error);
+          });
         }
       };
 
-      this.ws.onclose = () => {
-        this.isConnected = false;
-        // BUG: Messages sent while disconnected are silently dropped —
-        // no queue to buffer and replay after reconnection
-        this.emit("disconnected");
-        this.attemptReconnect();
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string);
+          if (data.id !== undefined && this.pendingRequests.has(data.id)) {
+            const pending = this.pendingRequests.get(data.id)!;
+            this.pendingRequests.delete(data.id);
+            data.error
+              ? pending.reject(new Error(data.error.message))
+              : pending.resolve(data.result);
+          } else if (data.method === "eth_subscription") {
+            const remoteId = data.params?.subscription;
+            const localId = this.subscriptionIdsByRemote.get(remoteId);
+            const subscription = localId ? this.subscriptions.get(localId) : undefined;
+            subscription?.callback(data.params.result);
+          }
+        } catch (error: unknown) {
+          this.emit("error", error);
+        }
       };
 
-      this.ws.onerror = (err) => {
-        if (!this.isConnected) reject(new Error("WebSocket connection failed"));
+      ws.onclose = () => {
+        if (this.ws !== ws) return;
+        this.isConnected = false;
+        this.emit("disconnected");
+        if (!this.manuallyDisconnected) this.attemptReconnect();
+      };
+
+      ws.onerror = (err) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error("WebSocket connection failed"));
+        }
         this.emit("error", err);
       };
     });
+
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
   }
 
   private attemptReconnect(): void {
-    if (this.reconnectCount >= this.maxReconnectAttempts) {
+    if (this.manuallyDisconnected || this.reconnectCount >= this.maxReconnectAttempts) {
       this.emit("maxReconnectsReached");
       return;
     }
     this.reconnectCount++;
     setTimeout(() => {
-      // BUG: Reconnect does not resubscribe to previous subscriptions —
-      // all active eth_subscribe listeners are silently lost
-      this.connect().catch(() => this.attemptReconnect());
+      if (!this.manuallyDisconnected) {
+        this.connect().catch(() => this.attemptReconnect());
+      }
     }, this.reconnectInterval);
+  }
+
+  private async resubscribeAll(): Promise<void> {
+    for (const [localId, subscription] of this.subscriptions) {
+      const newRemoteId = String(
+        await this.send("eth_subscribe", [subscription.event, ...subscription.params]),
+      );
+      this.subscriptionIdsByRemote.delete(subscription.remoteId);
+      subscription.remoteId = newRemoteId;
+      this.subscriptionIdsByRemote.set(newRemoteId, localId);
+    }
+  }
+
+  isReady(): boolean {
+    return this.isConnected;
   }
 
   async send(method: string, params: unknown[] = []): Promise<unknown> {
@@ -95,22 +148,40 @@ export class WebSocketProvider extends EventEmitter {
 
   async subscribe(
     event: string,
-    callback: (data: unknown) => void
+    callback: (data: unknown) => void,
+    params: unknown[] = []
   ): Promise<string> {
-    const subId = (await this.send("eth_subscribe", [event])) as string;
-    this.subscriptions.set(subId, callback);
-    return subId;
+    if (!this.isConnected) await this.connect();
+    const subId = (await this.send("eth_subscribe", [event, ...params])) as string;
+    const localId = String(subId);
+    this.subscriptions.set(localId, {
+      event,
+      params,
+      callback,
+      remoteId: localId,
+    });
+    this.subscriptionIdsByRemote.set(localId, localId);
+    return localId;
   }
 
   async unsubscribe(subscriptionId: string): Promise<boolean> {
+    const subscription = this.subscriptions.get(subscriptionId);
+    if (!subscription) return false;
+
     this.subscriptions.delete(subscriptionId);
-    return (await this.send("eth_unsubscribe", [subscriptionId])) as boolean;
+    this.subscriptionIdsByRemote.delete(subscription.remoteId);
+    if (!this.isConnected) return true;
+    return (await this.send("eth_unsubscribe", [subscription.remoteId])) as boolean;
   }
 
   disconnect(): void {
-    this.ws?.close();
+    this.manuallyDisconnected = true;
+    const ws = this.ws;
     this.ws = null;
     this.isConnected = false;
     this.pendingRequests.clear();
+    this.subscriptions.clear();
+    this.subscriptionIdsByRemote.clear();
+    ws?.close();
   }
 }

--- a/test/SDKEventSubscriptions.test.js
+++ b/test/SDKEventSubscriptions.test.js
@@ -1,0 +1,220 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execFileSync } = require("child_process");
+
+function loadSdk() {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagents-sdk-events-"));
+  execFileSync(
+    process.platform === "win32" ? "npx.cmd" : "npx",
+    [
+      "tsc",
+      "--target",
+      "ES2022",
+      "--module",
+      "Node16",
+      "--moduleResolution",
+      "Node16",
+      "--skipLibCheck",
+      "--types",
+      "node",
+      "--outDir",
+      outputDir,
+      "sdk/src/index.ts",
+      "sdk/src/providers/websocket.ts",
+    ],
+    { cwd: path.join(__dirname, ".."), stdio: "inherit" },
+  );
+  process.env.NODE_PATH = path.join(__dirname, "..", "node_modules");
+  require("module").Module._initPaths();
+  return {
+    sdk: require(path.join(outputDir, "index.js")),
+    websocket: require(path.join(outputDir, "providers", "websocket.js")),
+  };
+}
+
+function createProvider() {
+  const provider = {
+    subscriptions: new Map(),
+    subscribeCalls: [],
+    unsubscribeCalls: [],
+    async subscribe(event, callback, params) {
+      const id = `subscription-${this.subscribeCalls.length + 1}`;
+      this.subscribeCalls.push({ id, event, callback, params });
+      this.subscriptions.set(id, callback);
+      return id;
+    },
+    async unsubscribe(id) {
+      this.unsubscribeCalls.push(id);
+      this.subscriptions.delete(id);
+      return true;
+    },
+    async emit(id, log) {
+      await this.subscriptions.get(id)?.(log);
+    },
+  };
+  return provider;
+}
+
+async function main() {
+  const loaded = loadSdk();
+  const { OpenAgentsSDK } = loaded.sdk;
+  const sdk = new OpenAgentsSDK({
+    name: "agent",
+    endpoint: "https://agent.example",
+    privateKey: "0x" + "11".repeat(32),
+    rpcUrl: "https://rpc.example",
+    registryAddress: "0x" + "22".repeat(20),
+    routerAddress: "0x" + "33".repeat(20),
+  });
+  const provider = createProvider();
+  const contract = {
+    address: "0x" + "44".repeat(20),
+    abi: [
+      "event TaskUpdated(address indexed user,uint256 indexed taskId,string status)",
+    ],
+  };
+  const events = [];
+  const subscription = await sdk.subscribeToEvents(
+    contract,
+    "TaskUpdated",
+    (event) => events.push(event),
+    {
+      provider,
+      indexedFilters: { user: "0x" + "55".repeat(20), taskId: 7n },
+    },
+  );
+
+  assert.strictEqual(provider.subscribeCalls.length, 1);
+  assert.deepStrictEqual(provider.subscribeCalls[0].event, "logs");
+  assert.deepStrictEqual(provider.subscribeCalls[0].params[0].address, contract.address);
+  assert.strictEqual(provider.subscribeCalls[0].params[0].topics.length, 3);
+  assert.strictEqual(provider.subscribeCalls[0].params[0].topics[1], "0x" + "55".repeat(20).padStart(64, "0"));
+
+  const iface = new (require("ethers").Interface)(contract.abi);
+  const encoded = iface.encodeEventLog(iface.getEvent("TaskUpdated"), ["0x" + "55".repeat(20), 7n, "complete"]);
+  await provider.emit(subscription.id, {
+    address: contract.address,
+    topics: encoded.topics,
+    data: encoded.data,
+    transactionHash: "0x" + "66".repeat(32),
+  });
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].name, "TaskUpdated");
+  assert.strictEqual(events[0].args.user, "0x" + "55".repeat(20));
+  assert.strictEqual(events[0].args.taskId, 7n);
+  assert.strictEqual(events[0].args.status, "complete");
+
+  assert.strictEqual(await subscription.unsubscribe(), true);
+  assert.strictEqual(await subscription.unsubscribe(), false);
+  assert.deepStrictEqual(provider.unsubscribeCalls, [subscription.id]);
+
+  const wildcardSubscription = await sdk.subscribeToEvents(
+    contract,
+    "TaskUpdated",
+    () => undefined,
+    { provider, indexedFilters: { taskId: 7n } },
+  );
+  assert.strictEqual(provider.subscribeCalls[1].params[0].topics.length, 3);
+  assert.strictEqual(provider.subscribeCalls[1].params[0].topics[1], null);
+  await wildcardSubscription.unsubscribe();
+
+  await testWebSocketProvider(loaded.websocket.WebSocketProvider);
+  console.log("SDK event subscription tests passed");
+}
+
+async function testWebSocketProvider(WebSocketProvider) {
+  const originalWebSocket = global.WebSocket;
+  class FakeWebSocket {
+    static instances = [];
+    static nextSubscriptionId = 1;
+
+    constructor(url) {
+      this.url = url;
+      this.sent = [];
+      FakeWebSocket.instances.push(this);
+      queueMicrotask(() => this.onopen?.());
+    }
+
+    send(payload) {
+      const request = JSON.parse(payload);
+      this.sent.push(request);
+      if (request.method === "eth_subscribe") {
+        const result = `remote-${FakeWebSocket.nextSubscriptionId++}`;
+        queueMicrotask(() => this.onmessage?.({
+          data: JSON.stringify({ jsonrpc: "2.0", id: request.id, result }),
+        }));
+      } else if (request.method === "eth_unsubscribe") {
+        queueMicrotask(() => this.onmessage?.({
+          data: JSON.stringify({ jsonrpc: "2.0", id: request.id, result: true }),
+        }));
+      }
+    }
+
+    close() {
+      this.onclose?.();
+    }
+
+    emitSubscription(subscription, result) {
+      this.onmessage?.({
+        data: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "eth_subscription",
+          params: { subscription, result },
+        }),
+      });
+    }
+  }
+
+  global.WebSocket = FakeWebSocket;
+  try {
+    const provider = new WebSocketProvider({ url: "wss://rpc.example", reconnectIntervalMs: 0 });
+    const received = [];
+    const subscription = await provider.subscribe(
+      "logs",
+      (log) => received.push(log),
+      [{ address: "0x" + "44".repeat(20) }],
+    );
+    assert.strictEqual(FakeWebSocket.instances.length, 1);
+    assert.deepStrictEqual(FakeWebSocket.instances[0].sent[0].params, [
+      "logs",
+      { address: "0x" + "44".repeat(20) },
+    ]);
+
+    FakeWebSocket.instances[0].emitSubscription("remote-1", { blockNumber: "0x1" });
+    assert.deepStrictEqual(received, [{ blockNumber: "0x1" }]);
+
+    FakeWebSocket.instances[0].close();
+    await waitFor(() => FakeWebSocket.instances.length === 2);
+    await waitFor(() => FakeWebSocket.instances[1].sent.length === 1);
+    assert.deepStrictEqual(FakeWebSocket.instances[1].sent[0].params, [
+      "logs",
+      { address: "0x" + "44".repeat(20) },
+    ]);
+    FakeWebSocket.instances[1].emitSubscription("remote-2", { blockNumber: "0x2" });
+    assert.deepStrictEqual(received, [
+      { blockNumber: "0x1" },
+      { blockNumber: "0x2" },
+    ]);
+
+    assert.strictEqual(await provider.unsubscribe(subscription), true);
+    assert.deepStrictEqual(FakeWebSocket.instances[1].sent[1].params, ["remote-2"]);
+    provider.disconnect();
+  } finally {
+    global.WebSocket = originalWebSocket;
+  }
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for WebSocket provider state");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
/claim #196

## Summary
- Add OpenAgentsSDK.subscribeToEvents with ABI-decoded named event args and raw logs.
- Build eth_subscribe log filters from named indexed parameters while preserving wildcard topics.
- Retain and restore subscriptions across WebSocket reconnects; cleanup is idempotent.
- Add focused SDK/provider tests and safe redacted contributor metadata.

## Validation
- node test/SDKEventSubscriptions.test.js — passing
- node --check test/SDKEventSubscriptions.test.js — passing
- npx tsc --noEmit --target ES2022 --module Node16 --moduleResolution Node16 --skipLibCheck --types node sdk/src/index.ts sdk/src/providers/websocket.ts — passing
- python3 -m json.tool CONTRIBUTORS.json — passing
- git diff --check — passing
- npm test — blocked before tests by baseline Hardhat HH606 (configured Solidity 0.8.20 vs installed OpenZeppelin ^0.8.24); Node 23 also unsupported by this repository version

Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

The issue request for full private session/platform instructions is intentionally omitted. Public runtime metadata is redacted; validation commands are reproducible.