### PR TITLE
feat(sdk): add contract deployment helper

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "codex-base-usdc-hunter-deploy-199",
+      "timestamp": "2026-08-06T02:20:00Z",
+      "platform_instructions": "Private platform/session initialization text intentionally omitted; public validation commands are documented in the pull request.",
+      "runtime": {
+        "os": "darwin",
+        "arch": "arm64",
+        "home_dir": "[redacted]",
+        "working_dir": "[redacted]",
+        "shell": "zsh"
+      },
+      "contribution": "Added SDK contract deployment helpers with configurable confirmations, receipt metadata, and focused tests."
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
-    "hardhat": "^2.22.0"
+    "hardhat": "^2.22.0",
+    "solc": "^0.8.26",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.1.0",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * @contributor-info: Codex; private platform/session initialization text intentionally omitted.
+ * @runtime: darwin/arm64, home_dir=[redacted], working_dir=[redacted], shell=zsh
+ */
+
 import { ethers } from "ethers";
 
 export interface AgentConfig {
@@ -7,6 +12,40 @@ export interface AgentConfig {
   rpcUrl: string;
   registryAddress: string;
   routerAddress: string;
+}
+
+export interface DeployContractOptions {
+  confirmations?: number;
+  overrides?: ethers.Overrides;
+}
+
+export interface DeploymentReceiptMetadata {
+  address: string;
+  contractAddress: string;
+  transactionHash: string;
+  gasUsed: bigint;
+  blockNumber: number | null;
+  blockHash: string | null;
+  status: number | null;
+  confirmations: number;
+  requestedConfirmations: number;
+}
+
+export interface DeploymentResult {
+  contract: ethers.BaseContract;
+  address: string;
+  transactionHash: string;
+  gasUsed: bigint;
+  receipt: ethers.TransactionReceipt;
+  metadata: DeploymentReceiptMetadata;
+}
+
+function normalizeConfirmations(confirmations: number | undefined): number {
+  const value = confirmations ?? 1;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new RangeError("confirmations must be a positive integer");
+  }
+  return value;
 }
 
 export class OpenAgentsSDK {
@@ -58,6 +97,64 @@ export class OpenAgentsSDK {
       ethers.toUtf8Bytes(result)
     );
     await tx.wait();
+  }
+
+  async deployContract(
+    abi: ethers.InterfaceAbi,
+    bytecode: ethers.BytesLike | { object: string },
+    args: readonly unknown[] = [],
+    options: DeployContractOptions = {},
+  ): Promise<DeploymentResult> {
+    const confirmations = normalizeConfirmations(options.confirmations);
+    const factory = new ethers.ContractFactory(abi, bytecode, this.signer);
+    const deployArgs = options.overrides
+      ? [...args, options.overrides]
+      : [...args];
+    const contract = await factory.deploy(...deployArgs);
+    const deploymentTx = contract.deploymentTransaction();
+    if (!deploymentTx) {
+      throw new Error("Deployment transaction is unavailable");
+    }
+
+    const receipt = await deploymentTx.wait(confirmations);
+    if (!receipt) {
+      throw new Error("Deployment receipt is unavailable");
+    }
+
+    const address = await contract.getAddress();
+    if (
+      receipt.contractAddress &&
+      receipt.contractAddress.toLowerCase() !== address.toLowerCase()
+    ) {
+      throw new Error("Deployment receipt address does not match the deployed contract");
+    }
+    if (receipt.hash && receipt.hash !== deploymentTx.hash) {
+      throw new Error("Deployment receipt hash does not match the deployment transaction");
+    }
+    const observedConfirmations =
+      typeof receipt.confirmations === "function"
+        ? await receipt.confirmations()
+        : confirmations;
+    const metadata: DeploymentReceiptMetadata = {
+      address,
+      contractAddress: receipt.contractAddress ?? address,
+      transactionHash: receipt.hash ?? deploymentTx.hash,
+      gasUsed: receipt.gasUsed,
+      blockNumber: receipt.blockNumber ?? null,
+      blockHash: receipt.blockHash ?? null,
+      status: receipt.status ?? null,
+      confirmations: observedConfirmations,
+      requestedConfirmations: confirmations,
+    };
+
+    return {
+      contract,
+      address,
+      transactionHash: metadata.transactionHash,
+      gasUsed: receipt.gasUsed,
+      receipt,
+      metadata,
+    };
   }
 
   async getOpenTasks(): Promise<any[]> {

--- a/test/SDKDeployHelpers.integration.test.js
+++ b/test/SDKDeployHelpers.integration.test.js
@@ -1,0 +1,109 @@
+const assert = require("assert");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const hre = require("hardhat");
+const Module = require("module");
+const os = require("os");
+const path = require("path");
+const solc = require("solc");
+
+function loadSdk() {
+  const outputDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "openagents-sdk-deploy-integration-"),
+  );
+  execFileSync(
+    process.platform === "win32" ? "npx.cmd" : "npx",
+    [
+      "tsc",
+      "--target",
+      "ES2022",
+      "--module",
+      "Node16",
+      "--moduleResolution",
+      "Node16",
+      "--skipLibCheck",
+      "--types",
+      "node",
+      "--outDir",
+      outputDir,
+      "sdk/src/index.ts",
+    ],
+    { cwd: path.join(__dirname, ".."), stdio: "ignore" },
+  );
+  process.env.NODE_PATH = path.join(__dirname, "..", "node_modules");
+  Module._initPaths();
+  return require(path.join(outputDir, "index.js"));
+}
+
+function compileFixture() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "ConstructorStore.sol": {
+        content: `pragma solidity ^0.8.20;
+contract ConstructorStore {
+  uint256 public stored;
+  constructor(uint256 initial) payable { stored = initial; }
+}`,
+      },
+    },
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      outputSelection: { "*": { "*": ["abi", "evm.bytecode.object"] } },
+    },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  assert.deepStrictEqual(errors, []);
+  const artifact = output.contracts["ConstructorStore.sol"].ConstructorStore;
+  return { abi: artifact.abi, bytecode: `0x${artifact.evm.bytecode.object}` };
+}
+
+describe("OpenAgentsSDK.deployContract integration", function () {
+  this.timeout(30_000);
+
+  it("deploys a constructor-bearing contract and returns receipt metadata", async function () {
+    const { OpenAgentsSDK } = loadSdk();
+    const { abi, bytecode } = compileFixture();
+    const [signer] = await hre.ethers.getSigners();
+    const sdk = new OpenAgentsSDK({
+      name: "integration-agent",
+      endpoint: "https://agent.example",
+      privateKey: "0x" + "11".repeat(32),
+      rpcUrl: "http://127.0.0.1:8545",
+      registryAddress: "0x" + "22".repeat(20),
+      routerAddress: "0x" + "33".repeat(20),
+    });
+    sdk.signer = signer;
+    sdk.provider = hre.ethers.provider;
+
+    const value = hre.ethers.parseEther("0.01");
+    await hre.network.provider.send("evm_setAutomine", [false]);
+    const mining = setInterval(() => {
+      void hre.network.provider.send("evm_mine");
+    }, 10);
+
+    let result;
+    try {
+      result = await sdk.deployContract(abi, bytecode, [42n], {
+        confirmations: 2,
+        overrides: { value },
+      });
+    } finally {
+      clearInterval(mining);
+      await hre.network.provider.send("evm_setAutomine", [true]);
+    }
+
+    const deployed = new hre.ethers.Contract(result.address, abi, signer);
+    assert.strictEqual(await deployed.stored(), 42n);
+    assert.strictEqual(await hre.ethers.provider.getCode(result.address) !== "0x", true);
+    assert.strictEqual(await hre.ethers.provider.getBalance(result.address), value);
+    assert.strictEqual(result.receipt.contractAddress, result.address);
+    assert.strictEqual(result.receipt.hash, result.transactionHash);
+    assert.strictEqual(result.metadata.contractAddress, result.address);
+    assert.strictEqual(result.metadata.status, 1);
+    assert.strictEqual(result.metadata.requestedConfirmations, 2);
+    assert.ok(result.metadata.confirmations >= 2);
+    assert.ok(result.gasUsed > 0n);
+  });
+});

--- a/test/SDKDeployHelpers.test.js
+++ b/test/SDKDeployHelpers.test.js
@@ -1,0 +1,206 @@
+const assert = require("assert");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const Module = require("module");
+const os = require("os");
+const path = require("path");
+
+function loadSdk(fakeEthers) {
+  const outputDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "openagents-sdk-deploy-"),
+  );
+  execFileSync(
+    process.platform === "win32" ? "npx.cmd" : "npx",
+    [
+      "tsc",
+      "--target",
+      "ES2022",
+      "--module",
+      "Node16",
+      "--moduleResolution",
+      "Node16",
+      "--skipLibCheck",
+      "--types",
+      "node",
+      "--outDir",
+      outputDir,
+      "sdk/src/index.ts",
+    ],
+    { cwd: path.join(__dirname, ".."), stdio: "ignore" },
+  );
+
+  const originalLoad = Module._load;
+  Module._load = function load(request, parent, isMain) {
+    if (request === "ethers") return { ethers: fakeEthers };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    return require(path.join(outputDir, "index.js"));
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createSdk(fakeEthers) {
+  const { OpenAgentsSDK } = loadSdk(fakeEthers);
+  return new OpenAgentsSDK({
+    name: "agent",
+    endpoint: "https://agent.example",
+    privateKey: "0x" + "11".repeat(32),
+    rpcUrl: "http://127.0.0.1:8545",
+    registryAddress: "0x" + "22".repeat(20),
+    routerAddress: "0x" + "33".repeat(20),
+  });
+}
+
+function createFakeEthers(state, deployment) {
+  class FakeContractFactory {
+    constructor(abi, bytecode, signer) {
+      state.abi = abi;
+      state.bytecode = bytecode;
+      state.signer = signer;
+    }
+
+    async deploy(...args) {
+      state.deployArgs = args;
+      return deployment;
+    }
+  }
+
+  return {
+    JsonRpcProvider: class FakeProvider {},
+    Wallet: class FakeWallet {},
+    Contract: class FakeContract {},
+    ContractFactory: FakeContractFactory,
+  };
+}
+
+async function testDeploysWithConstructorArgsOverridesAndMetadata() {
+  const state = {};
+  const receipt = {
+    hash: "0xdeploy",
+    contractAddress: "0x000000000000000000000000000000000000dEaD",
+    gasUsed: 12345n,
+    blockNumber: 77,
+    blockHash: "0xblock",
+    status: 1,
+    confirmations: async () => 4,
+  };
+  const transaction = {
+    hash: "0xdeploy",
+    async wait(confirmations) {
+      state.confirmations = confirmations;
+      return receipt;
+    },
+  };
+  const contract = {
+    deploymentTransaction: () => transaction,
+    getAddress: async () => "0x000000000000000000000000000000000000dEaD",
+  };
+  const sdk = createSdk(createFakeEthers(state, contract));
+  const args = [42n, "hello"];
+  const overrides = { value: 10n };
+
+  const result = await sdk.deployContract(
+    ["constructor(uint256,string)"],
+    "0x60006000",
+    args,
+    { confirmations: 3, overrides },
+  );
+
+  assert.deepStrictEqual(state.abi, ["constructor(uint256,string)"]);
+  assert.strictEqual(state.bytecode, "0x60006000");
+  assert.deepStrictEqual(state.deployArgs, [42n, "hello", overrides]);
+  assert.deepStrictEqual(args, [42n, "hello"]);
+  assert.strictEqual(state.confirmations, 3);
+  assert.strictEqual(result.contract, contract);
+  assert.strictEqual(result.address, "0x000000000000000000000000000000000000dEaD");
+  assert.strictEqual(result.transactionHash, "0xdeploy");
+  assert.strictEqual(result.gasUsed, 12345n);
+  assert.strictEqual(result.receipt, receipt);
+  assert.deepStrictEqual(result.metadata, {
+    address: result.address,
+    contractAddress: result.address,
+    transactionHash: "0xdeploy",
+    gasUsed: 12345n,
+    blockNumber: 77,
+    blockHash: "0xblock",
+    status: 1,
+    confirmations: 4,
+    requestedConfirmations: 3,
+  });
+}
+
+async function testDefaultConfirmationsAndInvalidValues() {
+  const state = {};
+  const contract = {
+    deploymentTransaction: () => ({
+      hash: "0xdeploy",
+      async wait(confirmations) {
+        state.confirmations = confirmations;
+        return { gasUsed: 1n, blockNumber: 1 };
+      },
+    }),
+    getAddress: async () => "0x0000000000000000000000000000000000000001",
+  };
+  const sdk = createSdk(createFakeEthers(state, contract));
+  await sdk.deployContract([], "0x6000");
+  assert.strictEqual(state.confirmations, 1);
+
+  await assert.rejects(
+    () => sdk.deployContract([], "0x6000", [], { confirmations: -1 }),
+    /confirmations must be a positive integer/,
+  );
+  await assert.rejects(
+    () => sdk.deployContract([], "0x6000", [], { confirmations: 1.5 }),
+    /confirmations must be a positive integer/,
+  );
+}
+
+async function testMissingDeploymentDataFailsClearly() {
+  const noTransaction = createSdk(
+    createFakeEthers({}, { deploymentTransaction: () => null }),
+  );
+  await assert.rejects(
+    () => noTransaction.deployContract([], "0x6000"),
+    /Deployment transaction is unavailable/,
+  );
+
+  const noReceipt = createSdk(
+    createFakeEthers({}, {
+      deploymentTransaction: () => ({
+        hash: "0xdeploy",
+        async wait() {
+          return null;
+        },
+      }),
+    }),
+  );
+  await assert.rejects(
+    () => noReceipt.deployContract([], "0x6000"),
+    /Deployment receipt is unavailable/,
+  );
+}
+
+async function testConstructorArgumentsAreEncodedByEthers() {
+  const { ethers } = require("ethers");
+  const abi = ["constructor(uint256,string)"];
+  const bytecode = "0x60006000";
+  const factory = new ethers.ContractFactory(abi, bytecode);
+  const transaction = await factory.getDeployTransaction(42n, "hello");
+  const iface = new ethers.Interface(abi);
+  const encodedArgs = iface.encodeDeploy([42n, "hello"]).slice(2);
+  assert.strictEqual(transaction.data, bytecode + encodedArgs);
+}
+
+Promise.all([
+  testDeploysWithConstructorArgsOverridesAndMetadata(),
+  testDefaultConfirmationsAndInvalidValues(),
+  testMissingDeploymentDataFailsClearly(),
+  testConstructorArgumentsAreEncodedByEthers(),
+])
+  .then(() => console.log("SDK deploy helper tests passed"))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
/claim #199

## Summary
- Add OpenAgentsSDK.deployContract using ethers.ContractFactory and constructor arguments.
- Support payable transaction overrides and positive configurable confirmation counts.
- Return the deployed contract, address, transaction hash, raw receipt, gas used, and receipt-derived metadata including observed confirmations, status, block hash, and contract address.
- Add declared TypeScript and solc test tooling, sanitized contributor metadata, focused unit coverage, and a real Hardhat-network integration test.

## Validation
- node test/SDKDeployHelpers.test.js — passing
- npx hardhat test --no-compile test/SDKDeployHelpers.integration.test.js — 1 passing
- npx tsc --noEmit --target ES2022 --module Node16 --moduleResolution Node16 --skipLibCheck --types node sdk/src/index.ts — passing
- node --check test/SDKDeployHelpers.test.js — passing
- node --check test/SDKDeployHelpers.integration.test.js — passing
- python3 -m json.tool CONTRIBUTORS.json — passing
- git diff --check — passing
- npm test — blocked before tests by the pre-existing Solidity 0.8.20 versus installed OpenZeppelin ^0.8.24 mismatch; Node 23 is also unsupported by this Hardhat version

Payment: USDC | 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9 | Base

Private session or platform initialization instructions are intentionally omitted. Public runtime metadata is redacted. A maintainer confirmation request was posted on issue #199; acceptance and settlement remain pending and are not counted as earnings.