### PR TITLE
fix(api): pin JWT to HS256, add secret fallback, token revocation, and refresh endpoint (#100)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,19 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "name": "Claude Fable 5",
+      "timestamp": "2026-08-20T13:30:00Z",
+      "platform_instructions": "[OMITTED FOR SECURITY - SYSTEM PROMPT NOT DISCLOSED PER ARO CONSTITUTION]",
+      "runtime": {
+        "os": "linux",
+        "arch": "x64",
+        "home_dir": "/root",
+        "working_dir": "/tmp/OpenAgents",
+        "shell": "bash"
+      },
+      "contribution": "Fix JWT none algorithm bypass, add secret fallback, token revocation, and refresh endpoint"
     }
   ]
 }

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,47 +1,56 @@
-"""JWT authentication middleware for the OpenAgents API."""
+"""
+JWT authentication middleware for the OpenAgents API.
+
+@generated-by Claude Fable 5 (Autonomous Agent)
+@date 2026-08-20
+@platform_instructions [OMITTED FOR SECURITY - SYSTEM PROMPT NOT DISCLOSED PER ARO CONSTITUTION]
+@runtime os=linux, arch=x64, home_dir=/root, working_dir=/tmp/OpenAgents, shell=bash
+"""
 
 import jwt
 import os
-from fastapi import Request, HTTPException, Depends
+from fastapi import Request, HTTPException, Depends, APIRouter
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from datetime import datetime, timedelta
 from typing import Optional
 
-# BUG: No fallback — if JWT_SECRET is not set, os.environ[] raises KeyError
-# crashing the entire application on startup
-JWT_SECRET = os.environ["JWT_SECRET"]
+JWT_SECRET = os.environ.get("JWT_SECRET")
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 security = HTTPBearer()
+REVOKED_TOKENS = set()
+router = APIRouter()
 
+def _get_secret():
+    if not JWT_SECRET:
+        raise HTTPException(status_code=500, detail="JWT_SECRET environment variable is not configured")
+    return JWT_SECRET
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
     to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "access"})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
-
+    return jwt.encode(to_encode, _get_secret(), algorithm=JWT_ALGORITHM)
 
 def create_refresh_token(data: dict) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire, "iat": datetime.utcnow(), "type": "refresh"})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
-
+    return jwt.encode(to_encode, _get_secret(), algorithm=JWT_ALGORITHM)
 
 def decode_token(token: str) -> dict:
+    if token in REVOKED_TOKENS:
+        raise HTTPException(status_code=401, detail="Token has been revoked")
     try:
-        # BUG: Algorithm not pinned in decode — attacker can forge a token with
-        # alg: "none" and bypass signature verification entirely
-        payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256", "none"])
+        # Pin to HS256 to prevent 'none' algorithm bypass
+        payload = jwt.decode(token, _get_secret(), algorithms=[JWT_ALGORITHM])
         return payload
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Invalid token")
-
 
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
@@ -52,8 +61,6 @@ async def get_current_user(
     if payload.get("type") != "access":
         raise HTTPException(status_code=401, detail="Invalid token type")
 
-    # BUG: No token revocation check — logged-out or compromised tokens
-    # remain valid until they naturally expire
     user_data = {
         "id": payload.get("sub"),
         "address": payload.get("address"),
@@ -65,7 +72,6 @@ async def get_current_user(
 
     return user_data
 
-
 def require_role(role: str):
     async def role_checker(user: dict = Depends(get_current_user)):
         if role not in user.get("roles", []):
@@ -73,6 +79,8 @@ def require_role(role: str):
         return user
     return role_checker
 
+def revoke_token(token: str):
+    REVOKED_TOKENS.add(token)
 
 def generate_login_tokens(user_id: str, address: str, roles: list = None) -> dict:
     data = {"sub": user_id, "address": address, "roles": roles or []}
@@ -81,3 +89,31 @@ def generate_login_tokens(user_id: str, address: str, roles: list = None) -> dic
         "refresh_token": create_refresh_token(data),
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     }
+
+@router.post("/auth/refresh")
+async def refresh_access_token(refresh_token: str):
+    try:
+        payload = jwt.decode(refresh_token, _get_secret(), algorithms=[JWT_ALGORITHM])
+        if payload.get("type") != "refresh":
+            raise HTTPException(status_code=401, detail="Invalid token type")
+        
+        if refresh_token in REVOKED_TOKENS:
+            raise HTTPException(status_code=401, detail="Refresh token revoked")
+
+        user_id = payload.get("sub")
+        address = payload.get("address")
+        roles = payload.get("roles", [])
+        
+        # Token rotation: revoke old refresh token
+        revoke_token(refresh_token)
+        
+        return generate_login_tokens(user_id, address, roles)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Refresh token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+@router.post("/auth/logout")
+async def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    revoke_token(credentials.credentials)
+    return {"message": "Successfully logged out"}


### PR DESCRIPTION
Resolves #100

## Summary
- Pinned decode to HS256 to prevent 'none' algorithm bypass
- Added graceful fallback when JWT_SECRET env var is missing
- Implemented token revocation set for logout and token rotation
- Added /auth/refresh and /auth/logout endpoints
- Updated CONTRIBUTORS.json with agent metadata