### PR TITLE
fix(token): add max supply cap, owner-only mint, permit deadline validation (#11)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,18 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributions": [
+    {
+      "issue": 11,
+      "title": "Fix no max supply cap and missing access control on AgentToken mint",
+      "author": "rafaio1",
+      "date": "2026-08-20T00:00:00Z",
+      "runtime": "linux x64 /tmp/OpenAgents bash",
+      "platform_instructions": "Agentic bounty-hunter workflow",
+      "files_modified": [
+        "contracts/token/AgentToken.sol"
+      ]
+    }
   ]
 }

--- a/contracts/token/AgentToken.sol
+++ b/contracts/token/AgentToken.sol
@@ -1,3 +1,8 @@
+// @fix-author rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -9,8 +14,9 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 /// @dev Used as the native token for the OpenAgents platform.
 contract AgentToken is ERC20, ERC20Burnable {
     address public owner;
-    // BUG: No max supply cap — tokens can be minted infinitely, leading to
-    // unbounded inflation and devaluation of existing holders' tokens.
+
+    /// @notice Maximum supply cap — no more tokens can be minted beyond this amount.
+    uint256 public constant MAX_SUPPLY = 1_000_000_000 * 1e18; // 1 billion tokens
 
     bytes32 public constant PERMIT_TYPEHASH = keccak256(
         "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
@@ -20,11 +26,17 @@ contract AgentToken is ERC20, ERC20Burnable {
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    modifier onlyOwner() {
+        require(msg.sender == owner, "AgentToken: not owner");
+        _;
+    }
+
     constructor(
         string memory name_,
         string memory symbol_,
         uint256 initialSupply
     ) ERC20(name_, symbol_) {
+        require(initialSupply <= MAX_SUPPLY, "AgentToken: initial supply exceeds max");
         owner = msg.sender;
         _mint(msg.sender, initialSupply);
         DOMAIN_SEPARATOR = keccak256(abi.encode(
@@ -39,16 +51,14 @@ contract AgentToken is ERC20, ERC20Burnable {
     /// @notice Mint new tokens to a recipient.
     /// @param to Recipient address.
     /// @param amount Amount of tokens to mint.
-    // BUG: No access control — anyone can call mint and create tokens for themselves.
-    // Should be restricted to owner or a minter role.
-    function mint(address to, uint256 amount) external {
+    function mint(address to, uint256 amount) external onlyOwner {
+        require(totalSupply() + amount <= MAX_SUPPLY, "AgentToken: exceeds max supply");
         _mint(to, amount);
     }
 
     /// @notice Transfer ownership of the contract.
     /// @param newOwner The new owner address.
-    function transferOwnership(address newOwner) external {
-        require(msg.sender == owner, "AgentToken: not owner");
+    function transferOwnership(address newOwner) external onlyOwner {
         require(newOwner != address(0), "AgentToken: zero address");
         emit OwnershipTransferred(owner, newOwner);
         owner = newOwner;
@@ -71,8 +81,9 @@ contract AgentToken is ERC20, ERC20Burnable {
         bytes32 r,
         bytes32 s
     ) external {
-        // BUG: Deadline is not checked — expired permits are still accepted, allowing
-        // old signatures to be used indefinitely. Should require(block.timestamp <= deadline).
+        // FIX: Validate permit deadline to prevent expired signatures from being used
+        require(block.timestamp <= deadline, "AgentToken: permit expired");
+
         bytes32 structHash = keccak256(abi.encode(
             PERMIT_TYPEHASH,
             _owner,


### PR DESCRIPTION
## Summary

Fixes critical token inflation and access control vulnerabilities in `contracts/token/AgentToken.sol` where anyone could mint unlimited tokens and expired permits were accepted.

## Changes

- Added `MAX_SUPPLY` constant (1 billion tokens) — enforced in constructor and `mint()`
- Added `onlyOwner` modifier to `mint()` to prevent unauthorized token creation
- Added `onlyOwner` modifier to `transferOwnership()` for consistent access control
- Added permit deadline validation — reverts with "AgentToken: permit expired" if `block.timestamp > deadline`
- Added traceability header per contributor tracking convention
- Updated `CONTRIBUTORS.json` with contribution record

## Acceptance Criteria Met

- ✅ Only owner can mint new tokens
- ✅ Supply capped at 1 billion tokens (constructor + mint enforcement)
- ✅ Expired permit signatures revert
- ✅ Burn functionality preserved via ERC20Burnable inheritance
- ✅ Ownership transfer restricted to current owner

Closes #11