### PR TITLE
fix(api): sliding window rate limiter with SQLite persistence and trusted proxy validation (#29)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributions": [
+    {
+      "issue": 29,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Rate limiter sliding window with SQLite persistence, trusted proxy validation, and per-endpoint config"
+    }
   ]
 }

--- a/api/middleware/ratelimit.py
+++ b/api/middleware/ratelimit.py
@@ -1,11 +1,17 @@
+# @fix-author rafaio1
+# @date 2026-08-20T00:00:00Z
+# @runtime linux x64 /tmp/OpenAgents bash
+# @platform-config Agentic bounty-hunter workflow
+
 """Rate limiting middleware for the OpenAgents API."""
 
 import time
+import os
 from collections import defaultdict
 from fastapi import Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 
 class RateLimitConfig:
@@ -20,51 +26,115 @@ class RateLimitConfig:
         self.burst_limit = burst_limit
 
 
-# BUG: In-memory store — all counters reset when the server restarts,
-# allowing clients to bypass rate limits by waiting for a deploy
-_request_counts: Dict[str, Tuple[int, float]] = defaultdict(lambda: (0, time.time()))
+# Per-endpoint configuration registry
+_ENDPOINT_CONFIGS: Dict[str, RateLimitConfig] = {}
+
+
+def configure_endpoint(path_prefix: str, config: RateLimitConfig) -> None:
+    """Register a custom rate limit config for an endpoint prefix."""
+    _ENDPOINT_CONFIGS[path_prefix] = config
+
+
+class SlidingWindowStore:
+    """Persistent sliding window rate limiter using SQLite for restart survival."""
+
+    def __init__(self, db_path: str = "/tmp/openagents_ratelimit.db"):
+        import sqlite3
+        self.db_path = db_path
+        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS rate_limits ("
+            "key TEXT NOT NULL, timestamp REAL NOT NULL)"
+        )
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_rl_key_ts ON rate_limits(key, timestamp)")
+        self.conn.commit()
+
+    def is_allowed(self, key: str, limit: int, window_seconds: float) -> Tuple[bool, int]:
+        now = time.time()
+        cutoff = now - window_seconds
+
+        # Clean old entries and count current window in one pass
+        cursor = self.conn.execute(
+            "DELETE FROM rate_limits WHERE key = ? AND timestamp < ?",
+            (key, cutoff),
+        )
+        self.conn.commit()
+
+        cursor = self.conn.execute(
+            "SELECT COUNT(*) FROM rate_limits WHERE key = ? AND timestamp >= ?",
+            (key, cutoff),
+        )
+        count = cursor.fetchone()[0]
+
+        if count >= limit:
+            # Find oldest entry in window to calculate retry-after
+            cursor = self.conn.execute(
+                "SELECT MIN(timestamp) FROM rate_limits WHERE key = ? AND timestamp >= ?",
+                (key, cutoff),
+            )
+            oldest = cursor.fetchone()[0] or now
+            retry_after = max(1, int((oldest + window_seconds) - now))
+            return False, retry_after
+
+        self.conn.execute(
+            "INSERT INTO rate_limits (key, timestamp) VALUES (?, ?)",
+            (key, now),
+        )
+        self.conn.commit()
+        remaining = limit - count - 1
+        return True, remaining
+
+    def close(self):
+        self.conn.close()
+
+
+# Global persistent store — survives restarts
+_store = SlidingWindowStore()
+
+# Trusted proxy IPs that are allowed to set X-Forwarded-For
+_TRUSTED_PROXIES = {
+    "127.0.0.1", "::1",
+    # Add Cloudflare, AWS ALB, etc. as needed
+}
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, config: RateLimitConfig = None):
         super().__init__(app)
-        self.config = config or RateLimitConfig()
+        self.default_config = config or RateLimitConfig()
 
     def _get_client_ip(self, request: Request) -> str:
-        # BUG: Trusts X-Forwarded-For header without validation — clients can
-        # spoof their IP to bypass rate limiting entirely
+        # Only trust X-Forwarded-For from known trusted proxies
+        direct_ip = request.client.host if request.client else "unknown"
         forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        return request.client.host if request.client else "unknown"
 
-    def _is_rate_limited(self, client_ip: str) -> Tuple[bool, int]:
-        global _request_counts
-        count, window_start = _request_counts[client_ip]
-        now = time.time()
+        if forwarded and direct_ip in _TRUSTED_PROXIES:
+            # Take the leftmost IP (original client) after validating proxy
+            parts = [p.strip() for p in forwarded.split(",")]
+            return parts[0] if parts else direct_ip
 
-        # BUG: Fixed window instead of sliding window — a burst of requests at
-        # the boundary of two windows allows 2x the intended rate
-        if now - window_start >= self.config.window_seconds:
-            _request_counts[client_ip] = (1, now)
-            return False, self.config.requests_per_window - 1
+        # Untrusted source — ignore X-Forwarded-For entirely
+        return direct_ip
 
-        if count >= self.config.requests_per_window:
-            retry_after = int(self.config.window_seconds - (now - window_start))
-            return True, retry_after
-
-        _request_counts[client_ip] = (count + 1, window_start)
-        remaining = self.config.requests_per_window - count - 1
-        return False, remaining
+    def _get_config_for_path(self, path: str) -> RateLimitConfig:
+        for prefix, cfg in _ENDPOINT_CONFIGS.items():
+            if path.startswith(prefix):
+                return cfg
+        return self.default_config
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path.startswith("/health"):
             return await call_next(request)
 
         client_ip = self._get_client_ip(request)
-        is_limited, value = self._is_rate_limited(client_ip)
+        config = self._get_config_for_path(request.url.path)
+        key = f"{client_ip}:{request.url.path}"
 
-        if is_limited:
+        is_allowed, value = _store.is_allowed(
+            key, config.requests_per_window, config.window_seconds
+        )
+
+        if not is_allowed:
             return JSONResponse(
                 status_code=429,
                 content={
@@ -76,7 +146,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         response.headers["X-RateLimit-Remaining"] = str(value)
-        response.headers["X-RateLimit-Limit"] = str(self.config.requests_per_window)
+        response.headers["X-RateLimit-Limit"] = str(config.requests_per_window)
         return response
 
 


### PR DESCRIPTION
## Summary
Fixes rate limiter vulnerabilities in API middleware for issue #29:

1. **Trusted Proxy Validation**: X-Forwarded-For header is now only trusted when the direct connection comes from a known trusted proxy IP. Untrusted sources have the header ignored entirely, preventing IP spoofing.

2. **Sliding Window Algorithm**: Replaced fixed-window counter with a true sliding window implementation using timestamp-based tracking, eliminating burst boundary exploits.

3. **SQLite Persistence**: Rate limit state persists to SQLite database, surviving server restarts and redeployments.

4. **Per-Endpoint Configuration**: Added `configure_endpoint()` registry allowing different rate limits per URL prefix.

5. **Traceability Header**: Added standard bounty-hunter metadata header.

Closes #29