### PR TITLE
feat(registry): add batchRegister for gas-efficient multi-agent onboarding (#145)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 145,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Add batchRegister function to AgentRegistry for gas-efficient multi-agent onboarding"
+    }
   ]
 }

--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,3 +1,7 @@
+// @fix-author rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -20,6 +24,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public constant MAX_BATCH_SIZE = 50;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -53,6 +58,45 @@ contract AgentRegistry is Ownable {
 
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
+    }
+
+    /// @notice Register multiple agents in a single transaction for gas efficiency.
+    /// @param names Array of agent names (max 50).
+    /// @param endpoints Array of agent endpoints (must match names length).
+    /// @return agentIds_ Array of newly created agent IDs.
+    function batchRegister(
+        string[] calldata names,
+        string[] calldata endpoints
+    ) external payable returns (bytes32[] memory agentIds_) {
+        require(names.length == endpoints.length, "Array length mismatch");
+        require(names.length > 0 && names.length <= MAX_BATCH_SIZE, "Invalid batch size");
+        require(msg.value >= registrationFee * names.length, "Insufficient total fee");
+
+        agentIds_ = new bytes32[](names.length);
+        for (uint256 i = 0; i < names.length; i++) {
+            // Inline registration logic to avoid external call overhead in loop
+            require(bytes(names[i]).length > 0 && bytes(names[i]).length <= 64, "Invalid name");
+            
+            // Use unique salt per agent including index to prevent ID collision in same block
+            bytes32 agentId = keccak256(abi.encodePacked(msg.sender, names[i], block.timestamp, i));
+            require(agents[agentId].registeredAt == 0, "Agent exists");
+
+            agents[agentId] = Agent({
+                owner: msg.sender,
+                name: names[i],
+                endpoint: endpoints[i],
+                reputation: 100,
+                tasksCompleted: 0,
+                registeredAt: block.timestamp,
+                active: true
+            });
+
+            ownerAgents[msg.sender].push(agentId);
+            agentIds.push(agentId);
+            
+            emit AgentRegistered(agentId, msg.sender, names[i]);
+            agentIds_[i] = agentId;
+        }
     }
 
     function deactivateAgent(bytes32 agentId) external {


### PR DESCRIPTION
Fixes #145

## Summary
Registering multiple agents previously required separate transactions, causing high gas costs for platform onboarding. This adds a batch registration function supporting up to 50 agents in a single call.

## Changes
- Added `MAX_BATCH_SIZE = 50` constant
- Implemented `batchRegister(string[] names, string[] endpoints)` with fee validation
- Uses unique salt per agent (including index) to prevent ID collision within same block
- Emits individual `AgentRegistered` events for each agent
- Prepended standard fix header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified compilation with solc 0.8.20
- Batch size limits enforced (1-50)
- Fee calculation scales linearly with batch size