### PR TITLE
fix(lottery): add cancellation and refund mechanism for insufficient participants (#125)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 125,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Add lottery cancellation and refund mechanism for insufficient participants"
+    }
   ]
 }

--- a/contracts/lottery/RandomLottery.sol
+++ b/contracts/lottery/RandomLottery.sol
@@ -1,3 +1,7 @@
+// @fix-author rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -9,22 +13,27 @@ contract RandomLottery {
     uint256 public ticketPrice;
     uint256 public roundEnd;
     uint256 public currentRound;
+    uint256 public minParticipants;
 
     address[] public players;
     mapping(uint256 => address) public roundWinners;
+    mapping(uint256 => mapping(address => bool)) public refunded;
 
     event TicketPurchased(address indexed player, uint256 round);
     event RoundStarted(uint256 indexed round, uint256 endTime);
     event WinnerSelected(address indexed winner, uint256 prize, uint256 round);
+    event LotteryCancelled(uint256 indexed round, uint256 playerCount);
+    event RefundClaimed(address indexed player, uint256 amount, uint256 round);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "Not owner");
         _;
     }
 
-    constructor(uint256 _ticketPrice) {
+    constructor(uint256 _ticketPrice, uint256 _minParticipants) {
         owner = msg.sender;
         ticketPrice = _ticketPrice;
+        minParticipants = _minParticipants > 0 ? _minParticipants : 2;
     }
 
     function startRound(uint256 duration) external onlyOwner {
@@ -44,6 +53,7 @@ contract RandomLottery {
 
     function drawWinner() external onlyOwner {
         require(block.timestamp >= roundEnd, "Round not ended");
+        require(players.length >= minParticipants, "Insufficient participants - cancel instead");
 
         // BUG: prevrandao is manipulable by validators — validators can influence
         // the randomness value, making the lottery outcome predictable/riggable
@@ -65,6 +75,40 @@ contract RandomLottery {
         require(sent, "Transfer failed");
 
         emit WinnerSelected(winner, prize, currentRound);
+    }
+
+    /// @notice Cancel the current round if deadline passed without enough participants.
+    /// @dev Only callable by owner after roundEnd when player count is below minimum.
+    function cancelLottery() external onlyOwner {
+        require(block.timestamp >= roundEnd, "Round still active");
+        require(players.length < minParticipants, "Enough participants");
+        require(roundEnd > 0, "No active round");
+
+        emit LotteryCancelled(currentRound, players.length);
+        roundEnd = 0; // Mark round as settled (cancelled)
+    }
+
+    /// @notice Claim refund for a cancelled round.
+    /// @dev Players can claim their ticket price back after cancellation.
+    function claimRefund() external {
+        require(roundEnd == 0, "Round not cancelled");
+        require(!refunded[currentRound][msg.sender], "Already refunded");
+        
+        // Verify player participated in this round
+        bool isPlayer = false;
+        for (uint256 i = 0; i < players.length; i++) {
+            if (players[i] == msg.sender) {
+                isPlayer = true;
+                break;
+            }
+        }
+        require(isPlayer, "Not a participant");
+
+        refunded[currentRound][msg.sender] = true;
+        (bool sent, ) = msg.sender.call{value: ticketPrice}("");
+        require(sent, "Refund failed");
+
+        emit RefundClaimed(msg.sender, ticketPrice, currentRound);
     }
 
     function getPlayers() external view returns (address[] memory) {


### PR DESCRIPTION
Fixes #125

## Summary
The `RandomLottery` contract had no mechanism to refund participants if a round was cancelled or failed to reach minimum participation, permanently locking funds.

## Changes
- Added `minParticipants` constructor parameter (defaults to 2)
- Added `cancelLottery()` function callable by owner after deadline when participant count is below minimum
- Added `claimRefund()` allowing participants to reclaim ticket price after cancellation
- Added per-player `refunded` mapping to prevent double claims
- Added min participants check in `drawWinner` to enforce cancellation path
- Added `LotteryCancelled` and `RefundClaimed` events
- Prepended standard fix header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified compilation with solc 0.8.20
- Cancellation correctly blocks draw when participants < minimum
- Refund claims are idempotent and restricted to actual participants