### PR TITLE
fix(sdk): cap maxRetries at 5, backoff at 60s, and reset failures on success (#102)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 102,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Cap maxRetries at 5, backoff at 60s, and reset consecutiveFailures on success in retry utility"
+    }
   ]
 }

--- a/sdk/src/utils/retry.ts
+++ b/sdk/src/utils/retry.ts
@@ -1,3 +1,7 @@
+// @fix-author rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 /**
  * Retry utility with exponential backoff for unreliable RPC calls.
  */
@@ -10,9 +14,9 @@ export interface RetryOptions {
 }
 
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "onRetry">> = {
-  maxRetries: Infinity, // BUG: No cap — will retry forever by default
+  maxRetries: 5, // Capped at 5 retries to prevent infinite loops
   baseDelayMs: 500,
-  maxDelayMs: 30_000,
+  maxDelayMs: 60_000, // Cap backoff at 60s to prevent overflow/excessive waits
 };
 
 export class RetryHandler {
@@ -31,8 +35,7 @@ export class RetryHandler {
     for (let attempt = 0; attempt <= this.options.maxRetries; attempt++) {
       try {
         const result = await fn();
-        // BUG: consecutiveFailures is never reset on success,
-        // so backoff keeps growing even after recovery
+        this.consecutiveFailures = 0; // Reset on success
         return result;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
@@ -50,9 +53,9 @@ export class RetryHandler {
   }
 
   private calculateBackoff(attempt: number): number {
-    // BUG: 2 ** attempt overflows to Infinity for large attempt values (attempt > ~1023),
-    // and Math.min with Infinity returns maxDelayMs, but intermediate calc can cause issues
-    const exponentialDelay = this.options.baseDelayMs * Math.pow(2, attempt);
+    // Cap exponent to prevent Infinity from Math.pow(2, large_number)
+    const cappedAttempt = Math.min(attempt, 20);
+    const exponentialDelay = this.options.baseDelayMs * Math.pow(2, cappedAttempt);
     const jitter = Math.random() * this.options.baseDelayMs;
     return Math.min(exponentialDelay + jitter, this.options.maxDelayMs);
   }


### PR DESCRIPTION
Fixes #102

## Summary
The retry utility had no cap on retries (defaulting to Infinity) and never reset the consecutive failure counter on success, causing unbounded backoff growth even after recovery. Additionally, the exponential backoff calculation could overflow for large attempt values.

## Changes
- Capped `maxRetries` default at 5 to prevent infinite retry loops
- Increased `maxDelayMs` cap to 60s for reasonable upper bound
- Reset `consecutiveFailures` to 0 on successful execution
- Capped exponent in `calculateBackoff` to 20 to prevent `Math.pow` overflow
- Prepended standard fix header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified TypeScript compilation without errors
- Backoff correctly caps at 60s regardless of attempt count
- Failure counter resets after successful operation