### PR TITLE
fix(api): add task status transition validation, creator-completer check, and pagination cap (#96)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 96,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Add task status transition validation, creator-completer check, and pagination cap"
+    }
   ]
 }

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,7 +1,11 @@
+# @generated-by rafaio1
+# @date 2026-08-20T00:00:00Z
+# @runtime linux x64 /tmp/OpenAgents bash
+# @platform-config Agentic bounty-hunter workflow
 """Task management endpoints for bounty assignments."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional
 from datetime import datetime
 
@@ -22,7 +26,14 @@ class TaskCreate(BaseModel):
 
 
 class TaskStatusUpdate(BaseModel):
-    status: str  # BUG: Not validated against VALID_STATUSES enum — any string accepted
+    status: str
+    
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        if v not in VALID_STATUSES:
+            raise ValueError(f"Invalid status: must be one of {VALID_STATUSES}")
+        return v
 
 
 @router.post("/")
@@ -50,7 +61,7 @@ async def list_tasks(
     skip: int = Query(0, ge=0),
     # BUG: No upper bound on limit — clients can request millions of rows,
     # causing DB strain and potential OOM
-    limit: int = Query(50, ge=1),
+    limit: int = Query(50, ge=1, le=100),
     db=Depends(get_db),
 ):
     query = db.query(Task)
@@ -69,6 +80,17 @@ async def get_task(task_id: int, db=Depends(get_db)):
     return task
 
 
+# Valid state transitions: current_status -> set of allowed next statuses
+VALID_TRANSITIONS = {
+    "open": {"assigned", "cancelled"},
+    "assigned": {"in_progress", "cancelled"},
+    "in_progress": {"review", "cancelled"},
+    "review": {"completed", "in_progress"},
+    "completed": set(),
+    "cancelled": set(),
+}
+
+
 @router.patch("/{task_id}/status")
 async def update_task_status(
     task_id: int,
@@ -80,10 +102,26 @@ async def update_task_status(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    # BUG: Creator can mark their own task as completed — should require
-    # a third party or the assignee to confirm completion
-    if task.creator_id != user["id"]:
-        raise HTTPException(status_code=403, detail="Only the creator can update status")
+    # Validate state transition
+    allowed = VALID_TRANSITIONS.get(task.status, set())
+    if update.status not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid transition from '{task.status}' to '{update.status}'"
+        )
+
+    # Prevent creator from marking their own task as completed (conflict of interest)
+    if update.status == "completed" and task.creator_id == user["id"]:
+        raise HTTPException(
+            status_code=403,
+            detail="Creator cannot complete their own task — requires assignee or reviewer"
+        )
+
+    # Only creator or assigned agent can update status
+    is_creator = task.creator_id == user["id"]
+    is_assignee = task.agent_id is not None and user.get("agent_id") == task.agent_id
+    if not (is_creator or is_assignee):
+        raise HTTPException(status_code=403, detail="Only creator or assignee can update status")
 
     task.status = update.status
     task.updated_at = datetime.utcnow()


### PR DESCRIPTION
Fixes #96

## Summary
The task status update endpoint allowed creators to mark their own tasks as completed (conflict of interest), accepted arbitrary status strings without validation, and had no upper bound on list pagination.

## Changes
- Added `VALID_TRANSITIONS` map enforcing allowed state transitions (open→assigned→in_progress→review→completed)
- Blocked creator from completing their own task — requires assignee or reviewer
- Added Pydantic `field_validator` on `TaskStatusUpdate.status` against `VALID_STATUSES` enum
- Capped `list_tasks` limit at 100 to prevent DB strain
- Prepended standard contributor header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified FastAPI app starts without import errors
- Invalid status values are rejected with descriptive error
- Creator self-completion returns 403 Forbidden