### PR TITLE
fix(staking): prevent duplicate pools, validate zero addresses, and fix reward overflow (#94)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 94,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Fix MultiTokenStaking duplicate pool check, zero-address validation, and reward overflow"
+    }
   ]
 }

--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -1,3 +1,7 @@
+// @contributor rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -38,20 +42,21 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
 
-    // BUG: Missing zero-address validation — rewardToken can be set to address(0),
-    // causing all reward transfers to silently burn tokens or revert unpredictably.
     constructor(address _rewardToken, uint256 _rewardPerSecond) Ownable(msg.sender) {
+        require(_rewardToken != address(0), "MultiStaking: zero reward token");
         rewardToken = IERC20(_rewardToken);
         rewardPerSecond = _rewardPerSecond;
     }
 
+    mapping(address => bool) public poolExists;
+
     /// @notice Add a new staking pool.
     /// @param _allocPoint Allocation weight for reward distribution.
     /// @param _stakeToken The ERC20 token to be staked in this pool.
-    // BUG: No duplicate token check — the same token can be added multiple times,
-    // causing reward accounting to break as totalAllocPoint inflates and existing
-    // stakers in the original pool get diluted unexpectedly.
     function addPool(uint256 _allocPoint, address _stakeToken) external onlyOwner {
+        require(_stakeToken != address(0), "MultiStaking: zero stake token");
+        require(!poolExists[_stakeToken], "MultiStaking: duplicate pool");
+        poolExists[_stakeToken] = true;
         totalAllocPoint += _allocPoint;
         poolInfo.push(PoolInfo({
             stakeToken: IERC20(_stakeToken),
@@ -75,10 +80,8 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
 
         uint256 elapsed = block.timestamp - pool.lastRewardTime;
-        // BUG: Reward calculation can overflow for large elapsed * rewardPerSecond * allocPoint
-        // values. With high rewardPerSecond (e.g., 1e18) and long time gaps, the intermediate
-        // multiplication exceeds uint256 before the division by totalAllocPoint.
-        uint256 reward = elapsed * rewardPerSecond * pool.allocPoint / totalAllocPoint;
+        // Safe multiplication order: divide early to prevent overflow
+        uint256 reward = (elapsed * rewardPerSecond / totalAllocPoint) * pool.allocPoint;
         pool.accRewardPerShare += reward * 1e12 / pool.totalStaked;
         pool.lastRewardTime = block.timestamp;
     }


### PR DESCRIPTION
Fixes #94

## Summary
The `MultiTokenStaking` contract allowed duplicate stake tokens to be added (breaking reward accounting), lacked zero-address validation for critical parameters, and had a reward calculation vulnerable to uint256 overflow.

## Changes
- Added `poolExists` mapping to prevent duplicate stake token registration
- Added zero-address checks in constructor (`_rewardToken`) and `addPool` (`_stakeToken`)
- Reordered multiplication in `updatePool` to divide by `totalAllocPoint` before multiplying by `allocPoint`, preventing intermediate overflow
- Prepended standard contributor header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified compilation with solc 0.8.20
- Duplicate `addPool` calls correctly revert
- Zero-address parameters are rejected at deployment and pool creation