### PR TITLE
fix(token): add MAX_SUPPLY cap, owner-only mint, and permit deadline check (#70)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 70,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Fix AgentToken: add MAX_SUPPLY cap, owner-only mint access control, and permit deadline validation"
+    }
   ]
 }

--- a/contracts/token/AgentToken.sol
+++ b/contracts/token/AgentToken.sol
@@ -1,3 +1,7 @@
+// @contributor rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -9,8 +13,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 /// @dev Used as the native token for the OpenAgents platform.
 contract AgentToken is ERC20, ERC20Burnable {
     address public owner;
-    // BUG: No max supply cap — tokens can be minted infinitely, leading to
-    // unbounded inflation and devaluation of existing holders' tokens.
+    uint256 public constant MAX_SUPPLY = 1_000_000_000e18; // 1 billion tokens
 
     bytes32 public constant PERMIT_TYPEHASH = keccak256(
         "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
@@ -36,12 +39,12 @@ contract AgentToken is ERC20, ERC20Burnable {
         ));
     }
 
-    /// @notice Mint new tokens to a recipient.
+    /// @notice Mint new tokens to a recipient. Only callable by owner.
     /// @param to Recipient address.
     /// @param amount Amount of tokens to mint.
-    // BUG: No access control — anyone can call mint and create tokens for themselves.
-    // Should be restricted to owner or a minter role.
     function mint(address to, uint256 amount) external {
+        require(msg.sender == owner, "AgentToken: not owner");
+        require(totalSupply() + amount <= MAX_SUPPLY, "AgentToken: exceeds max supply");
         _mint(to, amount);
     }
 
@@ -71,8 +74,7 @@ contract AgentToken is ERC20, ERC20Burnable {
         bytes32 r,
         bytes32 s
     ) external {
-        // BUG: Deadline is not checked — expired permits are still accepted, allowing
-        // old signatures to be used indefinitely. Should require(block.timestamp <= deadline).
+        require(block.timestamp <= deadline, "AgentToken: permit expired");
         bytes32 structHash = keccak256(abi.encode(
             PERMIT_TYPEHASH,
             _owner,


### PR DESCRIPTION
Fixes #70

## Summary
The `AgentToken` contract had no maximum supply cap allowing infinite inflation, lacked access control on the mint function enabling anyone to create tokens, and did not validate permit deadlines allowing expired signatures to be replayed indefinitely.

## Changes
- Added `MAX_SUPPLY = 1_000_000_000e18` constant (1 billion tokens)
- Restricted `mint()` to owner only with supply cap enforcement
- Added `require(block.timestamp <= deadline)` check in `permit()` to reject expired signatures
- Prepended standard contributor header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified compilation with solc 0.8.20
- Non-owner mint calls correctly revert
- Minting beyond MAX_SUPPLY reverts with descriptive error
- Expired permits are rejected