### PR TITLE
fix(staking): cap rewardPerToken at periodFinish and restrict notifyRewardAmount to owner (#66)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -41,5 +41,13 @@
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
     }
+  ],
+  "contributors": [
+    {
+      "issue": 66,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Fix phantom reward accrual in StakingRewards with lastTimeRewardApplicable cap and owner-only notifyRewardAmount"
+    }
   ]
 }

--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -1,3 +1,7 @@
+// @contributor rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -66,11 +70,8 @@ contract StakingRewards is ReentrancyGuard {
         if (_totalSupply == 0) {
             return rewardPerTokenStored;
         }
-        // BUG: Uses block.timestamp directly instead of lastTimeRewardApplicable().
-        // After periodFinish, this keeps accruing phantom rewards indefinitely,
-        // allowing stakers to drain more rewards than were actually deposited.
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate * 1e18 / _totalSupply
         );
     }
 
@@ -110,21 +111,21 @@ contract StakingRewards is ReentrancyGuard {
         }
     }
 
-    /// @notice Notify the contract of a new reward amount to distribute.
+    /// @notice Notify the contract of a new reward amount to distribute. Only callable by owner.
     /// @param reward Total reward tokens to distribute over the duration.
-    // BUG: No access control — anyone can call notifyRewardAmount. An attacker can
-    // call this with 0 to reset the rewardRate to near-zero, stealing future rewards.
     function notifyRewardAmount(uint256 reward) external updateReward(address(0)) {
+        require(msg.sender == owner, "StakingRewards: not owner");
+        require(reward > 0, "StakingRewards: zero reward");
+
         if (block.timestamp >= periodFinish) {
-            // BUG: Precision loss — integer division truncates rewardRate for small
-            // reward amounts relative to rewardsDuration (7 days = 604800 seconds).
-            // E.g., 500000 wei / 604800 = 0, meaning all rewards are lost.
             rewardRate = reward / rewardsDuration;
         } else {
             uint256 remaining = periodFinish - block.timestamp;
             uint256 leftover = remaining * rewardRate;
             rewardRate = (reward + leftover) / rewardsDuration;
         }
+
+        require(rewardRate > 0, "StakingRewards: reward too small for duration");
 
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + rewardsDuration;


### PR DESCRIPTION
Fixes #66

## Summary
The `StakingRewards` contract accrued phantom rewards after the reward period ended because `rewardPerToken()` used `block.timestamp` directly instead of capping at `periodFinish`. Additionally, `notifyRewardAmount()` lacked access control, allowing anyone to reset the reward rate to zero.

## Changes
- Replaced `block.timestamp` with `lastTimeRewardApplicable()` in `rewardPerToken()` to cap accrual at period end
- Added `require(msg.sender == owner)` access control to `notifyRewardAmount()`
- Added `require(reward > 0)` and `require(rewardRate > 0)` checks to prevent precision-loss zero-rate scenarios
- Prepended standard contributor header per bounty workflow
- Updated CONTRIBUTORS.json

## Testing
- Verified compilation with solc 0.8.20
- Reward accrual correctly stops at periodFinish
- Non-owner calls to notifyRewardAmount revert