### PR TITLE
fix(bridge): restrict addValidator to owner and enforce min validator count (#61)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,12 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "issue": 61,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Fix BridgeValidator addValidator access control and enforce min validator count on removal"
     }
   ]
 }

--- a/contracts/bridge/BridgeValidator.sol
+++ b/contracts/bridge/BridgeValidator.sol
@@ -1,3 +1,7 @@
+// @contributor rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -44,7 +48,7 @@ contract BridgeValidator {
     // BUG: Validators can add themselves — the onlyValidator modifier allows any
     // existing validator to add new validators (including themselves again with
     // more weight), bypassing owner governance over the validator set.
-    function addValidator(address validator, uint128 weight) external onlyValidator {
+    function addValidator(address validator, uint128 weight) external onlyOwner {
         require(!validators[validator].isActive, "BridgeValidator: already active");
         require(weight > 0, "BridgeValidator: zero weight");
 
@@ -70,6 +74,7 @@ contract BridgeValidator {
     // set is empty, bricking the bridge since no one can sign transactions.
     function removeValidator(address validator) external onlyOwner {
         require(validators[validator].isActive, "BridgeValidator: not active");
+        require(validatorList.length > 3, "BridgeValidator: min validators");
 
         totalWeight -= validators[validator].weight;
         validators[validator].isActive = false;


### PR DESCRIPTION
Fixes issue #61: changes addValidator modifier from onlyValidator to onlyOwner to prevent unauthorized validator additions, and adds minimum validator count check (>3) in removeValidator to prevent bricking the bridge.