### PR TITLE
fix(lottery): fix reentrancy in claimPrize, add dust tracking and zero-winner check (#51)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,12 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "issue": 51,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Fix reentrancy in PrizeSplit claimPrize with CEI pattern and nonReentrant, add dust tracking to last winner, and zero-winner check"
     }
   ]
 }

--- a/contracts/lottery/PrizeSplit.sol
+++ b/contracts/lottery/PrizeSplit.sol
@@ -1,10 +1,16 @@
+// @contributor rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title PrizeSplit
 /// @notice Distributes prize pool among multiple winners with configurable shares
 /// @dev Winners claim their share after the admin finalizes the round
-contract PrizeSplit {
+contract PrizeSplit is ReentrancyGuard {
     address public admin;
     uint256 public totalPrize;
     uint256 public roundId;
@@ -39,29 +45,35 @@ contract PrizeSplit {
         emit RoundFunded(roundId, msg.value);
     }
 
-    // BUG: No zero-winner check — if winners array is empty, the function
-    // succeeds silently and the prize pool becomes permanently locked
+    /// @notice Finalize a round with winners and distribute shares.
+    /// @param _roundId The round to finalize.
+    /// @param winners Array of winner addresses.
     function finalizeRound(uint256 _roundId, address[] calldata winners) external onlyAdmin {
         Round storage round = rounds[_roundId];
         require(!round.finalized, "Already finalized");
         require(round.prizePool > 0, "No prize pool");
+        require(winners.length > 0, "PrizeSplit: no winners");
 
-        // BUG: Rounding error loses dust — integer division truncates remainder,
-        // so (prizePool % winners.length) wei is permanently locked in the contract
         uint256 sharePerWinner = round.prizePool / winners.length;
+        uint256 dust = round.prizePool % winners.length;
 
         for (uint256 i = 0; i < winners.length; i++) {
             round.winners.push(winners[i]);
-            round.shares[winners[i]] = sharePerWinner;
+            uint256 share = sharePerWinner;
+            // Last winner gets the dust to prevent loss
+            if (i == winners.length - 1) {
+                share += dust;
+            }
+            round.shares[winners[i]] = share;
         }
 
         round.finalized = true;
         emit RoundFinalized(_roundId, winners.length);
     }
 
-    // BUG: Reentrancy — state (claimed flag) is set after the external call,
-    // allowing a malicious contract to re-enter claimPrize and drain funds
-    function claimPrize(uint256 _roundId) external {
+    /// @notice Claim prize share for a finalized round.
+    /// @param _roundId The round to claim from.
+    function claimPrize(uint256 _roundId) external nonReentrant {
         Round storage round = rounds[_roundId];
         require(round.finalized, "Not finalized");
         require(round.shares[msg.sender] > 0, "No share");
@@ -69,11 +81,11 @@ contract PrizeSplit {
 
         uint256 amount = round.shares[msg.sender];
 
+        // Effects before interactions (CEI pattern)
+        round.claimed[msg.sender] = true;
+
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "Transfer failed");
-
-        // State updated after external call — reentrancy window
-        round.claimed[msg.sender] = true;
 
         emit PrizeClaimed(msg.sender, amount, _roundId);
     }


### PR DESCRIPTION
Fixes issue #51: applies checks-effects-interactions pattern with nonReentrant guard to prevent reentrancy in claimPrize, adds dust tracking so remainder goes to last winner preventing fund loss, and enforces zero-winner check in finalizeRound.