### PR TITLE
fix(registry): O(1) activeCount, pagination, and owner filter for AgentRegistry (#45)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,12 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "issue": 45,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Fix AgentRegistry getActiveAgentCount O(n) gas issue with O(1) counter, add pagination and owner filter"
     }
   ]
 }

--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,3 +1,7 @@
+// @contributor rafaio1
+// @date 2026-08-20T00:00:00Z
+// @runtime linux x64 /tmp/OpenAgents bash
+// @platform-config Agentic bounty-hunter workflow
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -20,6 +24,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public activeCount;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -51,13 +56,16 @@ contract AgentRegistry is Ownable {
         ownerAgents[msg.sender].push(agentId);
         agentIds.push(agentId);
 
+        activeCount++;
         emit AgentRegistered(agentId, msg.sender, name);
         return agentId;
     }
 
     function deactivateAgent(bytes32 agentId) external {
         require(agents[agentId].owner == msg.sender, "Not agent owner");
+        require(agents[agentId].active, "Already inactive");
         agents[agentId].active = false;
+        activeCount--;
         emit AgentDeactivated(agentId);
     }
 
@@ -79,9 +87,31 @@ contract AgentRegistry is Ownable {
         return agents[agentId];
     }
 
+    /// @notice Get the total number of active agents (O(1)).
+    /// @return count The number of currently active agents.
     function getActiveAgentCount() external view returns (uint256 count) {
-        for (uint256 i = 0; i < agentIds.length; i++) {
-            if (agents[agentIds[i]].active) count++;
+        return activeCount;
+    }
+
+    /// @notice Get a paginated list of agent IDs owned by a specific address.
+    /// @param ownerAddr The owner address to filter by.
+    /// @param offset Starting index in the owner's agent list.
+    /// @param limit Maximum number of results to return.
+    /// @return result Array of agent IDs for the requested page.
+    function getAgentsByOwner(address ownerAddr, uint256 offset, uint256 limit) external view returns (bytes32[] memory result) {
+        bytes32[] storage allAgents = ownerAgents[ownerAddr];
+        uint256 total = allAgents.length;
+        if (offset >= total) {
+            return new bytes32[](0);
+        }
+        uint256 end = offset + limit;
+        if (end > total) {
+            end = total;
+        }
+        uint256 len = end - offset;
+        result = new bytes32[](len);
+        for (uint256 i = 0; i < len; i++) {
+            result[i] = allAgents[offset + i];
         }
     }
 


### PR DESCRIPTION
Fixes issue #45: replaces O(n) loop in getActiveAgentCount with O(1) activeCount counter that increments on registration and decrements on deactivation, adds getAgentsByOwner with pagination support for gas-efficient filtering.