### PR TITLE
fix(api): add db indexes, cascade deletes, UTC timestamps, and auto-update (#37)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,12 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "issue": 37,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Add database indexes on address/status/fk columns, cascade deletes for User->Agent->Task->Payment, timezone-aware UTC timestamps, and auto-update updated_at"
     }
   ]
 }

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -1,12 +1,16 @@
+# @contributor rafaio1
+# @date 2026-08-20T00:00:00Z
+# @runtime linux x64 /tmp/OpenAgents bash
+# @platform-config Agentic bounty-hunter workflow
 """SQLAlchemy models and database session management."""
 
 from sqlalchemy import (
     create_engine, Column, Integer, String, Float, Text, JSON,
-    ForeignKey, DateTime, Enum as SAEnum,
+    ForeignKey, DateTime, Enum as SAEnum, event, Index,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openagents.db")
@@ -28,16 +32,17 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    address = Column(String(42), unique=True, nullable=False)
+    address = Column(String(42), unique=True, nullable=False, index=True)  # Indexed for fast wallet lookups
     username = Column(String(64), unique=True, nullable=True)
-    # BUG: No index on address — wallet lookups on every auth request do full table scans
-    created_at = Column(DateTime, default=datetime.utcnow)  # BUG: naive datetime, no timezone
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
-    agents = relationship("Agent", back_populates="owner")
+    agents = relationship("Agent", back_populates="owner", cascade="all, delete-orphan")
 
 
 class Agent(Base):
     __tablename__ = "agents"
+    __table_args__ = (Index("ix_agents_owner_id", "owner_id"),)
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(128), nullable=False)
@@ -45,33 +50,43 @@ class Agent(Base):
     model_type = Column(String(32), default="gpt-4")
     config = Column(JSON, default=dict)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
-    # BUG: No cascade delete — deleting a user leaves orphaned agents
     owner = relationship("User", back_populates="agents")
-    tasks = relationship("Task", back_populates="agent")
+    tasks = relationship("Task", back_populates="agent", cascade="all, delete-orphan")
 
 
 class Task(Base):
     __tablename__ = "tasks"
+    __table_args__ = (
+        Index("ix_tasks_status", "status"),
+        Index("ix_tasks_creator_id", "creator_id"),
+        Index("ix_tasks_agent_id", "agent_id"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String(256), nullable=False)
     description = Column(Text, nullable=True)
     reward_amount = Column(Float, nullable=False)
-    status = Column(String(32), default="open")
+    status = Column(String(32), default="open", index=True)
     creator_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     agent_id = Column(Integer, ForeignKey("agents.id"), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     deadline = Column(DateTime, nullable=True)
 
     agent = relationship("Agent", back_populates="tasks")
-    payments = relationship("Payment", back_populates="task")
+    payments = relationship("Payment", back_populates="task", cascade="all, delete-orphan")
 
 
 class Payment(Base):
     __tablename__ = "payments"
+    __table_args__ = (
+        Index("ix_payments_task_id", "task_id"),
+        Index("ix_payments_status", "status"),
+        Index("ix_payments_from_address", "from_address"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
@@ -79,8 +94,9 @@ class Payment(Base):
     to_address = Column(String(42), nullable=True)
     amount = Column(Float, nullable=False)
     token_address = Column(String(42), default="0x0000000000000000000000000000000000000000")
-    status = Column(String(32), default="pending")
-    created_at = Column(DateTime, default=datetime.utcnow)
+    status = Column(String(32), default="pending", index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     claimed_at = Column(DateTime, nullable=True)
 
     task = relationship("Task", back_populates="payments")


### PR DESCRIPTION
Fixes issue #37: adds indexes on address, status, and foreign key columns for query performance, implements cascade deletes from User through Agent/Task/Payment, switches to timezone-aware UTC timestamps, and adds auto-update for updated_at fields.