### PR TITLE
feat(api): add webhook notification system with HMAC signing, retries, and CRUD (#33)

### DIFF
--- a/CONTRIBUTORS.json
+++ b/CONTRIBUTORS.json
@@ -40,6 +40,12 @@
         "shell": "zsh"
       },
       "contribution": "Refactored SafeMath library and added comprehensive unit tests for edge cases"
+    },
+    {
+      "issue": 33,
+      "author": "rafaio1",
+      "date": "2026-08-20",
+      "description": "Add webhook notification system with HMAC-SHA256 signing, 5x retry with backoff, delivery history, and CRUD endpoints for task state changes"
     }
   ]
 }

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 
+from .routes import webhooks
+
 app = FastAPI(
     title="OpenAgents API",
     description="Off-chain indexer and agent discovery API for the OpenAgents protocol",
@@ -100,6 +102,9 @@ async def leaderboard(limit: int = Query(20, le=50)):
         )
     entries.sort(key=lambda x: x["reputation"], reverse=True)
     return entries[:limit]
+
+
+app.include_router(webhooks.router)
 
 
 @app.get("/health")

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -86,5 +86,37 @@ class Payment(Base):
     task = relationship("Task", back_populates="payments")
 
 
+class WebhookSubscription(Base):
+    __tablename__ = "webhook_subscriptions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    url = Column(String(512), nullable=False)
+    secret = Column(String(128), nullable=True)
+    events = Column(JSON, default=list)  # ["created", "assigned", "completed", "disputed"]
+    active = Column(Integer, default=1)  # SQLite boolean compat
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    deliveries = relationship("WebhookDelivery", back_populates="subscription", cascade="all, delete-orphan")
+
+
+class WebhookDelivery(Base):
+    __tablename__ = "webhook_deliveries"
+    __table_args__ = (Index("ix_webhook_deliveries_subscription_id", "subscription_id"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    subscription_id = Column(Integer, ForeignKey("webhook_subscriptions.id"), nullable=False)
+    event = Column(String(64), nullable=False)
+    payload = Column(JSON, default=dict)
+    status_code = Column(Integer, nullable=True)
+    success = Column(Integer, default=0)
+    attempts = Column(Integer, default=1)
+    error_message = Column(Text, nullable=True)
+    delivered_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    subscription = relationship("WebhookSubscription", back_populates="deliveries")
+
+
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,5 +1,10 @@
+# @contributor rafaio1
+# @date 2026-08-20T00:00:00Z
+# @runtime linux x64 /tmp/OpenAgents bash
+# @platform-config Agentic bounty-hunter workflow
 """Task management endpoints for bounty assignments."""
 
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
@@ -7,6 +12,7 @@ from datetime import datetime
 
 from ..models.database import get_db, Task
 from ..middleware.auth import get_current_user
+from ..services.webhook import notify_task_state_change
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
@@ -40,6 +46,13 @@ async def create_task(task: TaskCreate, user=Depends(get_current_user), db=Depen
     db.add(new_task)
     db.commit()
     db.refresh(new_task)
+    
+    # Trigger webhook for task creation
+    asyncio.create_task(notify_task_state_change(
+        db, new_task.id, "created",
+        {"id": new_task.id, "title": new_task.title, "status": new_task.status}
+    ))
+    
     return {"id": new_task.id, "status": new_task.status}
 
 
@@ -85,9 +98,27 @@ async def update_task_status(
     if task.creator_id != user["id"]:
         raise HTTPException(status_code=403, detail="Only the creator can update status")
 
+    if update.status not in VALID_STATUSES:
+        raise HTTPException(status_code=400, detail=f"Invalid status: {update.status}")
+    
+    old_status = task.status
     task.status = update.status
     task.updated_at = datetime.utcnow()
     db.commit()
+    
+    # Map status changes to webhook events
+    event_map = {
+        "assigned": "assigned",
+        "completed": "completed",
+        "review": "disputed",  # review state maps to disputed event
+    }
+    event = event_map.get(update.status)
+    if event and old_status != update.status:
+        asyncio.create_task(notify_task_state_change(
+            db, task.id, event,
+            {"id": task.id, "title": task.title, "old_status": old_status, "new_status": update.status}
+        ))
+    
     return {"id": task.id, "status": task.status}
 
 

--- a/api/routes/webhooks.py
+++ b/api/routes/webhooks.py
@@ -1,0 +1,180 @@
+"""Webhook subscription management endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime, timezone
+
+from ..models.database import get_db, WebhookSubscription, WebhookDelivery
+from ..middleware.auth import get_current_user
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+VALID_EVENTS = {"created", "assigned", "completed", "disputed"}
+
+
+class WebhookCreate(BaseModel):
+    url: str
+    events: List[str]
+    secret: Optional[str] = None
+
+
+class WebhookUpdate(BaseModel):
+    url: Optional[str] = None
+    events: Optional[List[str]] = None
+    active: Optional[bool] = None
+    secret: Optional[str] = None
+
+
+@router.post("/")
+async def create_webhook(
+    webhook: WebhookCreate,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    # Validate events
+    for event in webhook.events:
+        if event not in VALID_EVENTS:
+            raise HTTPException(status_code=400, detail=f"Invalid event: {event}")
+
+    sub = WebhookSubscription(
+        url=webhook.url,
+        events=webhook.events,
+        secret=webhook.secret,
+        owner_id=user["id"],
+        active=1,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return {"id": sub.id, "url": sub.url, "events": sub.events, "active": bool(sub.active)}
+
+
+@router.get("/")
+async def list_webhooks(
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    subs = db.query(WebhookSubscription).filter(
+        WebhookSubscription.owner_id == user["id"]
+    ).all()
+    return [
+        {
+            "id": s.id,
+            "url": s.url,
+            "events": s.events,
+            "active": bool(s.active),
+            "created_at": s.created_at.isoformat() if s.created_at else None,
+        }
+        for s in subs
+    ]
+
+
+@router.get("/{webhook_id}")
+async def get_webhook(
+    webhook_id: int,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    sub = db.query(WebhookSubscription).filter(
+        WebhookSubscription.id == webhook_id,
+        WebhookSubscription.owner_id == user["id"],
+    ).first()
+    if not sub:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    return {
+        "id": sub.id,
+        "url": sub.url,
+        "events": sub.events,
+        "active": bool(sub.active),
+        "secret": sub.secret,
+        "created_at": sub.created_at.isoformat() if sub.created_at else None,
+    }
+
+
+@router.patch("/{webhook_id}")
+async def update_webhook(
+    webhook_id: int,
+    update: WebhookUpdate,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    sub = db.query(WebhookSubscription).filter(
+        WebhookSubscription.id == webhook_id,
+        WebhookSubscription.owner_id == user["id"],
+    ).first()
+    if not sub:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+
+    if update.url is not None:
+        sub.url = update.url
+    if update.events is not None:
+        for event in update.events:
+            if event not in VALID_EVENTS:
+                raise HTTPException(status_code=400, detail=f"Invalid event: {event}")
+        sub.events = update.events
+    if update.active is not None:
+        sub.active = 1 if update.active else 0
+    if update.secret is not None:
+        sub.secret = update.secret
+
+    sub.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    return {"id": sub.id, "url": sub.url, "events": sub.events, "active": bool(sub.active)}
+
+
+@router.delete("/{webhook_id}")
+async def delete_webhook(
+    webhook_id: int,
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    sub = db.query(WebhookSubscription).filter(
+        WebhookSubscription.id == webhook_id,
+        WebhookSubscription.owner_id == user["id"],
+    ).first()
+    if not sub:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+    db.delete(sub)
+    db.commit()
+    return {"deleted": True}
+
+
+@router.get("/{webhook_id}/deliveries")
+async def list_deliveries(
+    webhook_id: int,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user=Depends(get_current_user),
+    db=Depends(get_db),
+):
+    # Verify ownership
+    sub = db.query(WebhookSubscription).filter(
+        WebhookSubscription.id == webhook_id,
+        WebhookSubscription.owner_id == user["id"],
+    ).first()
+    if not sub:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+
+    deliveries = (
+        db.query(WebhookDelivery)
+        .filter(WebhookDelivery.subscription_id == webhook_id)
+        .order_by(WebhookDelivery.delivered_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "id": d.id,
+            "event": d.event,
+            "status_code": d.status_code,
+            "success": bool(d.success),
+            "attempts": d.attempts,
+            "error_message": d.error_message,
+            "delivered_at": d.delivered_at.isoformat() if d.delivered_at else None,
+        }
+        for d in deliveries
+    ]

--- a/api/services/webhook.py
+++ b/api/services/webhook.py
@@ -1,0 +1,106 @@
+"""Webhook notification system for task state changes."""
+
+import hmac
+import hashlib
+import json
+import asyncio
+import httpx
+from datetime import datetime, timezone
+from typing import Optional
+from sqlalchemy.orm import Session
+
+from ..models.database import Base, WebhookSubscription, WebhookDelivery
+
+WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "openagents-webhook-secret-key")
+MAX_RETRIES = 5
+BACKOFF_BASE = 2  # seconds
+
+
+def generate_signature(payload: bytes, secret: str) -> str:
+    """Generate HMAC-SHA256 signature for webhook payload."""
+    return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+
+async def deliver_webhook(
+    url: str,
+    event: str,
+    payload: dict,
+    subscription_id: int,
+    db: Session,
+):
+    """Deliver webhook with retry logic and backoff."""
+    body = json.dumps({
+        "event": event,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "data": payload,
+    }).encode()
+
+    signature = generate_signature(body, WEBHOOK_SECRET)
+    headers = {
+        "Content-Type": "application/json",
+        "X-OpenAgents-Signature": f"sha256={signature}",
+        "X-OpenAgents-Event": event,
+    }
+
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(url, content=body, headers=headers)
+
+                delivery = WebhookDelivery(
+                    subscription_id=subscription_id,
+                    event=event,
+                    payload=payload,
+                    status_code=response.status_code,
+                    success=200 <= response.status_code < 300,
+                    attempts=attempt + 1,
+                    delivered_at=datetime.now(timezone.utc),
+                )
+                db.add(delivery)
+                db.commit()
+
+                if 200 <= response.status_code < 300:
+                    return True
+
+                last_error = f"HTTP {response.status_code}"
+        except Exception as e:
+            last_error = str(e)
+
+        if attempt < MAX_RETRIES - 1:
+            await asyncio.sleep(BACKOFF_BASE ** (attempt + 1))
+
+    # Final failure record
+    delivery = WebhookDelivery(
+        subscription_id=subscription_id,
+        event=event,
+        payload=payload,
+        status_code=0,
+        success=False,
+        attempts=MAX_RETRIES,
+        error_message=last_error,
+        delivered_at=datetime.now(timezone.utc),
+    )
+    db.add(delivery)
+    db.commit()
+    return False
+
+
+async def notify_task_state_change(
+    db: Session,
+    task_id: int,
+    event: str,
+    task_data: dict,
+):
+    """Notify all active webhook subscriptions about a task state change."""
+    subscriptions = db.query(WebhookSubscription).filter(
+        WebhookSubscription.active == True,
+        WebhookSubscription.events.contains(event),
+    ).all()
+
+    tasks = []
+    for sub in subscriptions:
+        tasks.append(deliver_webhook(sub.url, event, task_data, sub.id, db))
+
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
Fixes issue #33: adds WebhookSubscription and WebhookDelivery models, implements HMAC-SHA256 signed POST notifications on task state changes (created/assigned/completed/disputed), 5x retry with exponential backoff, delivery history tracking, and full CRUD endpoints for webhook management.