### PR TITLE
fix(staking): add emergencyWithdraw to MultiTokenStaking for fund recovery

### DIFF
--- a/contracts/staking/MultiTokenStaking.sol
+++ b/contracts/staking/MultiTokenStaking.sol
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
+// @fix-author rafaio1
+// @date 2026-08-25T02:45:00Z
+// @runtime linux x64 /tmp/openagents_issue_202 bash
+// @platform-config Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement, senior dev multi-agent orchestration, and Wise payout integration.
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -37,6 +41,7 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
     event Deposit(address indexed user, uint256 indexed pid, uint256 amount);
     event Withdraw(address indexed user, uint256 indexed pid, uint256 amount);
     event Harvest(address indexed user, uint256 indexed pid, uint256 amount);
+    event EmergencyWithdraw(address indexed user, uint256 indexed pid, uint256 amount);
 
     // BUG: Missing zero-address validation — rewardToken can be set to address(0),
     // causing all reward transfers to silently burn tokens or revert unpredictably.
@@ -130,6 +135,28 @@ contract MultiTokenStaking is Ownable, ReentrancyGuard {
         }
         user.rewardDebt = user.amount * pool.accRewardPerShare / 1e12;
         emit Withdraw(msg.sender, pid, amount);
+    }
+
+    /// @notice Emergency withdrawal of staked tokens without rewards.
+    /// @dev Resets reward debt to zero and decrements pool total staked.
+    ///      Use only when normal withdraw is broken or contract is compromised.
+    /// @param pid Pool ID to withdraw from.
+    function emergencyWithdraw(uint256 pid) external nonReentrant {
+        PoolInfo storage pool = poolInfo[pid];
+        UserInfo storage user = userInfo[pid][msg.sender];
+        
+        uint256 amount = user.amount;
+        require(amount > 0, "MultiStaking: nothing staked");
+        
+        // Reset accounting - no rewards distributed
+        user.amount = 0;
+        user.rewardDebt = 0;
+        pool.totalStaked -= amount;
+        
+        // Return staked tokens
+        pool.stakeToken.safeTransfer(msg.sender, amount);
+        
+        emit EmergencyWithdraw(msg.sender, pid, amount);
     }
 
     /// @notice View pending rewards for a user in a pool.


### PR DESCRIPTION
## Summary
Adds critical safety valve to `contracts/staking/MultiTokenStaking.sol` per issue #195, allowing users to recover staked tokens if normal withdrawal becomes broken due to a bug or compromised state.

### Changes
- **emergencyWithdraw(pid)** function lets users withdraw full staked amount without rewards
- Resets user `amount` and `rewardDebt` to zero; decrements pool `totalStaked`
- Emits `EmergencyWithdraw(user, pid, amount)` event for off-chain tracking
- Protected by `nonReentrant` modifier to prevent reentrancy attacks
- No reward distribution on emergency path — clean accounting reset
- @fix-author metadata block with runtime and platform-config included per bounty convention

### Acceptance Criteria Met
- ✅ Users can withdraw staked tokens during any contract state
- ✅ No rewards distributed on emergency withdrawal (rewardDebt reset to 0)
- ✅ Pool accounting updated correctly (totalStaked decremented)
- ✅ EmergencyWithdraw event emitted with user, pool ID, and amount
- ✅ Backwards compatible — existing deposit/withdraw/harvest unchanged

Closes #195