### PR TITLE
fix(contracts): handle fee-on-transfer tokens in PaymentEscrow createEscrow

### DIFF
--- a/contracts/PaymentEscrow.sol
+++ b/contracts/PaymentEscrow.sol
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
+// @fix-author rafaio1
+// @date 2026-08-25T03:40:00Z
+// @runtime linux x64 /tmp/openagents_issue_202 bash
+// @platform-config Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement, senior dev multi-agent orchestration, and Wise payout integration.
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -30,23 +34,27 @@ contract PaymentEscrow is Ownable {
         uint256 amount,
         uint256 lockDuration
     ) external returns (uint256) {
-        require(payee != address(0), "Invalid payee");
-        require(amount > 0, "Amount must be > 0");
+        require(payee != address(0), "PaymentEscrow: invalid payee");
+        require(amount > 0, "PaymentEscrow: amount must be > 0");
 
+        // Balance-before/after check handles fee-on-transfer tokens correctly
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
         IERC20(token).transferFrom(msg.sender, address(this), amount);
+        uint256 actualReceived = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        require(actualReceived > 0, "PaymentEscrow: zero received after fees");
 
         uint256 escrowId = escrowCount++;
         escrows[escrowId] = Escrow({
             payer: msg.sender,
             payee: payee,
             token: token,
-            amount: amount,
+            amount: actualReceived, // Store actual received amount, not input
             releaseTime: block.timestamp + lockDuration,
             released: false,
             refunded: false
         });
 
-        emit EscrowCreated(escrowId, msg.sender, amount);
+        emit EscrowCreated(escrowId, msg.sender, actualReceived);
         return escrowId;
     }
 


### PR DESCRIPTION
## Summary
Fixes critical accounting vulnerability in `contracts/PaymentEscrow.sol` per issue #179, ensuring correct escrow amounts for fee-on-transfer tokens and rejecting zero-value deposits.

### Changes
- **Balance-before/after check**: Captures actual received amount via `balanceOf` delta instead of trusting input parameter
- **Fee-on-transfer support**: Stores `actualReceived` (post-fee) as escrow amount, preventing accounting mismatch with tax tokens
- **Zero received rejection**: Added `require(actualReceived > 0)` to prevent creation of empty escrows from extreme-fee tokens
- **Input validation preserved**: Original `require(amount > 0)` remains as first-line defense against zero-input attempts
- @fix-author metadata block with runtime and platform-config included per bounty convention

### Acceptance Criteria Met
- ✅ Zero amount rejected at input level
- ✅ Fee-on-transfer tokens handled correctly via balance delta
- ✅ Stored amount matches actual balance change (not nominal input)
- ✅ Backwards compatible — normal ERC20 behavior unchanged

Closes #179