### PR TITLE
feat: add batchRegister to AgentRegistry for gas-efficient multi-agent onboarding

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -1,3 +1,7 @@
+// @fix-author rafaio1
+// @date 2026-08-25T06:10:00Z
+// @runtime linux x64 /tmp/openagents_issue_194 bash
+// @platform-config Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement for AgentRegistry batch operations (Issue #194)
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -20,6 +24,7 @@ contract AgentRegistry is Ownable {
 
     uint256 public registrationFee;
     uint256 public minReputation;
+    uint256 public constant MAX_BATCH_SIZE = 50;
 
     event AgentRegistered(bytes32 indexed agentId, address indexed owner, string name);
     event AgentDeactivated(bytes32 indexed agentId);
@@ -32,9 +37,29 @@ contract AgentRegistry is Ownable {
 
     function registerAgent(string calldata name, string calldata endpoint) external payable returns (bytes32) {
         require(msg.value >= registrationFee, "Insufficient fee");
+        return _registerAgent(name, endpoint);
+    }
+
+    /// @notice Register multiple agents in a single transaction for gas efficiency.
+    /// @param names Array of agent names (max 50).
+    /// @param endpoints Array of agent endpoints (must match names length).
+    function batchRegister(
+        string[] calldata names,
+        string[] calldata endpoints
+    ) external payable {
+        require(names.length == endpoints.length, "Array length mismatch");
+        require(names.length > 0 && names.length <= MAX_BATCH_SIZE, "Invalid batch size");
+        require(msg.value >= registrationFee * names.length, "Insufficient total fee");
+
+        for (uint256 i = 0; i < names.length; i++) {
+            _registerAgent(names[i], endpoints[i]);
+        }
+    }
+
+    function _registerAgent(string calldata name, string calldata endpoint) internal returns (bytes32) {
         require(bytes(name).length > 0 && bytes(name).length <= 64, "Invalid name");
 
-        bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp));
+        bytes32 agentId = keccak256(abi.encodePacked(msg.sender, name, block.timestamp, agentIds.length));
 
         require(agents[agentId].registeredAt == 0, "Agent exists");
 


### PR DESCRIPTION
Closes #194

## Summary
Adds `batchRegister` function to `AgentRegistry` enabling gas-efficient registration of up to 50 agents in a single transaction.

### Changes
- **Batch Registration**: New `batchRegister(string[] names, string[] endpoints)` function processes multiple registrations atomically
- **Fee Collection**: Validates and collects total fee (`registrationFee * count`) once for the entire batch
- **Input Validation**: Enforces array length match, max batch size of 50, and non-empty batch
- **Refactored Core Logic**: Extracted `_registerAgent` internal function to eliminate code duplication between single and batch flows
- **Collision Resistance**: Added `agentIds.length` to agent ID hash seed to prevent collisions within same block during batch operations
- **Individual Events**: Each registration emits its own `AgentRegistered` event for off-chain indexing compatibility

### SOLID / Object Calisthenics
- Single Responsibility: `_registerAgent` encapsulates all registration logic; `batchRegister` handles only iteration and fee validation
- Open/Closed: Batch capability added without modifying existing `registerAgent` public interface
- No Static Mutable State: All state flows through contract storage
- Encapsulated Validation: Array bounds and fee checks are declarative requires at function entry

### Contributor Metadata
```
@fix-author rafaio1
@date 2026-08-25T06:10:00Z
@runtime linux x64 /tmp/openagents_issue_194 bash
@platform-config Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement
```
