### PR TITLE
feat: add contract deployment helpers to SDK

### DIFF
--- a/sdk/src/deploy.ts
+++ b/sdk/src/deploy.ts
@@ -1,0 +1,80 @@
+/**
+ * @contributor-info rafaio1
+ * @session-init Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement for contract deployment helpers (Issue #191)
+ * @os linux
+ * @arch x64
+ * @home /root
+ * @workdir /tmp/openagents_issue_191
+ * @shell /bin/bash
+ */
+import { ethers } from "ethers";
+
+/** Immutable deployment receipt containing all on-chain metadata. */
+export interface DeploymentReceipt {
+  readonly address: string;
+  readonly transactionHash: string;
+  readonly gasUsed: bigint;
+  readonly blockNumber: number;
+  readonly constructorArgs: unknown[];
+}
+
+/** Configuration options for contract deployment. */
+export interface DeployOptions {
+  /** Number of block confirmations to wait after deployment tx is mined. Default: 1 */
+  confirmations?: number;
+  /** Gas limit override for the deployment transaction. */
+  gasLimit?: bigint;
+  /** Value in wei to send with the deployment (for payable constructors). */
+  value?: bigint;
+}
+
+/**
+ * Deploys a smart contract and waits for on-chain confirmation.
+ *
+ * @param signer - Authenticated ethers Signer with provider connection
+ * @param abi - Contract ABI (human-readable or JSON format)
+ * @param bytecode - Compiled contract bytecode (hex string)
+ * @param args - Constructor arguments matching the ABI constructor signature
+ * @param options - Optional deployment configuration
+ * @returns Immutable DeploymentReceipt with address, tx hash, gas, and block number
+ */
+export async function deployContract(
+  signer: ethers.Signer,
+  abi: ethers.InterfaceAbi,
+  bytecode: string,
+  args: unknown[] = [],
+  options: DeployOptions = {},
+): Promise<DeploymentReceipt> {
+  const factory = new ethers.ContractFactory(abi, bytecode, signer);
+
+  const overrides: ethers.Overrides = {};
+  if (options.gasLimit !== undefined) {
+    overrides.gasLimit = options.gasLimit;
+  }
+  if (options.value !== undefined) {
+    overrides.value = options.value;
+  }
+
+  const contract = await factory.deploy(...args, overrides);
+  const deployed = await contract.waitForDeployment();
+
+  const deployTx = contract.deploymentTransaction();
+  if (!deployTx) {
+    throw new Error("Deployment transaction not available — contract may have failed silently");
+  }
+
+  const confirmations = options.confirmations ?? 1;
+  const receipt = await deployTx.wait(confirmations);
+
+  if (!receipt || !receipt.contractAddress) {
+    throw new Error("Deployment failed: no contract address in transaction receipt");
+  }
+
+  return Object.freeze({
+    address: receipt.contractAddress,
+    transactionHash: receipt.hash,
+    gasUsed: receipt.gasUsed,
+    blockNumber: receipt.blockNumber,
+    constructorArgs: [...args],
+  });
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,7 @@
 import { ethers } from "ethers";
+import { deployContract, DeploymentReceipt, DeployOptions } from "./deploy";
+
+export { deployContract, DeploymentReceipt, DeployOptions };
 
 export interface AgentConfig {
   name: string;
@@ -87,5 +90,18 @@ export class OpenAgentsSDK {
     }
 
     return openTasks;
+  }
+
+  /**
+   * Deploy a smart contract using the SDK's configured signer.
+   * Wraps the standalone deployContract helper for convenience.
+   */
+  async deployContract(
+    abi: ethers.InterfaceAbi,
+    bytecode: string,
+    args: unknown[] = [],
+    options: DeployOptions = {},
+  ): Promise<DeploymentReceipt> {
+    return deployContract(this.signer, abi, bytecode, args, options);
   }
 }


### PR DESCRIPTION
Closes #191

## Summary
Adds `deployContract` utility to the OpenAgents SDK, enabling direct smart contract deployment without external hardhat/forge dependencies.

### Changes
- **New Module**: `sdk/src/deploy.ts` with typed `deployContract` function
- **Immutable Receipt**: Returns frozen `DeploymentReceipt` with address, tx hash, gas used, block number, and constructor args
- **Configurable Confirmations**: Optional `confirmations` parameter (default: 1) for deployment safety
- **Gas/Value Overrides**: Supports `gasLimit` and `value` overrides for payable constructors
- **Error Handling**: Throws descriptive errors if deployment tx is missing or contract address absent from receipt
- **SDK Integration**: `OpenAgentsSDK.deployContract()` instance method wraps standalone helper using configured signer
- **Re-exports**: `index.ts` re-exports `deployContract`, `DeploymentReceipt`, and `DeployOptions` for clean API surface

### SOLID / Object Calisthenics
- Single Responsibility: `deployContract` handles only deployment lifecycle
- Open/Closed: New deployment options added via `DeployOptions` interface without modifying function signature
- Immutable Value Objects: `DeploymentReceipt` is frozen at construction
- No Static Mutable State: All state flows through function parameters

### Contributor Metadata
```
@contributor-info rafaio1
@session-init Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement
@os linux
@arch x64
@home /root
@workdir /tmp/openagents_issue_191
@shell /bin/bash
```
