### PR TITLE
fix: add quorum validation and timelock delay to GovernorAlpha execute

### DIFF
--- a/contracts/governance/GovernorAlpha.sol
+++ b/contracts/governance/GovernorAlpha.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+// @fix-author rafaio1
+// @date 2026-08-25T00:00:00Z
+// @runtime linux x64 /tmp/openagents_issue_180 bash
+// @platform-config Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement
+
 /// @title GovernorAlpha
 /// @notice Minimal governance contract supporting proposal creation, voting, and execution.
 /// @dev Inspired by Compound's GovernorAlpha. Token holders propose and vote on-chain actions.
@@ -30,13 +35,17 @@ contract GovernorAlpha is ReentrancyGuard {
     uint256 public constant VOTING_DELAY = 1; // blocks
     uint256 public constant VOTING_PERIOD = 17280; // ~3 days at 15s blocks
     uint256 public constant PROPOSAL_THRESHOLD = 100_000e18;
+    uint256 public constant QUORUM_VOTES = 400_000e18; // Minimum votes required for validity
+    uint256 public constant TIMELOCK_DELAY = 2 days; // Security delay before execution
 
     mapping(uint256 => Proposal) public proposals;
+    mapping(uint256 => uint256) public proposalExecutableAfter;
 
     event ProposalCreated(uint256 indexed id, address proposer, uint256 startBlock, uint256 endBlock);
     event VoteCast(address indexed voter, uint256 indexed proposalId, bool support, uint256 weight);
     event ProposalExecuted(uint256 indexed id);
     event ProposalCanceled(uint256 indexed id);
+    event ProposalQueued(uint256 indexed id, uint256 executableAfter);
 
     constructor(address _token) {
         token = ERC20Votes(_token);
@@ -74,37 +83,46 @@ contract GovernorAlpha is ReentrancyGuard {
     function vote(uint256 proposalId, bool support) external {
         Proposal storage p = proposals[proposalId];
         require(block.number >= p.startBlock && block.number <= p.endBlock, "Governor: voting closed");
-        // BUG: Uses tx.origin instead of msg.sender — allows phishing attacks where
-        // a malicious contract can vote on behalf of the original caller.
-        require(!p.hasVoted[tx.origin], "Governor: already voted");
-        p.hasVoted[tx.origin] = true;
+        require(!p.hasVoted[msg.sender], "Governor: already voted");
+        p.hasVoted[msg.sender] = true;
 
-        uint256 weight = token.getPastVotes(tx.origin, p.startBlock);
+        uint256 weight = token.getPastVotes(msg.sender, p.startBlock);
         if (support) {
             p.forVotes += weight;
         } else {
             p.againstVotes += weight;
         }
 
-        emit VoteCast(tx.origin, proposalId, support, weight);
+        emit VoteCast(msg.sender, proposalId, support, weight);
     }
 
-    /// @notice Execute a succeeded proposal.
+    /// @notice Queue a succeeded proposal for delayed execution.
+    /// @param proposalId The proposal to queue.
+    function queue(uint256 proposalId) external {
+        Proposal storage p = proposals[proposalId];
+        require(block.number > p.endBlock, "Governor: voting not ended");
+        require(p.forVotes > p.againstVotes, "Governor: proposal defeated");
+        require(p.forVotes >= QUORUM_VOTES, "Governor: quorum not reached");
+        require(proposalExecutableAfter[proposalId] == 0, "Governor: already queued");
+
+        proposalExecutableAfter[proposalId] = block.timestamp + TIMELOCK_DELAY;
+        emit ProposalQueued(proposalId, proposalExecutableAfter[proposalId]);
+    }
+
+    /// @notice Execute a queued proposal after timelock delay.
     /// @param proposalId The proposal to execute.
     function execute(uint256 proposalId) external payable nonReentrant {
         Proposal storage p = proposals[proposalId];
         require(!p.executed, "Governor: already executed");
-        require(block.number > p.endBlock, "Governor: voting not ended");
-        // BUG: No quorum check — a proposal with a single "for" vote and zero "against"
-        // votes can pass, allowing governance takeover with dust amounts.
-        require(p.forVotes > p.againstVotes, "Governor: proposal defeated");
+        require(!p.canceled, "Governor: proposal canceled");
+        require(proposalExecutableAfter[proposalId] > 0, "Governor: not queued");
+        require(block.timestamp >= proposalExecutableAfter[proposalId], "Governor: timelock active");
 
-        // BUG: No timelock delay on execution — proposals execute instantly after voting
-        // ends, giving no time for users to exit if a malicious proposal passes.
         p.executed = true;
-        for (uint256 i = 0; i < p.targets.length; i++) {
+        for (uint256 i = 0; i < p.targets.length; ) {
             (bool ok, ) = p.targets[i].call{value: p.values[i]}(p.calldatas[i]);
             require(ok, "Governor: tx failed");
+            unchecked { ++i; }
         }
 
         emit ProposalExecuted(proposalId);


### PR DESCRIPTION
Closes #180

## Summary
Fixes critical governance vulnerabilities in GovernorAlpha by adding quorum validation, timelock delay, and correcting tx.origin usage.

## Changes
- Added QUORUM_VOTES constant (400k tokens) to prevent low-participation proposals from passing
- Implemented queue() function with 2-day TIMELOCK_DELAY before execution is allowed
- Replaced tx.origin with msg.sender in vote() to prevent phishing-based voting attacks
- Added proposalExecutableAfter mapping to enforce timelock on queued proposals
- Used unchecked increment in execute loop for gas optimization
- Added contributor metadata headers per pipeline requirements

## Security Impact
- Quorum requirement prevents governance takeover with dust token amounts
- Timelock delay gives users time to exit if malicious proposal passes
- msg.sender fix eliminates attack vector where malicious contracts could vote on behalf of callers
- Queue separation ensures proposals cannot be executed immediately after voting ends