### PR TITLE
fix: restrict harvest to owner and fix fee calculation rounding

### DIFF
--- a/contracts/vault/CompoundVault.sol
+++ b/contracts/vault/CompoundVault.sol
@@ -6,6 +6,11 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
+// @fix-author rafaio1
+// @date 2026-08-25T00:00:00Z
+// @runtime linux x64 /tmp/openagents_issue_175 bash
+// @platform-config Autonomous bounty execution pipeline initialized with SOLID/Object Calisthenics enforcement
+
 /// @title CompoundVault
 /// @notice Auto-compounding vault that periodically harvests yield and reinvests.
 /// @dev Deposits into an underlying strategy, harvests rewards, sells for the base
@@ -84,24 +89,20 @@ contract CompoundVault is Ownable, ReentrancyGuard {
 
     /// @notice Harvest rewards from the strategy and calculate profit.
     /// @return profit The net profit after fees.
-    // BUG: No caller restriction — anyone can call harvest at any time, potentially
-    // front-running the actual compound step or harvesting at a suboptimal time,
-    // causing MEV extraction or locking in losses before a price recovery.
-    function harvest() external returns (uint256 profit) {
+    /// @dev Restricted to owner to prevent MEV front-running. Uses current price per share
+    ///      instead of stale cached value. Rounds up fee to prevent dust accumulation.
+    function harvest() external onlyOwner returns (uint256 profit) {
         uint256 rewardBalance = rewardToken.balanceOf(address(this));
         require(rewardBalance > 0, "Vault: nothing to harvest");
 
-        // BUG: Uses lastPricePerShare which is only updated during compound(), not
-        // during harvest. If compound() hasn't been called recently, the price is
-        // stale and the profit calculation is inaccurate — potentially overcharging
-        // or undercharging the performance fee.
-        uint256 estimatedValue = (rewardBalance * lastPricePerShare) / 1e18;
+        // Use current price per share for accurate valuation
+        uint256 currentPPS = pricePerShare();
+        uint256 estimatedValue = (rewardBalance * currentPPS) / 1e18;
 
-        // BUG: Fee calculation truncates to zero for small profit amounts.
-        // E.g., if estimatedValue is 9 and performanceFeeBps is 1000 (10%),
-        // fee = 9 * 1000 / 10000 = 0. Accumulated over many small harvests,
-        // the protocol collects zero fees while still processing transactions.
-        uint256 fee = (estimatedValue * performanceFeeBps) / 10000;
+        // Round up fee calculation to avoid zero-fee dust attacks
+        uint256 fee = (estimatedValue * performanceFeeBps + 9999) / 10000;
+        if (fee > estimatedValue) fee = estimatedValue;
+        
         profit = estimatedValue - fee;
 
         if (fee > 0) {
@@ -137,13 +138,14 @@ contract CompoundVault is Ownable, ReentrancyGuard {
     }
 
     /// @notice Update the fee recipient address.
+    /// @param _feeRecipient New fee recipient.
     function setFeeRecipient(address _feeRecipient) external onlyOwner {
         require(_feeRecipient != address(0), "Vault: zero address");
         feeRecipient = _feeRecipient;
     }
 
     /// @notice Get the current price per share.
-    function pricePerShare() external view returns (uint256) {
+    function pricePerShare() public view returns (uint256) {
         if (totalShares == 0) return 1e18;
         return (totalDeposited * 1e18) / totalShares;
     }


### PR DESCRIPTION
Closes #175

## Summary
Fixes critical vulnerabilities in CompoundVault by restricting harvest access and correcting fee calculation logic.

## Changes
- Added `onlyOwner` modifier to `harvest()` to prevent MEV front-running and suboptimal harvesting
- Replaced stale `lastPricePerShare` with real-time `pricePerShare()` call for accurate profit valuation
- Implemented ceiling division for fee calculation `(value * bps + 9999) / 10000` to prevent zero-fee dust attacks
- Added safety cap ensuring fee never exceeds estimated value
- Changed `pricePerShare()` visibility from external to public for internal use
- Added contributor metadata headers per pipeline requirements

## Security Impact
- Eliminates attack vector where anyone could trigger harvest at disadvantageous times
- Ensures protocol collects appropriate fees even on small harvest amounts
- Prevents accounting drift from stale price data between compound operations
- Maintains fair fee distribution across all vault participants